### PR TITLE
Experimental implementation of speech synthesis & added my theme

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ plugins
 .phpunit.result.cache
 
 composer.phar
+
+# Editor
+.vscode

--- a/do_text_text.php
+++ b/do_text_text.php
@@ -14,7 +14,7 @@
  */
 
 require_once 'inc/session_utility.php';
-
+include 'tts.php';
 
 
 /**

--- a/src/js/pgm.js
+++ b/src/js/pgm.js
@@ -74,14 +74,15 @@ Helper functions for overlib
  * @param {*} ann 
  * @returns {boolean}
  */
-function run_overlib_status_98 (wblink1, wblink2, wblink3, hints, txid, torder, txt, wid, multi_words, rtl, ann) {
+function run_overlib_status_98(wblink1, wblink2, wblink3, hints, txid, torder, txt, wid, multi_words, rtl, ann) {
   return overlib(
-    '<b>' + escape_html_chars_2(hints, ann) + '</b><br /> ' +
-		make_overlib_link_new_word(txid, torder, wid) + ' | ' +
-		make_overlib_link_delete_word(txid, wid) +
-		make_overlib_link_new_multiword(txid, torder, multi_words, rtl) + ' <br /> ' +
-		make_overlib_link_wb(wblink1, wblink2, wblink3, txt, txid, torder),
-    CAPTION, 
+    '<img src="icn/speaker-volume.png" style="cursor:pointer" title="Click on expression for tts" onclick="readTextAloud(' + "'" + txt + "'" + ')"> <br/>' + 
+    '<b>' + escape_html_chars_2(hints, ann) + '</b><br/>' +
+    make_overlib_link_new_word(txid, torder, wid) + ' | ' +
+    make_overlib_link_delete_word(txid, wid) +
+    make_overlib_link_new_multiword(txid, torder, multi_words, rtl) + ' <br /> ' +
+    make_overlib_link_wb(wblink1, wblink2, wblink3, txt, txid, torder),
+    CAPTION,
     'Word'
   );
 }
@@ -104,7 +105,8 @@ function run_overlib_status_98 (wblink1, wblink2, wblink3, hints, txid, torder, 
  */
 function run_overlib_status_99 (wblink1, wblink2, wblink3, hints, txid, torder, txt, wid, multi_words, rtl, ann) {
   return overlib(
-    '<b>' + escape_html_chars_2(hints, ann) + '</b><br /> ' +
+    '<img src="icn/speaker-volume.png" style="cursor:pointer" title="Click on expression for tts" onclick="readTextAloud(' + "'" + txt + "'" + ')"> <br/>' + 
+    '<b>' + escape_html_chars_2(hints, ann) + '</b><br/> ' +
 		make_overlib_link_new_word(txid, torder, wid) + ' | ' +
 		make_overlib_link_delete_word(txid, wid) +
 		make_overlib_link_new_multiword(txid, torder, multi_words, rtl) + ' <br /> ' +
@@ -131,7 +133,7 @@ function run_overlib_status_99 (wblink1, wblink2, wblink3, hints, txid, torder, 
  */
 function run_overlib_status_1_to_5 (wblink1, wblink2, wblink3, hints, txid, torder, txt, wid, stat, multi_words, rtl, ann) {
   return overlib(
-    '<b>' + escape_html_chars_2(hints, ann) + '</b><br /> ' +
+    '<img src="icn/speaker-volume.png" style="cursor:pointer" title="Click on expression for tts" onclick="readTextAloud(' + "'" + txt + "'" + ')"> <br/>' + 
 		make_overlib_link_change_status_all(txid, torder, wid, stat) + ' <br /> ' +
 		make_overlib_link_edit_word(txid, torder, wid) + ' | ' +
 		make_overlib_link_delete_word(txid, wid) +
@@ -171,6 +173,7 @@ function run_overlib_status_unknown (wblink1, wblink2, wblink3, hints, txid, tor
 }
 
 function run_overlib_multiword (wblink1, wblink2, wblink3, hints, txid, torder, txt, wid, stat, wcnt, ann) {
+  return overlib(
   return overlib(
     '<b>' + escape_html_chars_2(hints, ann) + '</b><br /> ' +
 		make_overlib_link_change_status_all(txid, torder, wid, stat) + ' <br /> ' +
@@ -770,6 +773,8 @@ function createSentLookupLink (torder, txid, url, txt) {
 
 /**
  * 
+ * 
+ * Replace html characters with encodings
  * @param {string} s 
  * @returns {string}
  */

--- a/src/js/pgm.js
+++ b/src/js/pgm.js
@@ -162,6 +162,7 @@ function run_overlib_status_1_to_5 (wblink1, wblink2, wblink3, hints, txid, tord
  */
 function run_overlib_status_unknown (wblink1, wblink2, wblink3, hints, txid, torder, txt, multi_words, rtl) {
   return overlib(
+    '<img src="icn/speaker-volume.png" style="cursor:pointer" title="Click on expression for tts" onclick="readTextAloud(' + "'" + txt + "'" + ')"> <br/>' + 
     '<b>' + escape_html_chars(hints) + '</b><br /> ' +
 		make_overlib_link_wellknown_word(txid, torder) + ' <br /> ' +
 		make_overlib_link_ignore_word(txid, torder) +
@@ -174,6 +175,7 @@ function run_overlib_status_unknown (wblink1, wblink2, wblink3, hints, txid, tor
 
 function run_overlib_multiword (wblink1, wblink2, wblink3, hints, txid, torder, txt, wid, stat, wcnt, ann) {
   return overlib(
+    '<img src="icn/speaker-volume.png" style="cursor:pointer" title="Click on expression for tts" onclick="readTextAloud(' + "'" + txt + "'" + ')"> <br/>' + 
     '<b>' + escape_html_chars_2(hints, ann) + '</b><br /> ' +
 		make_overlib_link_change_status_all(txid, torder, wid, stat) + ' <br /> ' +
 		make_overlib_link_edit_multiword(txid, torder, wid) + ' | ' +

--- a/src/js/pgm.js
+++ b/src/js/pgm.js
@@ -174,7 +174,6 @@ function run_overlib_status_unknown (wblink1, wblink2, wblink3, hints, txid, tor
 
 function run_overlib_multiword (wblink1, wblink2, wblink3, hints, txid, torder, txt, wid, stat, wcnt, ann) {
   return overlib(
-  return overlib(
     '<b>' + escape_html_chars_2(hints, ann) + '</b><br /> ' +
 		make_overlib_link_change_status_all(txid, torder, wid, stat) + ' <br /> ' +
 		make_overlib_link_edit_multiword(txid, torder, wid) + ' | ' +

--- a/src/themes/chaosarium_light/styles.css
+++ b/src/themes/chaosarium_light/styles.css
@@ -1,0 +1,511 @@
+body {
+  background-color: #fff;
+  color: #000;
+  font: 100%/1.25 "Lucida Grande", Arial, sans-serif, STHeiti,
+    "Arial Unicode MS", mingLiu;
+  margin: 20px;
+  padding: 0;
+  cursor: default;
+}
+input[type="text"] {
+  font: 85% "Lucida Grande", Arial, sans-serif, STHeiti, "Arial Unicode MS",
+    mingLiu;
+  border: 1px solid #c6c6c6;
+  padding: 3px;
+}
+p {
+  margin: 5px 0 5px 0;
+  padding: 0;
+}
+h3 {
+  margin: 0;
+  padding: 0;
+}
+h4 {
+  margin: 5px 0 10px 0;
+  padding: 0;
+}
+.click {
+  cursor: pointer;
+  color: #c00000;
+}
+.status0 {
+  background-color: #ade0ff60;
+  color: #000;
+  border-bottom: 2px solid #7dcdff;
+}
+.status1 {
+  background-color: #f5b8a96b;
+  color: #000;
+  border-bottom: 2px solid #ec8d75;
+}
+.status2 {
+  background-color: #f5cea996;
+  color: #000;
+  border-bottom: 2px solid #f3b671;
+}
+.status3 {
+  background-color: #ffecb0cf;
+  color: #000;
+  border-bottom: 2px solid #f3ce5c;
+}
+.status4 {
+  background-color: #e7ffbbad;
+  color: #000;
+  border-bottom: 2px solid #bfe774;
+}
+.status5 {
+  background-color: #e0fbe0cf;
+  color: #000;
+  border-bottom: 2px solid #9cda9c;
+}
+.status99 {
+  /* background-color: #f8f8f8; */
+  /* border-bottom: solid 2px rgba(18, 145, 18, 0.212); */
+  color: #000;
+  border-bottom: solid 2px rgba(43, 187, 43, 0);
+}
+.status99:hover {
+  background-color: #e0f5da;
+  border-bottom: solid 2px rgba(43, 187, 43, 0.212);
+  color: #000;
+}
+.status98 {
+  background-color: #88888836;
+  border-bottom: dashed 2px #bebebe;
+  color: #000;
+}
+.mwsty {
+  margin-right: 2px;
+  font-size: 60%;
+  font-weight: bold;
+  color: #000;
+  vertical-align: top;
+  white-space: nowrap;
+}
+.wsty {
+  margin-right: 2px;
+  color: #000;
+  margin-bottom: 0.4em !important;
+}
+.todosty {
+  background-color: #f5e1a9;
+}
+.doneoksty {
+  background-color: #a9f5a9;
+}
+.donewrongsty {
+  background-color: #f5b8a9;
+}
+.status5stat {
+  background-color: #a8eca8cf;
+  border-bottom: 2px solid #259f25;
+}
+.tword.lword,
+.nword.lword {
+  background-color: #d57;
+  box-shadow: 2px 0 0 0 #d57, -1px 0 0 0 #d57;
+}
+.tword {
+  background-color: #c9b;
+  box-shadow: 0 0 0 1px #fff;
+}
+.nword {
+  background-color: #fff;
+}
+#thetext {
+  -webkit-touch-callout: text;
+  -webkit-user-select: text;
+  -khtml-user-select: text;
+  -moz-user-select: text;
+  -ms-user-select: text;
+  user-select: text;
+}
+textarea {
+  font: 85% "Lucida Grande", Arial, sans-serif, STHeiti, "Arial Unicode MS",
+    mingLiu;
+  border: 1px solid #c6c6c6;
+  padding: 3px;
+}
+.bgdis {
+  background-color: #eaeae5 !important;
+}
+.tab1 {
+  background-color: #f8f8f8;
+  margin-bottom: 10px;
+  margin-top: 10px;
+  border-top: 1px solid gray;
+  border-left: 1px solid gray;
+  width: 1100px;
+}
+.tab2 {
+  background-color: #f8f8f8;
+  margin-bottom: 10px;
+  margin-top: 10px;
+  border-top: 1px solid gray;
+  border-left: 1px solid gray;
+  width: 100%;
+}
+.tab3 {
+  background-color: #f8f8f8;
+  margin-bottom: 10px;
+  margin-top: 10px;
+  border-top: 1px solid gray;
+  border-left: 1px solid gray;
+  width: auto;
+}
+.td1 {
+  border-bottom: 1px solid gray;
+  border-right: 1px solid gray;
+  vertical-align: top;
+}
+.td1bot {
+  border-bottom: 1px solid gray;
+  border-right: 1px solid gray;
+  vertical-align: bottom;
+}
+.th1 {
+  border-bottom: 1px solid gray;
+  border-right: 1px solid gray;
+  background-color: #ddd;
+  vertical-align: top;
+}
+th.clickable,
+.clickedit {
+  cursor: pointer;
+}
+.hide {
+  display: none;
+}
+a {
+  text-decoration: none;
+}
+a:link,
+a:visited,
+a:active,
+a:focus,
+a:hover {
+  color: #c00000;
+}
+img {
+  border: 0 none;
+}
+.red {
+  color: red;
+  font-weight: bold;
+  background-color: #ffffd0;
+  text-align: center;
+  font-size: 120%;
+}
+.msgblue {
+  color: #00f;
+  font-weight: bold;
+  background-color: #ffffe0;
+  text-align: center;
+  font-size: 120%;
+}
+.red2 {
+  color: red;
+  font-weight: bold;
+}
+.red3 {
+  color: red;
+}
+.scorered {
+  font-weight: bold;
+  color: red;
+}
+.scoregreen {
+  color: #006400;
+}
+.left {
+  text-align: left;
+}
+.right {
+  text-align: right;
+}
+.center {
+  text-align: center;
+}
+.bigger {
+  font-size: 130%;
+}
+.smaller {
+  font-size: 80%;
+}
+.backgray {
+  background-color: #ddd;
+}
+.backlightyellow {
+  background-color: #fffacd;
+}
+.smallgray {
+  color: gray;
+  font-size: 60%;
+}
+.smallgray2 {
+  color: gray;
+  font-size: 80%;
+}
+.smallgray3 {
+  color: gray;
+  font-size: 70%;
+  width: 850px;
+  margin-bottom: 20px;
+}
+#learnstatus {
+  color: #000;
+  font-size: 120%;
+  font-weight: bold;
+}
+#iknowall {
+  background-color: #addfff;
+  cursor: pointer;
+  color: #c00000;
+  padding: 5px;
+  border: 1px solid #000;
+  text-align: center;
+}
+.lwtlogo {
+  margin-right: 15px;
+  float: left;
+}
+.lwtlogoright {
+  margin-left: 30px;
+  float: right;
+}
+#floatdiv {
+  background: #ddd;
+  border: 1px solid #888;
+}
+.inline {
+  display: inline;
+}
+.grayborder {
+  border: 1pt solid gray;
+}
+.graydotted {
+  margin-top: 30px;
+  padding-top: 5px;
+  border-top: 1px dotted gray;
+}
+#printoptions {
+  margin-bottom: 15px;
+  padding-bottom: 15px;
+  border-bottom: 1px dotted gray;
+  line-height: 1.8;
+  margin-top: 20px;
+}
+.width50px {
+  width: 50px;
+}
+.width99pc {
+  width: 99%;
+}
+.width45pc {
+  width: 45%;
+}
+dd {
+  margin-top: 10pt;
+}
+dt {
+  margin-top: 10pt;
+}
+.annterm {
+  font-weight: bold;
+  border-bottom: 2px solid #ccc;
+}
+.anntermruby {
+  font-weight: normal;
+  border-bottom: 2px solid #fff;
+}
+.annrom {
+  color: #999;
+  font-size: 60%;
+  font-style: italic;
+}
+.annromruby {
+  color: #000;
+  font-size: 100%;
+  font-style: italic;
+}
+.annromrubysolo {
+  color: #000;
+  font-size: 100%;
+  font-style: normal;
+}
+.anntrans {
+  color: #09c;
+  font-size: 60%;
+  font-style: normal;
+}
+.anntransruby {
+  color: #09c;
+  font-size: 100%;
+  font-style: normal;
+}
+.anntransruby2 {
+  color: #069;
+  font-size: 125%;
+  font-style: normal;
+}
+#thumbnail {
+  width: inherit;
+  height: 30px;
+  top: 0;
+  border-radius: 2px;
+  cursor: pointer;
+  background-repeat: no-repeat;
+  background-size: contain;
+  background-position: center;
+  background-image: url("../icn/photo-album.png");
+}
+#thumbnail_container {
+  margin: 3px;
+  overflow: hidden;
+  width: 45px;
+  height: 30px;
+  display: inline-block;
+}
+#footer {
+  bottom: 0;
+  position: absolute;
+  width: 100%;
+  height: 45px;
+  line-height: 30px;
+  background: #ddd;
+  font-size: 14px;
+  text-align: center;
+  border-top: 1px solid #000;
+}
+.borderl {
+  border-left: 1px solid #000;
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+}
+.borderr {
+  border-top: 1px solid #000;
+  border-bottom: 1px solid #000;
+  border-right: 1px solid #000;
+}
+.uwordmarked {
+  font-weight: bold;
+  border-top: 3px solid red;
+  border-bottom: 3px solid red;
+  border-right: 3px solid red;
+  border-left: 3px solid red;
+}
+.kwordmarked {
+  font-weight: bold;
+  border-top: 3px solid black;
+  border-bottom: 3px solid black;
+  border-left: 3px solid black;
+  border-right: 3px solid black;
+}
+#termtags {
+  width: 340px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 2px;
+}
+#texttags {
+  width: 340px;
+  margin-top: 0;
+  margin-bottom: 0;
+  margin-left: 2px;
+}
+.editable_textarea {
+  display: inline;
+}
+.nowrap {
+  white-space: nowrap;
+  margin-left: 20pt;
+}
+.borderleft {
+  border-left: 1px solid black;
+  border-top: 1px solid black;
+  border-bottom: 1px solid black;
+  background-color: #eee;
+}
+.bordermiddle {
+  border-top: 1px solid black;
+  border-bottom: 1px solid black;
+  background-color: #eee;
+}
+.borderright {
+  border-right: 1px solid black;
+  border-top: 1px solid black;
+  border-bottom: 1px solid black;
+  background-color: #eee;
+}
+.wizard {
+  margin: 20px 0 5px 0;
+}
+@media print {
+  .noprint {
+    display: none;
+  }
+  #print {
+    font-size: 75%;
+  }
+}
+
+/* new */
+
+#overDiv table table:nth-of-type(1) {
+  background-color: none;
+}
+
+.tword:after,
+.word:after {
+  max-width: 15em;
+  opacity: 70%;
+}
+
+.bc98 {
+  background: rgb(170, 133, 187) !important;
+}
+
+/* change overlay colour */
+/* the whole overlay */
+#overDiv {
+  /* border: solid black 1px; */
+}
+
+/* the top ribbon */
+#overDiv table[bgcolor="#333399"] {
+  background-color: rgba(255, 255, 255, 0.541) !important;
+  padding: 0px 2px 1px 2px;
+  box-shadow: 0px 0px 0px 1px #666 !important;
+  backdrop-filter: blur(20px);
+  -webkit-backdrop-filter: blur(20px);
+}
+
+/* the main area */
+#overDiv table[bgcolor="#FFFFE8"] {
+  background-color: transparent !important;
+  border-top-left-radius: 0;
+  border-top-right-radius: 0;
+  /* backdrop-filter: blur(10px) */
+}
+
+/* normal text */
+#overDiv td[valign="TOP"] font {
+  /* color: blue ! important; */
+}
+
+/* the word text */
+#overDiv b font[color="#FFFFFF"] a[style="color:yellow"] {
+  color: #c00000 !important;
+  padding: 1px 3px;
+  border-radius: 6px !important;
+}
+
+/* the close text */
+#overDiv a font[color="#FFFFFF"],
+#overDiv b font[color="#FFFFFF"] {
+  /* background-color: purple ! important; */
+  color: black;
+  padding: 1px 3px;
+  border-radius: 6px !important;
+}


### PR DESCRIPTION
Hi!

I found it easier to simply reimplement speech synthesis again from your branch, so I closed #17. I have added a speaker button to the popup window for words, which I tested on both Safari and Edge.

<img width="176" alt="Capture d’écran 2022-02-27 à 18 19 08" src="https://user-images.githubusercontent.com/38693485/155878565-00663446-729f-4690-ada8-3e8cbf486d74.png">

This implementation remains experimental as I hard-coded the language code and the speech rate in `tts.php`:

```php
$tts_lang = 'fr-CA';
$tts_rate = 1.0;
```

I couldn't figure out how to add these two options to the language settings page without breaking the database (since it requires creating new columns). I might need some help on this if this is something we want.

I also included my theme in the pull request, which I wish to work on in future commits.