### PR TITLE
Run in Docker

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.dockerignore
+.git
+.gitignore
+docker/*
+*.md

--- a/README.md
+++ b/README.md
@@ -29,7 +29,20 @@ IT DIFFERS IN MANY RESPECTS FROM THE OFFICIAL LWT-VERSION
 * Two database backup modes (new or old structure)
 
 
+# Install instructions
+## Run in [Docker](https://docs.docker.com/get-docker/)
+This repository contains docker-compose file to accomodate running LWT in a docker container.
+#### To use it, change into project root folder and run
 
+	docker-compose -f docker/docker-compose.yml up -d
+	
+#### By default the server can be accessed on port 8010
+http://localhost:8010
+
+To remove the created containers run
+
+	docker-compose -f docker/docker-compose.yml down
+	
 ---
 ## Original README from LWT
 

--- a/docker/.env
+++ b/docker/.env
@@ -1,0 +1,4 @@
+DB_HOSTNAME=mariadb
+DB_USER=root
+DB_PASSWORD=secret
+DB_DATABASE=learning_with_texts

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,0 +1,16 @@
+FROM php:7.4-apache-buster
+
+# creating config file php.ini 
+RUN mv "$PHP_INI_DIR/php.ini-production" "$PHP_INI_DIR/php.ini" && \
+    echo 'mysqli.allow_local_infile = On' >> "$PHP_INI_DIR/php.ini"
+
+RUN docker-php-ext-install pdo pdo_mysql mysqli
+
+COPY . /var/www/html/
+
+# creating connect.inc.php
+ARG DB_HOSTNAME
+ARG DB_USER
+ARG DB_PASSWORD
+ARG DB_DATABASE
+RUN printf '<?php\n$server = "%s";\n$userid = "%s";\n$passwd = "%s";\n$dbname = "%s";\n?>' "$DB_HOSTNAME" "$DB_USER" "$DB_PASSWORD" "$DB_DATABASE" > /var/www/html/connect.inc.php

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,29 @@
+version: "3.9"
+services:
+  web:
+    build:
+      context: ./..
+      dockerfile: docker/Dockerfile
+      args:
+        - DB_HOSTNAME
+        - DB_USER
+        - DB_PASSWORD
+        - DB_DATABASE
+    container_name: lwt
+    depends_on:
+      - db
+    ports:
+      - "8010:80"
+    restart: unless-stopped
+  db:
+    container_name: lwt_db
+    environment:
+        MYSQL_ALLOW_EMPTY_PASSWORD: "no"
+        MYSQL_ROOT_PASSWORD: ${DB_PASSWORD}
+    hostname: ${DB_HOSTNAME}
+    image: mariadb:10.5
+    restart: unless-stopped
+    volumes:
+        - lwt_db_data:/var/lib/mysql
+volumes:
+  lwt_db_data:


### PR DESCRIPTION
From pull request [pirtleshell/lwt #6](https://github.com/pirtleshell/lwt/pull/6) by @m-cote: 

> * Adds
>       
>       * Dockerfile to build a docker image of the app,
>       * docker-compose.yml to run the app and maria DB in containers,
>       * .env file to configure DB connection settings.
> 
>     * Updates README.md with new section 'Run in Docker' containing instructions on how to run the app using docker-compose.

Need some minor adaptations to better stick to the rest of the ecosystem, but beyond that everything seems ready!

