### PR TITLE
Fix list elements using rtl for non-rtl languages

### DIFF
--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -1202,7 +1202,7 @@ function check_text($sql, $rtlScript, $wl)
     ?>
 <script type="text/javascript">
     MWORDS = <?php echo json_encode($mw) ?>;
-    if (<?php echo json_encode($rtlScript); ?>) {
+    if (<?php echo $rtlScript; ?>) {
         $(function() {
             $("li").attr("dir", "rtl");
         });


### PR DESCRIPTION
Hi,
Thanks for your work on lwt.

I had an issue where all list elements seemed to be using `dir="rtl"` even for languages that have the setting set to false. I managed to isolate the issue to this one line. Not being too experienced with php, I'm not really sure why it doesn't work as is, but removing the `json_encode` fixes the issue and it still works when I explicitly set the language to be rtl.