### PR TITLE
Fix sentence splitting with mecab

### DIFF
--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -773,7 +773,7 @@ function parse_japanese_text($text, $id)
                 $id>0 ?
                 "(SELECT ifnull(max(`SeID`)+1,1) FROM `{$tbpref}sentences`)" 
                 : 1 
-            ) . ", @count:=0,@last_term_type:=0, @at_sentence_end:=false;"
+            ) . ", @count:=0,@last_term_type:=0, @at_sentence_end:=false, @inside_quote=false;"
         );
         
         $sql = 
@@ -784,8 +784,10 @@ function parse_japanese_text($text, $id)
         (@term, @node_type, @third)
         SET 
         TiSeID = CASE
-                WHEN (@at_sentence_end = true AND @node_type != 3) THEN @sid:=@sid+1+(@at_sentence_end := false)
-                WHEN (@node_type = 3 AND @term NOT IN ('「', '」', '【', '】', '、', '，', '…', '‥', '『', '』', '〝', '〟', '：')) THEN @sid:=@sid*(@at_sentence_end := true)
+            WHEN (@inside_quote = false AND @term IN ('「', '【', '『', '〝')) THEN @sid:=@sid+(@inside_quote := true)*(@at_sentence_end := false)
+            WHEN (@inside_quote = true AND @term IN ('】', '」', '』', '〟')) THEN @sid:=@sid+(@inside_quote := false)*(@at_sentence_end := false)
+            WHEN (@inside_quote = false AND @at_sentence_end = true AND (@node_type != 3 OR @term IN ('「', '」', '【', '】', '、', '，', '…', '‥', '『', '』', '〝', '〟', '：', '――'))) THEN @sid:=@sid+1+(@at_sentence_end := false)
+            WHEN (@inside_quote = false AND @node_type = 3 AND @term NOT IN ('「', '」', '【', '】', '、', '，', '…', '‥', '『', '』', '〝', '〟', '：', '――')) THEN @sid:=@sid*(@at_sentence_end := true)
             ELSE @sid
         END,
         TiCount = (@count:= @count + CHAR_LENGTH(@term)) + 1 - CHAR_LENGTH(@term),


### PR DESCRIPTION
The sentence splitting wasn't working properly with mecab. It seems like the idea was to use the EOS markers, but their name is misleading and mecab doesn't actually split sentences. For example
```bash
echo "プリベット通り四番地の住人ダーズリー夫妻は、「おかげさまで、私どもはどこから見てもまともな人間です」というのが自慢だった。不思議とか神秘とかそんな非常識はまるっきり認めない人種で、まか不思議な出来事が彼らの周辺で起こるなんて、とうてい考えられなかった。" | mecab  -F %m\\t%t\\t%h\\n -U %m\\t%t\\t%h\\n -E EOS\\t3\\t7\\n
```
will output
```bash
プリベット      7       38
通り    2       51
四      8       48
番地    2       53
の      6       24
住人    2       38
ダーズリー      7       38
夫妻    2       38
は      6       16
、      3       9
「      3       5
おかげ  6       38
さ      6       57
まで    6       21
、      3       9
私      2       59
ども    6       51
は      6       16
どこ    6       59
から    6       13
見      2       31
て      6       18
も      6       16
まとも  6       40
な      6       25
人間    2       38
です    6       25
」      3       6
という  6       15
の      6       63
が      6       13
自慢    2       36
だっ    6       25
た      6       25
。      3       7
不思議  2       40
とか    6       23
神秘    2       40
とか    6       23
そんな  6       68
非常識  2       38
は      6       16
まるっきり      6       34
認め    2       31
ない    6       25
人種    2       38
で      6       13
、      3       9
ま      6       2
か      6       22
不思議  2       40
な      6       25
出来事  2       38
が      6       13
彼ら    2       59
の      6       24
周辺    2       38
で      6       13
起こる  2       31
なんて  6       21
、      3       9
とうてい        6       34
考え    2       31
られ    6       32
なかっ  6       25
た      6       25
。      3       7
EOS     3       7
```
where the only EOS is at the very end to mark the end of that "chunk" of input, even though the text contains two sentences.

The workaround I wrote is pretty hacky but it seems to work well. The node_type 3 signifies a punctuation mark, and I wrote a check to skip characters that shouldn't end a sentence, like commas and quotation marks. The code also handles repeated punctiation marks properly, like a sentence ending in ？！. I'm not very experienced with mysql or php so the only way I could do this was to stuff the variable assignments into the calculations which doesn't look great...

I also had problems with the EOS markers appearing in the final text, so I just dropped them altogether since they're not used in this new code. If this looks acceptable, I can clean up the surrounding code a little and remove some of the EOS checks.

edit: I added a commit that handles more edge cases but now it looks even worse. It also doesn't handle sentences that are separated by others by newlines, such as a line that's surrounded entirely by quotation marks. I don't think there's any way to detect them from mecab's output since it doesn't retain newlines, so the proper solution to this would be to do the word splitting in php. I'm not sure how to implement that though.