### PR TITLE
Fix #48: associate textitems to words on 'i know all' click.

### DIFF
--- a/all_words_wellknown.php
+++ b/all_words_wellknown.php
@@ -131,6 +131,16 @@ function all_words_wellknown_main_loop($txid, $status)
         $count += $modified_rows;
     }
     mysqli_free_result($res);
+
+    // Associate existing textitems.
+    runsql(
+        "UPDATE {$tbpref}words 
+        JOIN {$tbpref}textitems2 
+        ON Ti2WoID=0 AND lower(Ti2Text)=WoTextLC AND Ti2LgID = WoLgID 
+        SET Ti2WoID=WoID", 
+        ''
+    );
+
     return array($count, $javascript);
 }
 


### PR DESCRIPTION
Attempted fix for Issue #48 .

With this fix, the textitems are associated with the new words:

```
mysql> select woid, wowordcount, wolgid, wotext, wotextlc, wostatus from words where wotext in ('Insecto', 'gatita');
+------+-------------+--------+---------+----------+----------+
| woid | wowordcount | wolgid | wotext  | wotextlc | wostatus |
+------+-------------+--------+---------+----------+----------+
|  576 |           0 |      1 | gatita  | gatita   |       99 |
|  575 |           0 |      1 | Insecto | insecto  |       99 |
+------+-------------+--------+---------+----------+----------+
2 rows in set (0.00 sec)

mysql> select * from textitems2 where ti2txid = 4;
+---------+---------+---------+---------+----------+--------------+---------+----------------+
| Ti2WoID | Ti2LgID | Ti2TxID | Ti2SeID | Ti2Order | Ti2WordCount | Ti2Text | Ti2Translation |
+---------+---------+---------+---------+----------+--------------+---------+----------------+
|     575 |       1 |       4 |     169 |        1 |            1 | Insecto |                |
|       0 |       1 |       4 |     169 |        2 |            0 |         |                |
|     576 |       1 |       4 |     169 |        3 |            1 | gatita  |                |
|       0 |       1 |       4 |     169 |        4 |            0 | .       |                |
+---------+---------+---------+---------+----------+--------------+---------+----------------+
4 rows in set (0.00 sec)

```