### PR TITLE
Fix right-frame google translation link.

### DIFF
--- a/js/pgm.js
+++ b/js/pgm.js
@@ -254,19 +254,7 @@ function make_overlib_audio(txt,lang){let img=document.createElement("img");img.
 function getStatusName(status){return(STATUSES[status]?STATUSES[status].name:'Unknown')}
 function getStatusAbbr(status){return(STATUSES[status]?STATUSES[status].abbr:'?')}
 function translateSentence(url,sentctl){if((typeof sentctl!=='undefined')&&(url!='')){text=sentctl.value;if(typeof text==='string'){showRightFrames(undefined,createTheDictUrl(url,text.replace(/[{}]/g,'')))}}}
-
-function translateSentence2(url,sentctl) {
-  if((typeof sentctl!=='undefined')&&(url!='')) {
-    text=sentctl.value;
-    if(typeof text==='string') {
-      newtext=text.replace(/[{}]/g,'');
-      finalurl=url.replace('###', encodeURIComponent(newtext));
-      console.log('finalurl => ' + finalurl);
-      owin(finalurl);
-    }
-  }
-}
-
+function translateSentence2(url,sentctl){if((typeof sentctl!=='undefined')&&(url!='')){text=sentctl.value;if(typeof text==='string'){newtext=text.replace(/[{}]/g,'');finalurl=url.replace('###',encodeURIComponent(newtext));owin(finalurl)}}}
 function translateWord(url,wordctl){if((typeof wordctl!=='undefined')&&(url!='')){text=wordctl.value;if(typeof text==='string'){showRightFrames(undefined,createTheDictUrl(url,text))}}}
 function translateWord2(url,wordctl){if((typeof wordctl!=='undefined')&&(url!='')){text=wordctl.value;if(typeof text==='string'){owin(createTheDictUrl(url,text))}}}
 function translateWord3(url,word){owin(createTheDictUrl(url,word))}

--- a/js/pgm.js
+++ b/js/pgm.js
@@ -254,7 +254,19 @@ function make_overlib_audio(txt,lang){let img=document.createElement("img");img.
 function getStatusName(status){return(STATUSES[status]?STATUSES[status].name:'Unknown')}
 function getStatusAbbr(status){return(STATUSES[status]?STATUSES[status].abbr:'?')}
 function translateSentence(url,sentctl){if((typeof sentctl!=='undefined')&&(url!='')){text=sentctl.value;if(typeof text==='string'){showRightFrames(undefined,createTheDictUrl(url,text.replace(/[{}]/g,'')))}}}
-function translateSentence2(url,sentctl){if((typeof sentctl!=='undefined')&&(url!='')){text=sentctl.value;if(typeof text==='string'){owin(createTheDictUrl(url,text.replace(/[{}]/g,'')))}}}
+
+function translateSentence2(url,sentctl) {
+  if((typeof sentctl!=='undefined')&&(url!='')) {
+    text=sentctl.value;
+    if(typeof text==='string') {
+      newtext=text.replace(/[{}]/g,'');
+      finalurl=url.replace('###', encodeURIComponent(newtext));
+      console.log('finalurl => ' + finalurl);
+      owin(finalurl);
+    }
+  }
+}
+
 function translateWord(url,wordctl){if((typeof wordctl!=='undefined')&&(url!='')){text=wordctl.value;if(typeof text==='string'){showRightFrames(undefined,createTheDictUrl(url,text))}}}
 function translateWord2(url,wordctl){if((typeof wordctl!=='undefined')&&(url!='')){text=wordctl.value;if(typeof text==='string'){owin(createTheDictUrl(url,text))}}}
 function translateWord3(url,word){owin(createTheDictUrl(url,word))}

--- a/src/js/pgm.js
+++ b/src/js/pgm.js
@@ -710,9 +710,9 @@ function translateSentence2 (url, sentctl) {
   if ((typeof sentctl !== 'undefined') && (url != '')) {
     text = sentctl.value;
     if (typeof text === 'string') {
-      owin(
-        createTheDictUrl(url, text.replace(/[{}]/g, ''))
-      );
+      newtext = text.replace(/[{}]/g,'');
+      finalurl = url.replace('###', encodeURIComponent(newtext));
+      owin(finalurl);
     }
   }
 }


### PR DESCRIPTION
When using a Google Translate URL, every "translate click" fails on the first click, which is annoying.  This is a very simple fix.

The current pre-PR code uses a series of calls to eventually open a new window with a header Location change.  I believe that Google has blocked this for XSS attack reasons. This change just makes the proper URL using plain javascript and then opens the window. It's very clear what's happening with this new code, but I don't know enough project history to say if this is an acceptable change or not.

Note that the 'translate sentence' in the reading pane pop-up is still broken, because it uses a slightly different set of calls, and still relies on the Location header change.

Issuing this PR to master because master is currently broken, so it's a hotfix.