### PR TITLE
Autohide right frame at end of actions

### DIFF
--- a/delete_word.php
+++ b/delete_word.php
@@ -103,8 +103,8 @@ function delete_word_javascript($wid, $tid)
         .attr('title', title)
         .removeAttr("data_img");
         $('#learnstatus', context).html('<?php echo addslashes(texttodocount2($tid)); ?>');
-        window.parent.document.getElementById('frame-l').focus();
-        window.parent.setTimeout('cClick()', 100);
+
+        cleanupRightFrames();
     }
 
     delete_word(<?php echo $wid; ?>);

--- a/edit_mword.php
+++ b/edit_mword.php
@@ -148,8 +148,7 @@ function edit_mword_do_operation($term)
     }
     ?>
     <script type="text/javascript">
-        window.parent.document.getElementById('frame-l').focus();
-        window.parent.setTimeout('cClick()', 100);
+        cleanupRightFrames();
     </script>
 
     <?php

--- a/edit_word.php
+++ b/edit_word.php
@@ -158,9 +158,8 @@ function change_term_display($wid, $translation, $hex): void
     }
     ?>
     $('#learnstatus', contexth).html('<?php echo addslashes(texttodocount2($_REQUEST['tid'])); ?>');
-    window.parent.document.getElementById('frame-l').focus();
-    //window.parent.document.getElementById('frame-l').setTimeout('cClick()', 100);
-    window.parent.setTimeout('cClick()', 100);
+
+    cleanupRightFrames();
     //]]>
 </script>
     <?php

--- a/insert_word_ignore.php
+++ b/insert_word_ignore.php
@@ -106,8 +106,8 @@ function do_javascript_action($word, $wid, $hex, $textid)
     .attr('data_wid','<?php echo $wid; ?>')
     .attr('title',title);
     $('#learnstatus', contexth).html('<?php echo addslashes(texttodocount2($textid)); ?>');
-    window.parent.document.getElementById('frame-l').focus();
-    window.parent.setTimeout('cClick()', 100);
+
+    cleanupRightFrames();
     //]]>
     </script>
     <?php

--- a/insert_word_wellknown.php
+++ b/insert_word_wellknown.php
@@ -101,8 +101,8 @@ function insert_word_wellknown_javascript($word, $wid, $hex, $textid)
     .attr('data_wid','<?php echo $wid; ?>')
     .attr('title',title);
     $('#learnstatus', contexth).html('<?php echo addslashes(texttodocount2($textid)); ?>');
-    window.parent.document.getElementById('frame-l').focus();
-    window.parent.setTimeout('cClick()', 100);
+
+    cleanupRightFrames();
     //]]>
     </script>
     <?php

--- a/js/pgm.js
+++ b/js/pgm.js
@@ -170,7 +170,7 @@ return!1}
 function hideRightFrames(){if($('#frames-r').length){$('#frames-r').animate({right:'-100%'});return!0}
 return!1}
 function cleanupRightFrames(){let mytimeout=function(){var rf=window.parent.document.getElementById('frames-r');rf.click()}
-window.parent.setTimeout(mytimeout,400);window.parent.document.getElementById('frame-l').focus();window.parent.setTimeout('cClick()',100)}
+window.parent.setTimeout(mytimeout,800);window.parent.document.getElementById('frame-l').focus();window.parent.setTimeout('cClick()',100)}
 function successSound(){document.getElementById('success_sound').pause();document.getElementById('failure_sound').pause();return document.getElementById('success_sound').play()}
 function failureSound(){document.getElementById('success_sound').pause();document.getElementById('failure_sound').pause();return document.getElementById('failure_sound').play()}
 $.fn.serializeObject=function(){const o={};const a=this.serializeArray();$.each(a,function(){if(o[this.name]!==undefined){if(!o[this.name].push){o[this.name]=[o[this.name]]}

--- a/js/pgm.js
+++ b/js/pgm.js
@@ -169,6 +169,8 @@ if($('#frames-r').length){$('#frames-r').animate({right:'5px'});return!0}
 return!1}
 function hideRightFrames(){if($('#frames-r').length){$('#frames-r').animate({right:'-100%'});return!0}
 return!1}
+function cleanupRightFrames(){let mytimeout=function(){var rf=window.parent.document.getElementById('frames-r');rf.click()}
+window.parent.setTimeout(mytimeout,400);window.parent.document.getElementById('frame-l').focus();window.parent.setTimeout('cClick()',100)}
 function successSound(){document.getElementById('success_sound').pause();document.getElementById('failure_sound').pause();return document.getElementById('success_sound').play()}
 function failureSound(){document.getElementById('success_sound').pause();document.getElementById('failure_sound').pause();return document.getElementById('failure_sound').play()}
 $.fn.serializeObject=function(){const o={};const a=this.serializeArray();$.each(a,function(){if(o[this.name]!==undefined){if(!o[this.name].push){o[this.name]=[o[this.name]]}

--- a/set_word_status.php
+++ b/set_word_status.php
@@ -96,8 +96,8 @@ function set_word_status_javascript($tid, $wid, $status, $word, $trans, $roman)
     .attr('data_status','<?php echo $status; ?>')
     .attr('title',title);
     $('#learnstatus', contexth).html('<?php echo addslashes(texttodocount2($tid)); ?>');
-    window.parent.document.getElementById('frame-l').focus();
-    window.parent.setTimeout('cClick()', 100);
+
+    cleanupRightFrames();
     //]]>
 </script>
     <?php

--- a/src/js/jq_pgm.js
+++ b/src/js/jq_pgm.js
@@ -1110,6 +1110,36 @@ function hideRightFrames() {
   return false;
 }
 
+
+/**
+ * Hide the right frame and any popups.
+ *
+ * Called from several places: insert_word_ignore.php,
+ * set_word_status.php, delete_word.php, etc.
+ */
+function cleanupRightFrames() {
+
+  // A very annoying hack to get right frames to hide correctly.
+  // Calling hideRightFrames directly in window.parent.setTimeout
+  // does  //not work* for some reason ... when called that way,
+  // in hideRightFrames $('#frames-r').length is always 0.  I'm not
+  // sure why.  Using the mytimeout method lets the js find the
+  // element at runtime, and then it's clicked, invoking the function
+  // hideRightFrames, which then works.
+  //
+  // We have to use an anon function to ensure that the frames-r
+  // gets resolved when the timeout fires.
+  let mytimeout = function() {
+    var rf = window.parent.document.getElementById('frames-r');
+    rf.click();
+  }
+  window.parent.setTimeout(mytimeout, 400);
+
+  window.parent.document.getElementById('frame-l').focus();
+  window.parent.setTimeout('cClick()', 100);
+}
+
+
 /**
  * Play the success sound.
  *  

--- a/src/js/jq_pgm.js
+++ b/src/js/jq_pgm.js
@@ -1133,7 +1133,7 @@ function cleanupRightFrames() {
     var rf = window.parent.document.getElementById('frames-r');
     rf.click();
   }
-  window.parent.setTimeout(mytimeout, 400);
+  window.parent.setTimeout(mytimeout, 800);
 
   window.parent.document.getElementById('frame-l').focus();
   window.parent.setTimeout('cClick()', 100);


### PR DESCRIPTION
Resolves issue #61 , and makes using LWT feel much smoother.

Currently, after deleting/changing/ignoring etc a word in the reading frame, the right frames stay visible until the user clicks on the reading pane.  It's a bit annoying to have to do the click, especially when it's obvious that the user is done editing/changing.

This PR just adds a short timeout and then hides the right frame.