### PR TITLE
WORK-IN-PROGRESS don't merge: remove `$tbpref`

### DIFF
--- a/all_words_wellknown.php
+++ b/all_words_wellknown.php
@@ -27,7 +27,7 @@ require_once 'inc/session_utility.php';
  */
 function all_words_wellknown_get_words($txid)
 {
-    global $tbpref;
+
     $sql = "SELECT DISTINCT Ti2Text, LOWER(Ti2Text) AS Ti2TextLC
     FROM ( 
         textitems2 
@@ -54,7 +54,7 @@ function all_words_wellknown_get_words($txid)
  */
 function all_words_wellknown_process_word($status, $term, $termlc, $langid)
 {
-    global $tbpref;
+
     $wid = get_first_value(
         "SELECT WoID AS value FROM words 
         WHERE WoTextLC = " . convert_string_to_sqlsyntax($termlc)
@@ -114,7 +114,7 @@ function all_words_wellknown_process_word($status, $term, $termlc, $langid)
  */
 function all_words_wellknown_main_loop($txid, $status)
 {
-    global $tbpref;
+
     $langid = get_first_value(
         "SELECT TxLgID AS value 
         FROM texts 

--- a/all_words_wellknown.php
+++ b/all_words_wellknown.php
@@ -30,8 +30,8 @@ function all_words_wellknown_get_words($txid)
     global $tbpref;
     $sql = "SELECT DISTINCT Ti2Text, LOWER(Ti2Text) AS Ti2TextLC
     FROM ( 
-        {$tbpref}textitems2 
-        LEFT JOIN {$tbpref}words 
+        textitems2 
+        LEFT JOIN words 
         ON LOWER(Ti2Text) = WoTextLC AND Ti2LgID = WoLgID
     ) 
     WHERE WoID IS NULL AND Ti2WordCount = 1 AND Ti2TxID = $txid 
@@ -63,7 +63,7 @@ function all_words_wellknown_process_word($status, $term, $termlc, $langid)
         $rows = 0;
     } else {
         $message = runsql(
-            "INSERT INTO {$tbpref}words (
+            "INSERT INTO words (
                 WoLgID, WoText, WoTextLC, WoStatus, WoStatusChanged," 
                 . make_score_random_insert_update('iv') . 
             ") 
@@ -117,7 +117,7 @@ function all_words_wellknown_main_loop($txid, $status)
     global $tbpref;
     $langid = get_first_value(
         "SELECT TxLgID AS value 
-        FROM {$tbpref}texts 
+        FROM texts 
         WHERE TxID = $txid"
     );
     $javascript = "let title='';";
@@ -134,8 +134,8 @@ function all_words_wellknown_main_loop($txid, $status)
 
     // Associate existing textitems.
     runsql(
-        "UPDATE {$tbpref}words 
-        JOIN {$tbpref}textitems2 
+        "UPDATE words 
+        JOIN textitems2 
         ON Ti2WoID = 0 AND LOWER(Ti2Text) = WoTextLC AND Ti2LgID = WoLgID 
         SET Ti2WoID = WoID", 
         ''

--- a/backup_restore.php
+++ b/backup_restore.php
@@ -120,7 +120,7 @@ if (isset($_REQUEST['restore'])) {
                 LgRegexpSplitSentences, LgExceptionsSplitSentences, 
                 LgRegexpWordCharacters, LgRemoveSpaces, LgSplitEachChar, 
                 LgRightToLeft 
-                FROM ' . $tbpref . 'languages where LgName<>""'
+                FROM languages where LgName<>""'
             );
             $num_fields = mysqli_num_fields($result);
         } elseif ($table !== 'sentences' && $table !== 'textitems'  
@@ -314,20 +314,20 @@ if (isset($_REQUEST['restore'])) {
     exit();
 } elseif (isset($_REQUEST['empty'])) {
     // EMPTY
-    runsql('TRUNCATE ' . $tbpref . 'archivedtexts', '');
-    runsql('TRUNCATE ' . $tbpref . 'archtexttags', '');
-    runsql('TRUNCATE ' . $tbpref . 'feedlinks', '');
-    runsql('TRUNCATE ' . $tbpref . 'languages', '');
-    runsql('TRUNCATE ' . $tbpref . 'textitems2', '');
-    runsql('TRUNCATE ' . $tbpref . 'newsfeeds', '');
-    runsql('TRUNCATE ' . $tbpref . 'sentences', '');
-    runsql('TRUNCATE ' . $tbpref . 'tags', '');
-    runsql('TRUNCATE ' . $tbpref . 'tags2', '');
-    runsql('TRUNCATE ' . $tbpref . 'texts', '');
-    runsql('TRUNCATE ' . $tbpref . 'texttags', '');
-    runsql('TRUNCATE ' . $tbpref . 'words', '');
-    runsql('TRUNCATE ' . $tbpref . 'wordtags', '');
-    runsql('DELETE FROM ' . $tbpref . 'settings where StKey = \'currenttext\'', '');
+    runsql('TRUNCATE archivedtexts', '');
+    runsql('TRUNCATE archtexttags', '');
+    runsql('TRUNCATE feedlinks', '');
+    runsql('TRUNCATE languages', '');
+    runsql('TRUNCATE textitems2', '');
+    runsql('TRUNCATE newsfeeds', '');
+    runsql('TRUNCATE sentences', '');
+    runsql('TRUNCATE tags', '');
+    runsql('TRUNCATE tags2', '');
+    runsql('TRUNCATE texts', '');
+    runsql('TRUNCATE texttags', '');
+    runsql('TRUNCATE words', '');
+    runsql('TRUNCATE wordtags', '');
+    runsql('DELETE FROM settings where StKey = \'currenttext\'', '');
     optimizedb();
     get_tags($refresh = 1);
     get_texttags($refresh = 1);

--- a/backup_restore.php
+++ b/backup_restore.php
@@ -60,7 +60,7 @@ if (isset($_REQUEST['restore'])) {
     $out = "-- " . $fname . "\n";
     foreach ($tables as $table) { 
         // foreach table
-        $result = do_mysqli_query('SELECT * FROM ' . $tbpref . $table);
+        $result = do_mysqli_query('SELECT * FROM ' . $table);
         $num_fields = mysqli_num_fields($result);
         $out .= "\nDROP TABLE IF EXISTS " . $table . ";\n";
         $row2 = mysqli_fetch_row(do_mysqli_query("SHOW CREATE TABLE $tbpref$table"));
@@ -99,7 +99,7 @@ if (isset($_REQUEST['restore'])) {
             $result = do_mysqli_query(
                 'SELECT TxID, TxLgID, TxTitle, TxText, TxAnnotatedText, TxAudioURI, 
                 TxSourceURI 
-                FROM ' . $tbpref . $table
+                FROM ' . $table
             );
             $num_fields = 7;
         } elseif ($table == 'words') {
@@ -107,7 +107,7 @@ if (isset($_REQUEST['restore'])) {
                 'SELECT WoID, WoLgID, WoText, WoTextLC, WoStatus, WoTranslation, 
                 WoRomanization, WoSentence, WoCreated, WoStatusChanged, WoTodayScore,
                 WoTomorrowScore, WoRandom 
-                FROM ' . $tbpref . $table
+                FROM ' . $table
             );
             $num_fields = 13;
         } elseif ($table == 'languages') {
@@ -126,7 +126,7 @@ if (isset($_REQUEST['restore'])) {
         } elseif ($table !== 'sentences' && $table !== 'textitems'  
             && $table !== 'settings'
         ) {
-            $result = do_mysqli_query('SELECT * FROM ' . $tbpref . $table);
+            $result = do_mysqli_query('SELECT * FROM ' . $table);
             $num_fields = mysqli_num_fields($result);
         }
         $out .= "\nDROP TABLE IF EXISTS " . $table . ";\n";

--- a/bulk_translate_words.php
+++ b/bulk_translate_words.php
@@ -35,17 +35,17 @@ if (isset($_REQUEST['term'])) {
         ')';
         $cnt++;
     }
-    $sqltext = "INSERT INTO {$tbpref}words (
+    $sqltext = "INSERT INTO words (
         WoLgID, WoTextLC, WoText, WoStatus, WoTranslation, WoSentence, 
         WoRomanization, WoStatusChanged," .  
         make_score_random_insert_update('iv') . "
     ) VALUES " . rtrim(implode(',', $sqlarr), ',');
     runsql($sqltext, '');
     $tooltip_mode = getSettingWithDefault('set-tooltip-mode');
-    $max = get_first_value("SELECT max(WoID) AS value FROM {$tbpref}words");
+    $max = get_first_value("SELECT max(WoID) AS value FROM words");
     $res = do_mysqli_query(
         "SELECT WoID, WoTextLC, WoStatus, WoTranslation 
-        FROM {$tbpref}words 
+        FROM words 
         where WoID > $max"
     );
     pagestart($cnt . ' New Word' . ($cnt != 1 ? 's' : '') . ' Saved', false);
@@ -79,8 +79,8 @@ if (isset($_REQUEST['term'])) {
     mysqli_free_result($res);
     flush();
     do_mysqli_query(
-        "UPDATE {$tbpref}textitems2 
-        JOIN {$tbpref}words 
+        "UPDATE textitems2 
+        JOIN words 
         ON lower(Ti2Text)=WoTextLC AND Ti2WordCount=1 AND Ti2LgID=WoLgID AND WoID>$max 
         SET Ti2WoID = WoID"
     );
@@ -105,7 +105,7 @@ if(isset($pos)) {
     $offset = '';
     $limit = (int)getSettingWithDefault('set-ggl-translation-per-page') + 1;
     $sql = 'select LgName, LgDict1URI, LgDict2URI, LgGoogleTranslateURI 
-    from ' . $tbpref . 'languages, ' . $tbpref . 'texts 
+    from languages, texts 
     where LgID = TxLgID and TxID = ' . $tid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
@@ -372,7 +372,7 @@ function googleTranslateElementInit() {
     <?php
     $res = do_mysqli_query(
         'select Ti2Text as word,Ti2LgID,min(Ti2Order) as pos 
-        from ' . $tbpref . 'textitems2 
+        from textitems2 
         where Ti2WoID = 0 and Ti2TxID = ' . $tid . ' AND Ti2WordCount =1 
         group by LOWER(Ti2Text) 
         order by pos 

--- a/delete_mword.php
+++ b/delete_mword.php
@@ -19,11 +19,11 @@ $showAll = getSettingZeroOrOne('showallwords', 1);
 
 $tid = $_REQUEST['tid'];
 $wid = $_REQUEST['wid'];
-$word = get_first_value("select WoText as value from " . $tbpref . "words where WoID = " . $wid);
+$word = get_first_value("select WoText as value from words where WoID = " . $wid);
 pagestart("Term: " . $word, false);
-$m1 = runsql('delete from ' . $tbpref . 'words where WoID = ' . $wid, '');
+$m1 = runsql('delete from words where WoID = ' . $wid, '');
 adjust_autoincr('words', 'WoID');
-runsql('delete from ' . $tbpref . 'textitems2 where Ti2WordCount>1 AND Ti2WoID = ' . $wid, '');
+runsql('delete from textitems2 where Ti2WordCount>1 AND Ti2WoID = ' . $wid, '');
 
 echo "<p>OK, term deleted (" . $m1 . ").</p>";
 

--- a/delete_word.php
+++ b/delete_word.php
@@ -26,7 +26,7 @@ function get_term($wid)
     global $tbpref;
     $term = get_first_value(
         "SELECT WoText AS value 
-        FROM " . $tbpref . "words 
+        FROM words 
         WHERE WoID = " . $wid
     );
     return $term;
@@ -45,13 +45,13 @@ function delete_word_from_database($wid)
 {
     global $tbpref;
     $m1 = runsql(
-        'DELETE FROM ' . $tbpref . 'words 
+        'DELETE FROM words 
         WHERE WoID = ' . $wid, 
         ''
     );
     adjust_autoincr('words', 'WoID');
     runsql(
-        "UPDATE  " . $tbpref . "textitems2 
+        "UPDATE  textitems2 
         SET Ti2WoID  = 0 
         WHERE Ti2WordCount=1 AND Ti2WoID  = " . $wid, 
         ''

--- a/delete_word.php
+++ b/delete_word.php
@@ -19,11 +19,11 @@ require_once 'inc/session_utility.php';
  * 
  * @return string|null A word
  * 
- * @global string $tbpref 
+ *
  */
 function get_term($wid)
 {
-    global $tbpref;
+
     $term = get_first_value(
         "SELECT WoText AS value 
         FROM words 
@@ -39,11 +39,11 @@ function get_term($wid)
  * 
  * @return string Some edit message, number of affected rows or error message
  * 
- * @global string $tbpref 
+ *
  */
 function delete_word_from_database($wid)
 {
-    global $tbpref;
+
     $m1 = runsql(
         'DELETE FROM words 
         WHERE WoID = ' . $wid, 

--- a/devscripts/remove_tbpref/README.md
+++ b/devscripts/remove_tbpref/README.md
@@ -1,0 +1,27 @@
+Get rid of bad code.
+
+These scripts work on a Mac, probably not other *nix systems, def not windows.
+
+Run them from root dir
+
+# Sample sed
+
+sed -i "" "s/' \. \$tbpref \. 'words/words/g" ./insert_word_wellknown.php
+
+# Scripts
+
+## Find all tbprefs
+
+devscripts/remove_tbpref/find_tbpref.sh
+
+## save them to a file **outside of the proj dir**
+
+devscripts/remove_tbpref/find_tbpref.sh > ../find_tbpref_results.txt
+
+## Get the current counts
+
+devscripts/remove_tbpref/find_tbpref.sh | wc
+
+## Delete
+
+devscripts/remove_tbpref/run_seds.sh 

--- a/devscripts/remove_tbpref/find_tbpref.sh
+++ b/devscripts/remove_tbpref/find_tbpref.sh
@@ -1,1 +1,1 @@
-find . -name '*.*' -print0 | xargs -0 grep -i tbpref 2>/dev/null
+find . -name '*.php' -print0 | xargs -0 grep -i tbpref 2>/dev/null

--- a/devscripts/remove_tbpref/find_tbpref.sh
+++ b/devscripts/remove_tbpref/find_tbpref.sh
@@ -1,0 +1,1 @@
+find . -name '*.*' -print0 | xargs -0 grep -i tbpref 2>/dev/null

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -44,8 +44,7 @@ for f in $FILES; do
 
     if [[ $HASBADLINE -eq 0 ]]; then
         echo "Cleaning ${f}"
-
-        sed -i "" "s/^[[:space:]]*global \$tbpref;[[:space:]]*\n//g" $f
+        sed -i "" "s/^[[:space:]]*global \$tbpref;[[:space:]]*$//g" $f
     else
         echo "Skipping ${f}, has line ${BADLINE}"
     fi

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -40,6 +40,9 @@ for f in $FILES; do
         if [[ "$line" =~ "global $tbpref, $debug" ]]; then
             OK=1
         fi
+        if [[ "$line" =~ "global $debug, $tbpref" ]]; then
+            OK=1
+        fi
 
         if [[ $OK -eq 0 ]]; then
             BADLINE="$line"
@@ -51,7 +54,10 @@ for f in $FILES; do
         echo "Cleaning ${f}"
         sed -i "" "s/^[[:space:]]*global \$tbpref;[[:space:]]*$//g" $f
         sed -i "" "s/^[[:space:]]*global \$tbpref, \$debug;[[:space:]]*$/    global \$debug;/g" $f
+        sed -i "" "s/^[[:space:]]*global \$tbpref, \$langDefs;[[:space:]]*$/    global \$langDefs;/g" $f
+        sed -i "" "s/^[[:space:]]*global \$debug, \$tbpref;[[:space:]]*$/    global \$debug;/g" $f
         sed -i "" "s/^[[:space:]]*\* @global string \$tbpref.*$/ */g" $f
+        sed -i "" "s/^[[:space:]]*\* @global {string} \$tbpref.*$/ */g" $f
 
     else
         echo "Skipping ${f}, has line ${BADLINE}"

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+
+# Find files with tbpref but where the line either matches
+#  * @global string $tbpref Database table prefix
+#  global $tbpref;
+#  global $tbpref, $debug;
+# if the line is anything different, the file can't be updated, otherwise it can.
+
+# Obligatory "I hate bash" note here.
+
+# FILES=`find . -name '*.php' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
+# echo $FILES
+FILES=`echo ./edit_texts.php`
+
+for f in $FILES; do
+    echo "$f"
+
+    echo "initial grep"
+    grep "\$tbpref" $f
+    echo "----------------"
+    LINES=$(grep "\$tbpref" $f | sed -Ee 's/^[[:space:]]*//g' | sed -Ee 's/[[:space:]]*$//g' | sort | uniq)
+
+    HASBADLINE=0
+    BADLINE=""
+    while IFS= read -r line; do
+        echo "=> $line"
+        OK=0
+        if [[ "$line" =~ "@global string $tbpref" ]]; then
+            OK=1
+        fi
+        if [[ "$line" =~ "global $tbpref" ]]; then
+            OK=1
+        fi
+        if [[ "$line" =~ "global $tbpref, $debug" ]]; then
+            OK=1
+        fi
+
+        if [[ $OK -eq 1 ]]; then
+            echo "ok, this line matches one of the patterns"
+        else
+            echo "Bad line: ${line}"
+            BADLINE="$line"
+            HASBADLINE=1
+        fi
+    done <<< "$LINES"
+
+    if [[ $HASBADLINE -eq 0 ]]; then
+        echo "File only contains lines matching patterns, can clean it."
+    else
+        echo "Can't clean file, has bad line ${BADLINE}"
+    fi
+done

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -13,17 +13,17 @@
 FILES=`echo ./edit_texts.php`
 
 for f in $FILES; do
-    echo "$f"
+    # echo "$f"
 
-    echo "initial grep"
-    grep "\$tbpref" $f
-    echo "----------------"
+    # echo "initial grep"
+    # grep "\$tbpref" $f
+    # echo "----------------"
     LINES=$(grep "\$tbpref" $f | sed -Ee 's/^[[:space:]]*//g' | sed -Ee 's/[[:space:]]*$//g' | sort | uniq)
 
     HASBADLINE=0
     BADLINE=""
     while IFS= read -r line; do
-        echo "=> $line"
+        # echo "=> $line"
         OK=0
         if [[ "$line" =~ "@global string $tbpref" ]]; then
             OK=1
@@ -35,18 +35,15 @@ for f in $FILES; do
             OK=1
         fi
 
-        if [[ $OK -eq 1 ]]; then
-            echo "ok, this line matches one of the patterns"
-        else
-            echo "Bad line: ${line}"
+        if [[ $OK -eq 0 ]]; then
             BADLINE="$line"
             HASBADLINE=1
         fi
     done <<< "$LINES"
 
     if [[ $HASBADLINE -eq 0 ]]; then
-        echo "File only contains lines matching patterns, can clean it."
+        echo "Cleaning ${f}"
     else
-        echo "Can't clean file, has bad line ${BADLINE}"
+        echo "Skipping ${f}, has line ${BADLINE}"
     fi
 done

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -45,8 +45,8 @@ for f in $FILES; do
     if [[ $HASBADLINE -eq 0 ]]; then
         echo "Cleaning ${f}"
         sed -i "" "s/^[[:space:]]*global \$tbpref;[[:space:]]*$//g" $f
-        sed -i "" "s/^[[:space:]]*global \$tbpref, \$debug;[[:space:]]*$/    global $debug;/g" $f
-        sed -i "" "s/^[[:space:]]*\* @global string \$tbpref.*$//g" $f
+        sed -i "" "s/^[[:space:]]*global \$tbpref, \$debug;[[:space:]]*$/    global \$debug;/g" $f
+        sed -i "" "s/^[[:space:]]*\* @global string \$tbpref.*$/ */g" $f
 
     else
         echo "Skipping ${f}, has line ${BADLINE}"

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -8,9 +8,9 @@
 
 # Obligatory "I hate bash" note here.
 
-# FILES=`find . -name '*.php' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
+FILES=`find . -name '*.php' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
 # echo $FILES
-FILES=`echo ./edit_texts.php`
+# FILES=`echo ./edit_texts.php`
 
 
 for f in $FILES; do

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -45,6 +45,9 @@ for f in $FILES; do
     if [[ $HASBADLINE -eq 0 ]]; then
         echo "Cleaning ${f}"
         sed -i "" "s/^[[:space:]]*global \$tbpref;[[:space:]]*$//g" $f
+        sed -i "" "s/^[[:space:]]*global \$tbpref, \$debug;[[:space:]]*$/    global $debug;/g" $f
+        sed -i "" "s/^[[:space:]]*\* @global string \$tbpref.*$//g" $f
+
     else
         echo "Skipping ${f}, has line ${BADLINE}"
     fi

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -12,6 +12,7 @@
 # echo $FILES
 FILES=`echo ./edit_texts.php`
 
+
 for f in $FILES; do
     # echo "$f"
 
@@ -43,6 +44,8 @@ for f in $FILES; do
 
     if [[ $HASBADLINE -eq 0 ]]; then
         echo "Cleaning ${f}"
+
+        sed -i "" "s/^[[:space:]]*global \$tbpref;[[:space:]]*\n//g" $f
     else
         echo "Skipping ${f}, has line ${BADLINE}"
     fi

--- a/devscripts/remove_tbpref/only_global_or_comment.sh
+++ b/devscripts/remove_tbpref/only_global_or_comment.sh
@@ -6,6 +6,11 @@
 #  global $tbpref, $debug;
 # if the line is anything different, the file can't be updated, otherwise it can.
 
+# To check the changes, after running this script, you can run a fancy check:
+# (ref https://stackoverflow.com/questions/18810623/git-diff-to-show-only-lines-that-have-been-modified):
+#    git diff -U0 | grep '^[+-]' | grep -Ev '^(--- a/|\+\+\+ b/)' | sort | uniq
+# which shows that only the correct things were removed.
+
 # Obligatory "I hate bash" note here.
 
 FILES=`find . -name '*.php' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;

--- a/devscripts/remove_tbpref/run_seds.sh
+++ b/devscripts/remove_tbpref/run_seds.sh
@@ -15,5 +15,6 @@ for f in $FILES; do
         sed -i "" "s/{\$tbpref}$tbl/$tbl/g" $f
         sed -i "" "s/in_array(\$tbpref \. '$tbl', \$tables)/in_array('$tbl', \$tables)/g" $f
         sed -i "" "s/FROM ' \. \$tbpref \. \$table/FROM ' . \$table/g" $f
+        sed -i "" "s/\$tbpref \. '$tbl/$tbl/g" $f
     done
 done

--- a/devscripts/remove_tbpref/run_seds.sh
+++ b/devscripts/remove_tbpref/run_seds.sh
@@ -8,7 +8,7 @@ echo $FILES
 for f in $FILES; do
     echo "$f"
 
-    for tbl in archivedtexts archtexttags feedlinks languages merge_words newsfeeds numbers sentences settings tags tags2 temptextitems tempwords textitems textitems2 texts texttags tts words wordtags; do
+    for tbl in archivedtexts archtexttags db_to_mecab feedlinks languages mecab merge_words newsfeeds numbers sentences settings tags tags2 temptextitems tempwords textitems textitems2 texts texttags tts words wordtags; do
         # echo "  $tbl"
         sed -i "" "s/' \. \$tbpref \. '$tbl/$tbl/g" $f
         sed -i "" "s/\" \. \$tbpref \. \"$tbl/$tbl/g" $f
@@ -16,5 +16,6 @@ for f in $FILES; do
         sed -i "" "s/in_array(\$tbpref \. '$tbl', \$tables)/in_array('$tbl', \$tables)/g" $f
         sed -i "" "s/FROM ' \. \$tbpref \. \$table/FROM ' . \$table/g" $f
         sed -i "" "s/\$tbpref \. '$tbl/$tbl/g" $f
+        sed -i "" "s/\$tbpref \. \"$tbl/$tbl/g" $f
     done
 done

--- a/devscripts/remove_tbpref/run_seds.sh
+++ b/devscripts/remove_tbpref/run_seds.sh
@@ -1,5 +1,7 @@
+set -e
+
 FILES=`find . -name '*.*' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
-# FILES=`echo ./edit_words.php`
+# FILES=`echo ./inc/database_connect.php`
 
 for f in $FILES; do
     echo "$f"
@@ -9,5 +11,6 @@ for f in $FILES; do
         sed -i "" "s/' \. \$tbpref \. '$tbl/$tbl/g" $f
         sed -i "" "s/\" \. \$tbpref \. \"$tbl/$tbl/g" $f
         sed -i "" "s/{\$tbpref}$tbl/$tbl/g" $f
+        sed -i "" "s/in_array(\$tbpref \. '$tbl', \$tables)/in_array('$tbl', \$tables)/g" $f
     done
 done

--- a/devscripts/remove_tbpref/run_seds.sh
+++ b/devscripts/remove_tbpref/run_seds.sh
@@ -1,7 +1,9 @@
-set -e
+# set -e
+# set -x
 
 FILES=`find . -name '*.*' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
 # FILES=`echo ./inc/database_connect.php`
+echo $FILES
 
 for f in $FILES; do
     echo "$f"

--- a/devscripts/remove_tbpref/run_seds.sh
+++ b/devscripts/remove_tbpref/run_seds.sh
@@ -8,11 +8,12 @@ echo $FILES
 for f in $FILES; do
     echo "$f"
 
-    for tbl in archivedtexts archtexttags feedlinks languages newsfeeds sentences settings tags tags2 temptextitems tempwords textitems2 texts texttags tts words wordtags; do
-        echo "  $tbl"
+    for tbl in archivedtexts archtexttags feedlinks languages merge_words newsfeeds numbers sentences settings tags tags2 temptextitems tempwords textitems2 texts texttags tts words wordtags; do
+        # echo "  $tbl"
         sed -i "" "s/' \. \$tbpref \. '$tbl/$tbl/g" $f
         sed -i "" "s/\" \. \$tbpref \. \"$tbl/$tbl/g" $f
         sed -i "" "s/{\$tbpref}$tbl/$tbl/g" $f
         sed -i "" "s/in_array(\$tbpref \. '$tbl', \$tables)/in_array('$tbl', \$tables)/g" $f
+        sed -i "" "s/FROM ' \. \$tbpref \. \$table/FROM ' . \$table/g" $f
     done
 done

--- a/devscripts/remove_tbpref/run_seds.sh
+++ b/devscripts/remove_tbpref/run_seds.sh
@@ -1,7 +1,5 @@
-set +x
-
 FILES=`find . -name '*.*' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
-FILES=`echo ./edit_words.php`
+# FILES=`echo ./edit_words.php`
 
 for f in $FILES; do
     echo "$f"

--- a/devscripts/remove_tbpref/run_seds.sh
+++ b/devscripts/remove_tbpref/run_seds.sh
@@ -1,0 +1,15 @@
+set +x
+
+FILES=`find . -name '*.*' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
+FILES=`echo ./edit_words.php`
+
+for f in $FILES; do
+    echo "$f"
+
+    for tbl in archivedtexts archtexttags feedlinks languages newsfeeds sentences settings tags tags2 temptextitems tempwords textitems2 texts texttags tts words wordtags; do
+        echo "  $tbl"
+        sed -i "" "s/' \. \$tbpref \. '$tbl/$tbl/g" $f
+        sed -i "" "s/\" \. \$tbpref \. \"$tbl/$tbl/g" $f
+        sed -i "" "s/{\$tbpref}$tbl/$tbl/g" $f
+    done
+done

--- a/devscripts/remove_tbpref/run_seds.sh
+++ b/devscripts/remove_tbpref/run_seds.sh
@@ -1,14 +1,14 @@
 # set -e
 # set -x
 
-FILES=`find . -name '*.*' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
+FILES=`find . -name '*.php' -print0 | xargs -0 grep -l tbpref 2>/dev/null`;
 # FILES=`echo ./inc/database_connect.php`
 echo $FILES
 
 for f in $FILES; do
     echo "$f"
 
-    for tbl in archivedtexts archtexttags feedlinks languages merge_words newsfeeds numbers sentences settings tags tags2 temptextitems tempwords textitems2 texts texttags tts words wordtags; do
+    for tbl in archivedtexts archtexttags feedlinks languages merge_words newsfeeds numbers sentences settings tags tags2 temptextitems tempwords textitems textitems2 texts texttags tts words wordtags; do
         # echo "  $tbl"
         sed -i "" "s/' \. \$tbpref \. '$tbl/$tbl/g" $f
         sed -i "" "s/\" \. \$tbpref \. \"$tbl/$tbl/g" $f

--- a/display_impr_text.php
+++ b/display_impr_text.php
@@ -83,13 +83,13 @@ if (isset($audio)) {
  * 
  * @param int $textid Text ID
  * 
- * @global string $tbpref Database table prefix
+ *
  * 
  * @return void
  */
 function do_display_impr_text_page($textid)
 {
-    global $tbpref;
+
     $audio = get_first_value(
         'SELECT TxAudioURI AS value FROM texts 
         WHERE TxID = ' . $_REQUEST['text']

--- a/display_impr_text.php
+++ b/display_impr_text.php
@@ -91,7 +91,7 @@ function do_display_impr_text_page($textid)
 {
     global $tbpref;
     $audio = get_first_value(
-        'SELECT TxAudioURI AS value FROM ' . $tbpref . 'texts 
+        'SELECT TxAudioURI AS value FROM texts 
         WHERE TxID = ' . $_REQUEST['text']
     );
     pagestart_nobody('Display');

--- a/display_impr_text_header.php
+++ b/display_impr_text_header.php
@@ -30,7 +30,7 @@ function do_diplay_impr_text_header_data($textid)
 
     $sql = 
     'SELECT TxLgID, TxTitle, TxAudioURI, TxSourceURI 
-    FROM ' . $tbpref . 'texts
+    FROM texts
     WHERE TxID = ' . $textid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);

--- a/display_impr_text_header.php
+++ b/display_impr_text_header.php
@@ -22,11 +22,11 @@ require_once 'inc/session_utility.php';
  * @return array{0: string, 1: string, 2: string} Text title, 
  * text audio and source URI
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function do_diplay_impr_text_header_data($textid)
 {
-    global $tbpref;
+
 
     $sql = 
     'SELECT TxLgID, TxTitle, TxAudioURI, TxSourceURI 

--- a/display_impr_text_text.php
+++ b/display_impr_text_text.php
@@ -27,7 +27,7 @@ function get_annotated_text($textid)
     global $tbpref;
     $ann = get_first_value(
         "SELECT TxAnnotatedText AS value 
-        FROM " . $tbpref . "texts 
+        FROM texts 
         WHERE TxID = " . $textid
     );
 
@@ -47,7 +47,7 @@ function get_display_impr_text_text_data($textid)
     global $tbpref;
 
     /*$sql = 'SELECT TxLgID, TxTitle 
-    FROM ' . $tbpref . 'texts 
+    FROM texts 
     WHERE TxID = ' . $textid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
@@ -55,11 +55,11 @@ function get_display_impr_text_text_data($textid)
     mysqli_free_result($res);
 
     $sql = 'SELECT LgTextSize, LgRemoveSpaces, LgRightToLeft 
-    FROM ' . $tbpref . 'languages WHERE LgID = ' . $langid;*/
+    FROM languages WHERE LgID = ' . $langid;*/
 
     $sql = 'SELECT LgTextSize, LgRightToLeft 
-    FROM ' . $tbpref . 'texts 
-    JOIN ' . $tbpref . 'languages ON LgID = TxLgID
+    FROM texts 
+    JOIN languages ON LgID = TxLgID
     WHERE TxID = ' . $textid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
@@ -158,7 +158,7 @@ function get_word_annotations($vals)
             $wid = (int)$vals[2];
             $rom = get_first_value(
                 "SELECT WoRomanization AS value 
-                FROM " . $tbpref . "words WHERE WoID = " . $wid
+                FROM words WHERE WoID = " . $wid
             );
             if (!isset($rom)) {
                 $rom = ''; 

--- a/display_impr_text_text.php
+++ b/display_impr_text_text.php
@@ -24,7 +24,7 @@ require_once 'inc/session_utility.php';
  */
 function get_annotated_text($textid)
 {
-    global $tbpref;
+
     $ann = get_first_value(
         "SELECT TxAnnotatedText AS value 
         FROM texts 
@@ -44,7 +44,7 @@ function get_annotated_text($textid)
  */
 function get_display_impr_text_text_data($textid)
 {
-    global $tbpref;
+
 
     /*$sql = 'SELECT TxLgID, TxTitle 
     FROM texts 
@@ -145,11 +145,11 @@ function do_diplay_impr_text_text_area($ann, $textsize, $rtlScript)
  * 
  * @return array{0: string, 1: string} Translation and romanization.
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function get_word_annotations($vals)
 {
-    global $tbpref;
+
     $trans = '';
     $c = count($vals);
     $rom = '';

--- a/do_feeds.php
+++ b/do_feeds.php
@@ -50,7 +50,7 @@ $doc = null;
 $text_item = null;
 if (isset($_REQUEST['marked_items'])) {
     $marked_items = implode(',', $_REQUEST['marked_items']);
-    $res = do_mysqli_query("SELECT * FROM (SELECT * FROM " . $tbpref . "feedlinks WHERE FlID IN ($marked_items) ORDER BY FlNfID) A left join " . $tbpref . "newsfeeds ON NfID=FlNfID");
+    $res = do_mysqli_query("SELECT * FROM (SELECT * FROM feedlinks WHERE FlID IN ($marked_items) ORDER BY FlNfID) A left join newsfeeds ON NfID=FlNfID");
     $count=$message1=$message2=$message3=$message4=0;
     while($row = mysqli_fetch_assoc($res)){
         if(get_nf_option($row['NfOptions'], 'edit_text')==1) {
@@ -78,7 +78,7 @@ if (isset($_REQUEST['marked_items'])) {
         if(isset($texts['error'])) {
             echo $texts['error']['message'];
             foreach($texts['error']['link'] as $err_links){
-                runsql('UPDATE ' . $tbpref . 'feedlinks SET FlLink=CONCAT(" ",FlLink) where FlLink in ('.convert_string_to_sqlsyntax($err_links).')', "");
+                runsql('UPDATE feedlinks SET FlLink=CONCAT(" ",FlLink) where FlLink in ('.convert_string_to_sqlsyntax($err_links).')', "");
             }
             unset($texts['error']);
         }
@@ -96,7 +96,7 @@ if (isset($_REQUEST['marked_items'])) {
         <td class="td1">
         <select name="feed[<?php echo $count; ?>][TxLgID]" class="notempty setfocus">
                 <?php
-                $result = do_mysqli_query("SELECT LgName,LgID FROM " . $tbpref . "languages where LgName<>'' ORDER BY LgName");
+                $result = do_mysqli_query("SELECT LgName,LgID FROM languages where LgName<>'' ORDER BY LgName");
                 while($row_l = mysqli_fetch_assoc($result)){
                     echo '<option value="' . $row_l['LgID'] . '"';
                     if($row['NfLgID']===$row_l['LgID']) {
@@ -137,24 +137,24 @@ if (isset($_REQUEST['marked_items'])) {
             }
         }
         else{
-            do_mysqli_query('insert ignore into ' . $tbpref . 'tags2 (T2Text) values("' . $nf_tag_name . '")');
+            do_mysqli_query('insert ignore into tags2 (T2Text) values("' . $nf_tag_name . '")');
             foreach($texts as $text){
                 echo '<div class="msgblue"><p class="hide_message">+++ "' . $text['TxTitle']. '" added! +++</p></div>';
-                do_mysqli_query('INSERT INTO ' . $tbpref . 'texts (TxLgID,TxTitle,TxText,TxAudioURI,TxSourceURI)VALUES ('.$row['NfLgID'].',' . convert_string_to_sqlsyntax($text['TxTitle']) .','. convert_string_to_sqlsyntax($text['TxText']) .','. convert_string_to_sqlsyntax($text['TxAudioURI']) .','.convert_string_to_sqlsyntax($text['TxSourceURI']) .')');
+                do_mysqli_query('INSERT INTO texts (TxLgID,TxTitle,TxText,TxAudioURI,TxSourceURI)VALUES ('.$row['NfLgID'].',' . convert_string_to_sqlsyntax($text['TxTitle']) .','. convert_string_to_sqlsyntax($text['TxText']) .','. convert_string_to_sqlsyntax($text['TxAudioURI']) .','.convert_string_to_sqlsyntax($text['TxSourceURI']) .')');
                 $id = (int)get_last_key();
                 splitCheckText(
                     get_first_value(
-                        'select TxText as value from ' . $tbpref . 'texts where TxID = ' . $id
+                        'select TxText as value from texts where TxID = ' . $id
                     ), 
                     get_first_value(
-                        'select TxLgID as value from ' . $tbpref . 'texts where TxID = ' . $id
+                        'select TxLgID as value from texts where TxID = ' . $id
                     ), 
                     $id 
                 );
-                runsql('insert into ' . $tbpref . 'texttags (TtTxID, TtT2ID) select ' . $id . ', T2ID from ' . $tbpref . 'tags2 where T2Text = "' . $nf_tag_name .'"', "");        
+                runsql('insert into texttags (TtTxID, TtT2ID) select ' . $id . ', T2ID from tags2 where T2Text = "' . $nf_tag_name .'"', "");        
             }
             get_texttags(1);
-            $result=do_mysqli_query("SELECT TtTxID FROM " . $tbpref . "texttags join " . $tbpref . "tags2 on TtT2ID=T2ID WHERE T2Text='". $nf_tag_name ."'");
+            $result=do_mysqli_query("SELECT TtTxID FROM texttags join tags2 on TtT2ID=T2ID WHERE T2Text='". $nf_tag_name ."'");
             $text_count=0;
             while($row = mysqli_fetch_assoc($result)){
                 $text_item[$text_count++]=$row['TtTxID'];
@@ -166,27 +166,27 @@ if (isset($_REQUEST['marked_items'])) {
                     $text_item=array_slice($text_item, 0, $text_count-$nf_max_texts);
                     foreach ($text_item as $text_ID) {
                         $temp = runsql(
-                            'delete from ' . $tbpref . 'textitems2 where Ti2TxID = ' . $text_ID, 
+                            'delete from textitems2 where Ti2TxID = ' . $text_ID, 
                             ""
                         );
                         if (is_numeric($temp)) {
                             $message3 += (int) $temp;
                         }
                         $temp = runsql(
-                            'delete from ' . $tbpref . 'sentences where SeTxID = ' . $text_ID, 
+                            'delete from sentences where SeTxID = ' . $text_ID, 
                             ""
                         );
                         if (is_numeric($temp)) {
                             $message2 += (int) $temp;
                         }
                         $temp = runsql(
-                            'INSERT INTO ' . $tbpref . 'archivedtexts (
+                            'INSERT INTO archivedtexts (
                                 AtLgID, AtTitle, AtText, 
                                 AtAnnotatedText, AtAudioURI, AtSourceURI
                             ) 
                             SELECT TxLgID, TxTitle, TxText, 
                             TxAnnotatedText, TxAudioURI, TxSourceURI 
-                            FROM ' . $tbpref . 'texts 
+                            FROM texts 
                             WHERE TxID = ' . $text_ID, 
                             ""
                         );
@@ -195,23 +195,23 @@ if (isset($_REQUEST['marked_items'])) {
                         }
                         $id = get_last_key();
                         runsql(
-                            'INSERT INTO ' . $tbpref . 'archtexttags (AgAtID, AgT2ID) 
+                            'INSERT INTO archtexttags (AgAtID, AgT2ID) 
                             SELECT ' . $id . ', TtT2ID 
-                            FROM ' . $tbpref . 'texttags 
+                            FROM texttags 
                             WHERE TtTxID = ' . $text_ID, 
                             ""
                         );    
-                        $temp = runsql('DELETE FROM ' . $tbpref . 'texts WHERE TxID = ' . $text_ID, "");
+                        $temp = runsql('DELETE FROM texts WHERE TxID = ' . $text_ID, "");
                         if (is_numeric($temp)) {
                             $message1 += (int) $temp;
                         }
                         adjust_autoincr('texts', 'TxID');
                         adjust_autoincr('sentences', 'SeID');
                         runsql(
-                            "DELETE " . $tbpref . "texttags 
+                            "DELETE texttags 
                             FROM (" 
                                 . $tbpref . "texttags 
-                                LEFT JOIN " . $tbpref . "texts 
+                                LEFT JOIN texts 
                                 ON TtTxID = TxID
                             ) 
                             WHERE TxID IS NULL", 
@@ -363,10 +363,10 @@ elseif($currentregexmode=='r') { echo '<span style="vertical-align: middle"> Reg
 </td></tr><tr>
 <td class="td1 center" colspan="2" style="width:70%;"><?php
 if(!empty($currentlang)) {
-    $result = do_mysqli_query("SELECT NfName,NfID,NfUpdate FROM " . $tbpref . "newsfeeds WHERE NfLgID=$currentlang ORDER BY NfUpdate DESC");
+    $result = do_mysqli_query("SELECT NfName,NfID,NfUpdate FROM newsfeeds WHERE NfLgID=$currentlang ORDER BY NfUpdate DESC");
 }
 else{
-    $result = do_mysqli_query("SELECT NfName,NfID,NfUpdate FROM " . $tbpref . "newsfeeds ORDER BY NfUpdate DESC");
+    $result = do_mysqli_query("SELECT NfName,NfID,NfUpdate FROM newsfeeds ORDER BY NfUpdate DESC");
 }
 if(!mysqli_data_seek($result, 0)) {
     echo ' no feed available</td><td class="td1"></td></tr></table></form>';
@@ -402,7 +402,7 @@ if(mysqli_data_seek($result, 0)) {
         print_last_feed_update($diff);
     }
     echo '</td></tr>';
-    $sql = 'SELECT count(*) AS value FROM ' . $tbpref . 'feedlinks 
+    $sql = 'SELECT count(*) AS value FROM feedlinks 
     WHERE FlNfID in ('.$currentfeed.')'. $wh_query;
     $recno = (int)get_first_value($sql);
     if ($debug) { 
@@ -455,7 +455,7 @@ if(mysqli_data_seek($result, 0)) {
   <th class="th1 clickable" style="min-width:90px;">Date</th>
   </tr>    
         <?php
-        $result = do_mysqli_query("SELECT FlID, FlTitle, FlLink, FlDescription, FlDate, FlAudio,TxID, AtID FROM " . $tbpref . "feedlinks left join " . $tbpref . "texts on TxSourceURI=trim(FlLink) left join " . $tbpref . "archivedtexts on AtSourceURI=trim(FlLink) WHERE FlNfID in ($currentfeed) ".$wh_query." ORDER BY " . $sorts[$currentsort-1] . " ". $limit);
+        $result = do_mysqli_query("SELECT FlID, FlTitle, FlLink, FlDescription, FlDate, FlAudio,TxID, AtID FROM feedlinks left join texts on TxSourceURI=trim(FlLink) left join archivedtexts on AtSourceURI=trim(FlLink) WHERE FlNfID in ($currentfeed) ".$wh_query." ORDER BY " . $sorts[$currentsort-1] . " ". $limit);
         while($row = mysqli_fetch_assoc($result)){
             echo  '<tr>';
             if ($row['TxID']) {

--- a/do_feeds.php
+++ b/do_feeds.php
@@ -210,7 +210,7 @@ if (isset($_REQUEST['marked_items'])) {
                         runsql(
                             "DELETE texttags 
                             FROM (" 
-                                . $tbpref . "texttags 
+                                . texttags 
                                 LEFT JOIN texts 
                                 ON TtTxID = TxID
                             ) 

--- a/do_test.php
+++ b/do_test.php
@@ -29,11 +29,11 @@ require_once 'do_test_table.php';
  * 
  * @return string Language name
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function get_l2_language_name()
 {
-    global $tbpref;
+
 
     $lang = 'L2';
     if (getreq('lang') != '') {

--- a/do_test.php
+++ b/do_test.php
@@ -39,7 +39,7 @@ function get_l2_language_name()
     if (getreq('lang') != '') {
         $langid = (int) getreq('lang');
         $lang = (string) get_first_value(
-            'SELECT LgName AS value FROM ' . $tbpref . 'languages 
+            'SELECT LgName AS value FROM languages 
             WHERE LgID = ' . $langid . '
             LIMIT 1'
         ); 
@@ -47,8 +47,8 @@ function get_l2_language_name()
         $textid = (int) getreq('text');
         $lang = (string) get_first_value(
             'SELECT LgName AS value 
-            FROM ' . $tbpref . 'texts
-            JOIN ' . $tbpref . 'languages
+            FROM texts
+            JOIN languages
             ON TxLgID = LgID
             WHERE TxID = ' . $textid . '
             LIMIT 1'
@@ -61,7 +61,7 @@ function get_l2_language_name()
         if ($cntlang == 1) {
             $lang = (string) get_first_value(
                 'SELECT LgName AS value 
-                FROM ' . $tbpref . 'languages, ' . $testsql . ' AND LgID = WoLgID 
+                FROM languages, ' . $testsql . ' AND LgID = WoLgID 
                 LIMIT 1'
             ); 
         }

--- a/do_test_header.php
+++ b/do_test_header.php
@@ -44,7 +44,7 @@ function get_sql_test_data(&$title, &$p)
     }
     $title .= ' in ' . get_first_value(
         'SELECT LgName AS value 
-        FROM ' . $tbpref . 'languages, ' . $testsql . ' AND LgID = WoLgID 
+        FROM languages, ' . $testsql . ' AND LgID = WoLgID 
         LIMIT 1'
     ); 
     return $testsql;
@@ -66,9 +66,9 @@ function get_lang_test_data(&$title, &$p): string
     $langid = getreq('lang');
     $p = "lang=" . $langid; 
     $title = "All Terms in " . get_first_value(
-        'SELECT LgName AS value FROM ' . $tbpref . 'languages WHERE LgID = ' . $langid
+        'SELECT LgName AS value FROM languages WHERE LgID = ' . $langid
     );
-    $testsql = ' ' . $tbpref . 'words WHERE WoLgID = ' . $langid . ' ';
+    $testsql = ' words WHERE WoLgID = ' . $langid . ' ';
     return $testsql;
 }
 
@@ -88,11 +88,11 @@ function get_text_test_data(&$title, &$p): string
     $textid = getreq('text');
     $p = "text=" . $textid; 
     $title = get_first_value(
-        'SELECT TxTitle AS value FROM ' . $tbpref . 'texts WHERE TxID = ' . $textid
+        'SELECT TxTitle AS value FROM texts WHERE TxID = ' . $textid
     );
     saveSetting('currenttext', $_REQUEST['text']);
     $testsql = 
-    ' ' . $tbpref . 'words, ' . $tbpref . 'textitems2 
+    ' words, textitems2 
     WHERE Ti2LgID = WoLgID AND Ti2WoID = WoID AND Ti2TxID = ' . $textid . ' ';
     return $testsql;
 }

--- a/do_test_header.php
+++ b/do_test_header.php
@@ -26,11 +26,11 @@ require_once 'inc/session_utility.php';
  * 
  * @return string SQL query to use
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function get_sql_test_data(&$title, &$p)
 {
-    global $tbpref;
+
     $p = "selection=" . $_REQUEST['selection']; 
     $testsql = $_SESSION['testsql'];
     $totalcount = get_first_value('SELECT count(distinct WoID) AS value FROM ' . $testsql);
@@ -58,11 +58,11 @@ function get_sql_test_data(&$title, &$p)
  *
  * @return string SQL query to use
  *
- * @global string $tbpref Database table prefix
+ *
  */
 function get_lang_test_data(&$title, &$p): string 
 {
-    global $tbpref;
+
     $langid = getreq('lang');
     $p = "lang=" . $langid; 
     $title = "All Terms in " . get_first_value(
@@ -80,11 +80,11 @@ function get_lang_test_data(&$title, &$p): string
  *
  * @return string SQL query to use
  *
- * @global string $tbpref Database table prefix
+ *
  */
 function get_text_test_data(&$title, &$p): string
 {
-    global $tbpref;
+
     $textid = getreq('text');
     $p = "text=" . $textid; 
     $title = get_first_value(

--- a/do_test_table.php
+++ b/do_test_table.php
@@ -38,9 +38,9 @@ function get_test_table_sql()
             exit();
         }
     } else if (isset($_REQUEST['lang'])) {
-        $testsql = ' ' . $tbpref . 'words where WoLgID = ' . $_REQUEST['lang'] . ' ';
+        $testsql = ' words where WoLgID = ' . $_REQUEST['lang'] . ' ';
     } else if (isset($_REQUEST['text'])) {
-        $testsql = ' ' . $tbpref . 'words, ' . $tbpref . 'textitems2 
+        $testsql = ' words, textitems2 
         WHERE Ti2LgID = WoLgID AND Ti2WoID = WoID AND Ti2TxID = ' . $_REQUEST['text'] . ' ';
     } else { 
         my_die("do_test_table.php called with wrong parameters"); 
@@ -63,7 +63,7 @@ function do_test_table_language_settings($testsql)
     }
 
     $sql = 'SELECT LgTextSize, LgRegexpWordCharacters, LgRightToLeft 
-    FROM ' . $tbpref . 'languages WHERE LgID = ' . $lang;
+    FROM languages WHERE LgID = ' . $lang;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     mysqli_free_result($res);

--- a/do_test_table.php
+++ b/do_test_table.php
@@ -22,11 +22,11 @@ require_once 'inc/session_utility.php';
  * 
  * @return string SQL request string
  * 
- * @global string $tbpref Table prefix
+ *
  */
 function get_test_table_sql()
 {
-    global $tbpref;
+
     if (isset($_REQUEST['selection']) && isset($_SESSION['testsql'])) { 
         $testsql = $_SESSION['testsql'];
         $cntlang = get_first_value('SELECT count(distinct WoLgID) AS value FROM ' . $testsql);
@@ -51,7 +51,7 @@ function get_test_table_sql()
 
 function do_test_table_language_settings($testsql)
 {
-    global $tbpref;
+
 
     $lang = get_first_value('SELECT WoLgID AS value FROM ' . $testsql . ' LIMIT 1');
 

--- a/do_test_test.php
+++ b/do_test_test.php
@@ -44,9 +44,9 @@ function get_test_sql()
             exit();
         }
     } else if (isset($_REQUEST['lang'])) {
-        $testsql = " {$tbpref}words WHERE WoLgID = " . $_REQUEST['lang'] . " ";
+        $testsql = " words WHERE WoLgID = " . $_REQUEST['lang'] . " ";
     } else if (isset($_REQUEST['text'])) {
-        $testsql = " {$tbpref}words, {$tbpref}textitems2 
+        $testsql = " words, textitems2 
         WHERE Ti2LgID = WoLgID AND Ti2WoID = WoID AND Ti2TxID = " . 
         $_REQUEST['text'] . " ";
     } else {
@@ -156,24 +156,24 @@ function do_test_test_sentence($wid, $lang, $wordlc)
     $sent = null;
     // Select senetences where at least 70 % of words are known
     $sql = "SELECT DISTINCT SeID, UnknownRate
-    FROM {$tbpref}sentences
+    FROM sentences
     JOIN (
         SELECT total.Ti2SeID, UnknownWords / TotalWords AS UnknownRate
         FROM (
             SELECT Ti2SeID, COUNT(*) AS UnknownWords
-            FROM {$tbpref}textitems2
+            FROM textitems2
             WHERE Ti2WordCount = 1 AND Ti2WoID = 0
             GROUP BY Ti2SeID
         ) AS unknowns JOIN (
             SELECT Ti2SeID, COUNT(*) AS TotalWords
-            FROM {$tbpref}textitems2
+            FROM textitems2
             WHERE Ti2WordCount = 1
             GROUP BY Ti2SeID
         ) AS total
         ON unknowns.Ti2SeId = total.Ti2SeId
     ) AS ti_with_rate 
     ON SeID = ti_with_rate.Ti2SeID
-    JOIN {$tbpref}textitems2 AS ti_words
+    JOIN textitems2 AS ti_words
     ON SeID = ti_words.Ti2SeID
     WHERE Ti2WoID = $wid AND SeLgID = $lang AND UnknownRate < .3
     ORDER BY RAND() 
@@ -311,7 +311,7 @@ function prepare_test_area($testsql, $totaltests, $count, $testtype): int
     
     $sql = 'SELECT LgName, LgDict1URI, LgDict2URI, LgGoogleTranslateURI, LgTextSize, 
     LgRemoveSpaces, LgRegexpWordCharacters, LgRightToLeft 
-    FROM ' . $tbpref . 'languages WHERE LgID = ' . $lang;
+    FROM languages WHERE LgID = ' . $lang;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $wb1 = isset($record['LgDict1URI']) ? $record['LgDict1URI'] : "";
@@ -437,7 +437,7 @@ function do_test_test_javascript_interaction(
     $trans = repl_tab_nl($wo_record['WoTranslation']) . 
     getWordTagList($wid, ' ', 1, 0);
     $lang = get_first_value(
-        'SELECT LgName AS value FROM ' . $tbpref . 'languages
+        'SELECT LgName AS value FROM languages
         WHERE LgID = ' . $wo_record['WoLgID'] . '
         LIMIT 1'        
     );

--- a/do_test_test.php
+++ b/do_test_test.php
@@ -151,7 +151,7 @@ function do_test_test_finished($testsql, $totaltests)
  */
 function do_test_test_sentence($wid, $lang, $wordlc)
 {
-    global $debug, $tbpref;
+    global $debug;
     $num = 0;
     $sent = null;
     // Select senetences where at least 70 % of words are known
@@ -431,7 +431,7 @@ function prepare_test_area($testsql, $totaltests, $count, $testtype): int
 function do_test_test_javascript_interaction(
     $wo_record, $wb1, $wb2, $wb3, $testtype, $nosent, $save
 ) {
-    global $tbpref, $langDefs;
+    global $langDefs;
 
     $wid = $wo_record['WoID'];
     $trans = repl_tab_nl($wo_record['WoTranslation']) . 

--- a/do_test_test.php
+++ b/do_test_test.php
@@ -25,11 +25,11 @@ require_once 'inc/langdefs.php';
  * 
  * @return string SQL request string
  * 
- * @global string $tbpref Table prefix
+ *
  */
 function get_test_sql()
 {
-    global $tbpref;
+
     if (isset($_REQUEST['selection']) && isset($_SESSION['testsql'])) { 
         $testsql = $_SESSION['testsql'];
         $cntlang = get_first_value(
@@ -140,7 +140,7 @@ function do_test_test_finished($testsql, $totaltests)
  * @param string $lang   ID of the language
  * @param string $wordlc 
  * 
- * @global string $tbpref Table prefix
+ *
  * @global int    $debug  Echo the passage number if 1. 
  * 
  * @return array{0: string|null, 1: int} Sentence with escaped word and not a 0 
@@ -286,14 +286,14 @@ function print_term_test($wo_record, $sent, $testtype, $nosent, $regexword)
  *
  * @return int Number of tests left to do.
  *
- * @global string $tbpref Table prefix 
+ *
  * @global int    $debug  Show the SQL query used if 1.
  *
  * @psalm-return int<0, max>
  */
 function prepare_test_area($testsql, $totaltests, $count, $testtype): int
 {
-    global $tbpref, $debug;
+    global $debug;
     $nosent = 0;
     if ($testtype > 3) {
         $testtype -= 3;
@@ -425,7 +425,7 @@ function prepare_test_area($testsql, $totaltests, $count, $testtype): int
  * 
  * @return void
  * 
- * @global string $tbpref  Database table prefix
+ *
  * @global string $angDefs Languages definition array
  */
 function do_test_test_javascript_interaction(

--- a/do_text.php
+++ b/do_text.php
@@ -106,11 +106,11 @@ onclick="hideRightFrames();">
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function do_text_page($textid)
 {
-    global $tbpref;
+
 
     //framesetheader('Read');
     pagestart_nobody('Read');

--- a/do_text.php
+++ b/do_text.php
@@ -117,7 +117,7 @@ function do_text_page($textid)
     
     $audio = get_first_value(
         'SELECT TxAudioURI AS value 
-        FROM ' . $tbpref . 'texts 
+        FROM texts 
         WHERE TxID = ' . $textid
     );
     

--- a/do_text_header.php
+++ b/do_text_header.php
@@ -22,7 +22,7 @@ require_once 'inc/langdefs.php' ;
  *
  * @param string $textid ID of the text
  *
- * @global string $tbpref Table name prefix
+ *
  *
  * @since 2.0.3-fork
  *
@@ -32,7 +32,7 @@ require_once 'inc/langdefs.php' ;
  */
 function getData($textid): ?array
 {
-    global $tbpref;
+
     $sql = 
     'SELECT LgName, TxLgID, TxText, TxTitle, TxAudioURI, TxSourceURI, TxAudioPosition 
     FROM texts 

--- a/do_text_header.php
+++ b/do_text_header.php
@@ -35,8 +35,8 @@ function getData($textid): ?array
     global $tbpref;
     $sql = 
     'SELECT LgName, TxLgID, TxText, TxTitle, TxAudioURI, TxSourceURI, TxAudioPosition 
-    FROM ' . $tbpref . 'texts 
-    JOIN ' . $tbpref . 'languages ON TxLgID = LgID 
+    FROM texts 
+    JOIN languages ON TxLgID = LgID 
     WHERE TxID = ' . $textid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);

--- a/do_text_text.php
+++ b/do_text_text.php
@@ -23,11 +23,11 @@ require_once 'inc/session_utility.php';
  * @return array{TxLgID: int, TxTitle: string, TxAnnotatedText: string, 
  * TxPosition: int}|false|null Record corresponding to this text.
  * 
- * @global string $tbpref Table name prefix
+ *
  */
 function get_text_data($textid)
 {
-    global $tbpref;
+
     $sql = 
     'SELECT TxLgID, TxTitle, TxAnnotatedText, TxPosition 
     FROM texts
@@ -46,7 +46,7 @@ function get_text_data($textid)
  * @return array{TxLgID: int, TxTitle: string, TxAnnotatedText: string, 
  * TxPosition: int}|false|null Record corresponding to this text.
  * 
- * @global string $tbpref Table name prefix
+ *
  * 
  * @deprecated Use get_text_data instead.
  */
@@ -64,11 +64,11 @@ function getTextData($textid)
  * LgDict2URI: string, LgGoogleTranslateURI: string, LgTextSize: int, 
  * LgRemoveSpaces: int, LgRightToLeft: int}|false|null Record corresponding to this language.
  * 
- * @global string $tbpref Table name prefix
+ *
  */
 function get_language_settings($langid)
 {
-    global $tbpref;
+
     $sql = 
     'SELECT LgName, LgDict1URI, LgDict2URI, LgGoogleTranslateURI, 
     LgTextSize, LgRemoveSpaces, LgRightToLeft
@@ -89,7 +89,7 @@ function get_language_settings($langid)
  * LgDict2URI: string, LgGoogleTranslateURI: string, LgTextSize: int, 
  * LgRemoveSpaces: int, LgRightToLeft: int}|false|null Record corresponding to this language.
  * 
- * @global string $tbpref Table name prefix
+ *
  * 
  * @deprecated Use get_language_settings instead.
  */
@@ -403,11 +403,11 @@ function wordParser($record, $showAll, $currcharcount, $hideuntil): int
  * 
  * @return void
  * 
- * @global string $tbpref Table name prefix
+ *
  */
 function main_word_loop($textid, $showAll): void
 {
-    global $tbpref;
+
     
     $sql = 
     "SELECT
@@ -481,7 +481,7 @@ function main_word_loop($textid, $showAll): void
  * 
  * @return void
  * 
- * @global string $tbpref Table name prefix
+ *
  * 
  * @deprecated Use main_word_loop instead.
  */

--- a/do_text_text.php
+++ b/do_text_text.php
@@ -30,7 +30,7 @@ function get_text_data($textid)
     global $tbpref;
     $sql = 
     'SELECT TxLgID, TxTitle, TxAnnotatedText, TxPosition 
-    FROM ' . $tbpref . 'texts
+    FROM texts
     WHERE TxID = ' . $textid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
@@ -72,7 +72,7 @@ function get_language_settings($langid)
     $sql = 
     'SELECT LgName, LgDict1URI, LgDict2URI, LgGoogleTranslateURI, 
     LgTextSize, LgRemoveSpaces, LgRightToLeft
-    FROM ' . $tbpref . 'languages
+    FROM languages
     WHERE LgID = ' . $langid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
@@ -422,7 +422,7 @@ function main_word_loop($textid, $showAll): void
         ELSE CHAR_LENGTH(`WoTextLC`) 
      END AS TiTextLength, 
      WoID, WoText, WoStatus, WoTranslation, WoRomanization
-     FROM {$tbpref}textitems2 LEFT JOIN {$tbpref}words ON Ti2WoID = WoID
+     FROM textitems2 LEFT JOIN words ON Ti2WoID = WoID
      WHERE Ti2TxID = $textid
      ORDER BY Ti2Order asc, Ti2WordCount desc";
     

--- a/docs/html/delete__mword_8php.html
+++ b/docs/html/delete__mword_8php.html
@@ -94,7 +94,7 @@ Variables</h2></td></tr>
 &#160;</td><td class="memItemRight" valign="bottom"><b>$word</b> = <a class="el" href="database__connect_8php.html#a9c4a52b3d9b10360dce64ad0464bfad5">get_first_value</a>(&quot;select WoText as value from &quot; . $tbpref . &quot;words where WoID = &quot; . $wid)</td></tr>
 <tr class="separator:a5d7b6a696c068811c70679ceb91ecc93"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:adda8b9d523c64576b5fff6e48193844f"><td class="memItemLeft" align="right" valign="top"><a id="adda8b9d523c64576b5fff6e48193844f" name="adda8b9d523c64576b5fff6e48193844f"></a>
-&#160;</td><td class="memItemRight" valign="bottom"><b>$m1</b> = <a class="el" href="database__connect_8php.html#acba5ba1657b74c879fc17dd6f13c6bce">runsql</a>('delete from ' . $tbpref . 'words where WoID = ' . $wid, '')</td></tr>
+&#160;</td><td class="memItemRight" valign="bottom"><b>$m1</b> = <a class="el" href="database__connect_8php.html#acba5ba1657b74c879fc17dd6f13c6bce">runsql</a>('delete from words where WoID = ' . $wid, '')</td></tr>
 <tr class="separator:adda8b9d523c64576b5fff6e48193844f"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:add4e8a561e8883780b03be4048e17515"><td class="memItemLeft" align="right" valign="top">&#160;</td><td class="memItemRight" valign="bottom"><a class="el" href="delete__mword_8php.html#add4e8a561e8883780b03be4048e17515">if</a> (! $showAll)</td></tr>
 <tr class="separator:add4e8a561e8883780b03be4048e17515"><td class="memSeparator" colspan="2">&#160;</td></tr>

--- a/docs/html/edit__tword_8php.html
+++ b/docs/html/edit__tword_8php.html
@@ -105,7 +105,7 @@ Variables</h2></td></tr>
 &#160;</td><td class="memItemRight" valign="bottom"><b>$wid</b> = null</td></tr>
 <tr class="separator:a7a0680bb685ea7aa05526d97342ee209"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a5949648d603330b926af87a002edd6f7"><td class="memItemLeft" align="right" valign="top"><a id="a5949648d603330b926af87a002edd6f7" name="a5949648d603330b926af87a002edd6f7"></a>
-if($wid=='')&#160;</td><td class="memItemRight" valign="bottom"><b>$sql</b> = 'select WoText, WoLgID, WoTranslation, WoSentence, WoRomanization, WoStatus from ' . $tbpref . 'words where WoID = ' . $wid</td></tr>
+if($wid=='')&#160;</td><td class="memItemRight" valign="bottom"><b>$sql</b> = 'select WoText, WoLgID, WoTranslation, WoSentence, WoRomanization, WoStatus from words where WoID = ' . $wid</td></tr>
 <tr class="separator:a5949648d603330b926af87a002edd6f7"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a49a8a4009b02e49717caa88b128affc5"><td class="memItemLeft" align="right" valign="top"><a id="a49a8a4009b02e49717caa88b128affc5" name="a49a8a4009b02e49717caa88b128affc5"></a>
 &#160;</td><td class="memItemRight" valign="bottom"><b>$res</b> = <a class="el" href="database__connect_8php.html#af092366f1596cc99b3552185b173a53d">do_mysqli_query</a>($sql)</td></tr>

--- a/docs/html/index_8php.html
+++ b/docs/html/index_8php.html
@@ -107,7 +107,7 @@ Variables</h2></td></tr>
 if(is_numeric(<a class="el" href="database__connect_8php.html#a81cd47da0bcdaa2bf17382266982720b">getSetting</a>('currentlanguage')))&#160;</td><td class="memItemRight" valign="bottom"><b>$currenttext</b> = null</td></tr>
 <tr class="separator:ac69c712aff0917cf465006e7e55fb6b6"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a3bc4af4e5100b71de0425bff59766607"><td class="memItemLeft" align="right" valign="top"><a id="a3bc4af4e5100b71de0425bff59766607" name="a3bc4af4e5100b71de0425bff59766607"></a>
-if(is_numeric(<a class="el" href="database__connect_8php.html#a81cd47da0bcdaa2bf17382266982720b">getSetting</a>('currenttext')))&#160;</td><td class="memItemRight" valign="bottom"><b>$langcnt</b> = (int) <a class="el" href="database__connect_8php.html#a9c4a52b3d9b10360dce64ad0464bfad5">get_first_value</a>('SELECT COUNT(*) AS value FROM ' . $tbpref . 'languages')</td></tr>
+if(is_numeric(<a class="el" href="database__connect_8php.html#a81cd47da0bcdaa2bf17382266982720b">getSetting</a>('currenttext')))&#160;</td><td class="memItemRight" valign="bottom"><b>$langcnt</b> = (int) <a class="el" href="database__connect_8php.html#a9c4a52b3d9b10360dce64ad0464bfad5">get_first_value</a>('SELECT COUNT(*) AS value FROM languages')</td></tr>
 <tr class="separator:a3bc4af4e5100b71de0425bff59766607"><td class="memSeparator" colspan="2">&#160;</td></tr>
 </table>
 <a name="details" id="details"></a><h2 class="groupheader">Detailed Description</h2>

--- a/docs/html/mobile_8php.html
+++ b/docs/html/mobile_8php.html
@@ -82,7 +82,7 @@ Namespaces</h2></td></tr>
 <tr class="heading"><td colspan="2"><h2 class="groupheader"><a id="var-members" name="var-members"></a>
 Variables</h2></td></tr>
 <tr class="memitem:adce63ae6c998d5be2f111ce1017a16d1"><td class="memItemLeft" align="right" valign="top"><a id="adce63ae6c998d5be2f111ce1017a16d1" name="adce63ae6c998d5be2f111ce1017a16d1"></a>
-if(isset($_REQUEST[&quot;action&quot;])) else&#160;</td><td class="memItemRight" valign="bottom"><b>$sql</b> = 'select LgID, LgName from ' . $tbpref . 'languages where LgName&lt;&gt;&quot;&quot; order by LgName'</td></tr>
+if(isset($_REQUEST[&quot;action&quot;])) else&#160;</td><td class="memItemRight" valign="bottom"><b>$sql</b> = 'select LgID, LgName from languages where LgName&lt;&gt;&quot;&quot; order by LgName'</td></tr>
 <tr class="separator:adce63ae6c998d5be2f111ce1017a16d1"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a49a8a4009b02e49717caa88b128affc5"><td class="memItemLeft" align="right" valign="top"><a id="a49a8a4009b02e49717caa88b128affc5" name="a49a8a4009b02e49717caa88b128affc5"></a>
 &#160;</td><td class="memItemRight" valign="bottom"><b>$res</b> = <a class="el" href="database__connect_8php.html#af092366f1596cc99b3552185b173a53d">do_mysqli_query</a>($sql)</td></tr>

--- a/docs/html/print__impr__text_8php.html
+++ b/docs/html/print__impr__text_8php.html
@@ -97,7 +97,7 @@ Variables</h2></td></tr>
 &#160;</td><td class="memItemRight" valign="bottom"><b>$ann_exists</b> = (strlen($ann) &gt; 0)</td></tr>
 <tr class="separator:aa5f3d307d6a7dbddef0bb949354273a0"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a047170d6020a882807665812a27e2525"><td class="memItemLeft" align="right" valign="top"><a id="a047170d6020a882807665812a27e2525" name="a047170d6020a882807665812a27e2525"></a>
-if($ann_exists) if( $textid==0) if($delmode)&#160;</td><td class="memItemRight" valign="bottom"><b>$sql</b> = 'select TxLgID, TxTitle, TxAudioURI, TxSourceURI from ' . $tbpref . 'texts where TxID = ' . $textid</td></tr>
+if($ann_exists) if( $textid==0) if($delmode)&#160;</td><td class="memItemRight" valign="bottom"><b>$sql</b> = 'select TxLgID, TxTitle, TxAudioURI, TxSourceURI from texts where TxID = ' . $textid</td></tr>
 <tr class="separator:a047170d6020a882807665812a27e2525"><td class="memSeparator" colspan="2">&#160;</td></tr>
 <tr class="memitem:a49a8a4009b02e49717caa88b128affc5"><td class="memItemLeft" align="right" valign="top"><a id="a49a8a4009b02e49717caa88b128affc5" name="a49a8a4009b02e49717caa88b128affc5"></a>
 &#160;</td><td class="memItemRight" valign="bottom"><b>$res</b> = <a class="el" href="database__connect_8php.html#af092366f1596cc99b3552185b173a53d">do_mysqli_query</a>($sql)</td></tr>

--- a/edit_archivedtexts.php
+++ b/edit_archivedtexts.php
@@ -110,16 +110,16 @@ if (isset($_REQUEST['markaction'])) {
                 
                 if ($markaction == 'del') {
                     $message = runsql(
-                        'delete from ' . $tbpref . 'archivedtexts 
+                        'delete from archivedtexts 
                         where AtID in ' . $list, 
                         "Archived Texts deleted"
                     );
                     adjust_autoincr('archivedtexts', 'AtID');
                     runsql(
-                        "DELETE " . $tbpref . "archtexttags 
+                        "DELETE archtexttags 
                         FROM (
-                            " . $tbpref . "archtexttags 
-                            LEFT JOIN " . $tbpref . "archivedtexts 
+                            archtexttags 
+                            LEFT JOIN archivedtexts 
                             on AgAtID = AtID
                         ) 
                         WHERE AtID IS NULL", 
@@ -134,42 +134,42 @@ if (isset($_REQUEST['markaction'])) {
                 } elseif ($markaction == 'unarch') {
                     $count = 0;
                     $sql = "select AtID, AtLgID 
-                    from " . $tbpref . "archivedtexts 
+                    from archivedtexts 
                     where AtID in " . $list;
                     $res = do_mysqli_query($sql);
                     while ($record = mysqli_fetch_assoc($res)) {
                         $ida = $record['AtID'];
                         $mess = (int)runsql(
-                            'insert into ' . $tbpref . 'texts (
+                            'insert into texts (
                                 TxLgID, TxTitle, TxText, TxAnnotatedText, TxAudioURI, 
                                 TxSourceURI
                             ) 
                             select AtLgID, AtTitle, AtText, AtAnnotatedText, 
                             AtAudioURI, AtSourceURI 
-                            from ' . $tbpref . 'archivedtexts 
+                            from archivedtexts 
                             where AtID = ' . $ida, 
                             ""
                         );
                         $count += $mess;
                         $id = (int)get_last_key();
                         runsql(
-                            'insert into ' . $tbpref . 'texttags (TtTxID, TtT2ID) 
+                            'insert into texttags (TtTxID, TtT2ID) 
                             select ' . $id . ', AgT2ID 
-                            from ' . $tbpref . 'archtexttags 
+                            from archtexttags 
                             where AgAtID = ' . $ida, 
                             ""
                         );    
                         splitCheckText(
                             get_first_value(
                                 'select TxText as value 
-                                from ' . $tbpref . 'texts 
+                                from texts 
                                 where TxID = ' . $id
                             ), 
                             $record['AtLgID'], 
                             $id
                         );    
                         runsql(
-                            'delete from ' . $tbpref . 'archivedtexts 
+                            'delete from archivedtexts 
                             where AtID = ' . $ida, 
                             ""
                         );
@@ -177,10 +177,10 @@ if (isset($_REQUEST['markaction'])) {
                     mysqli_free_result($res);
                     adjust_autoincr('archivedtexts', 'AtID');
                     runsql(
-                        "DELETE " . $tbpref . "archtexttags 
+                        "DELETE archtexttags 
                         FROM (
-                            " . $tbpref . "archtexttags 
-                            LEFT JOIN " . $tbpref . "archivedtexts 
+                            archtexttags 
+                            LEFT JOIN archivedtexts 
                             on AgAtID = AtID
                         ) 
                         WHERE AtID IS NULL", 
@@ -198,15 +198,15 @@ if (isset($_REQUEST['markaction'])) {
 
 if (isset($_REQUEST['del'])) {
     $message = runsql(
-        'delete from ' . $tbpref . 'archivedtexts where AtID = ' . $_REQUEST['del'], 
+        'delete from archivedtexts where AtID = ' . $_REQUEST['del'], 
         "Archived Texts deleted"
     );
     adjust_autoincr('archivedtexts', 'AtID');
     runsql(
-        "DELETE " . $tbpref . "archtexttags 
+        "DELETE archtexttags 
         FROM (
-            " . $tbpref . "archtexttags 
-            LEFT JOIN " . $tbpref . "archivedtexts on AgAtID = AtID
+            archtexttags 
+            LEFT JOIN archivedtexts on AgAtID = AtID
         ) 
         WHERE AtID IS NULL", 
         ''
@@ -217,49 +217,49 @@ if (isset($_REQUEST['del'])) {
 
 elseif (isset($_REQUEST['unarch'])) {
     $message2 = runsql(
-        'insert into ' . $tbpref . 'texts (
+        'insert into texts (
             TxLgID, TxTitle, TxText, TxAnnotatedText, TxAudioURI, TxSourceURI
         ) select AtLgID, AtTitle, AtText, AtAnnotatedText, AtAudioURI, AtSourceURI 
-        from ' . $tbpref . 'archivedtexts 
+        from archivedtexts 
         where AtID = ' . $_REQUEST['unarch'], 
         "Texts added"
     );
     $id = (int)get_last_key();
     runsql(
-        'insert into ' . $tbpref . 'texttags (TtTxID, TtT2ID) 
+        'insert into texttags (TtTxID, TtT2ID) 
         select ' . $id . ', AgT2ID 
-        from ' . $tbpref . 'archtexttags 
+        from archtexttags 
         where AgAtID = ' . $_REQUEST['unarch'], 
         ""
     );    
     splitCheckText(
         get_first_value(
-            'select TxText as value from ' . $tbpref . 'texts where TxID = ' . $id
+            'select TxText as value from texts where TxID = ' . $id
         ), 
         get_first_value(
-            'select TxLgID as value from ' . $tbpref . 'texts where TxID = ' . $id
+            'select TxLgID as value from texts where TxID = ' . $id
         ), 
         $id 
     );    
     $message1 = runsql(
-        'delete from ' . $tbpref . 'archivedtexts 
+        'delete from archivedtexts 
         where AtID = ' . $_REQUEST['unarch'], 
         "Archived Texts deleted"
     );
     $message = $message1 . " / " . $message2 . " / Sentences added: " . 
     get_first_value(
         'select count(*) as value 
-        from ' . $tbpref . 'sentences 
+        from sentences 
         where SeTxID = ' . $id
     ) . " / Text items added: " . get_first_value(
-        'select count(*) as value from ' . $tbpref . 'textitems2 
+        'select count(*) as value from textitems2 
         where Ti2TxID = ' . $id
     );
     adjust_autoincr('archivedtexts', 'AtID');
     runsql(
-        "DELETE " . $tbpref . "archtexttags 
-        FROM (" . $tbpref . "archtexttags 
-        LEFT JOIN " . $tbpref . "archivedtexts on AgAtID = AtID) 
+        "DELETE archtexttags 
+        FROM (archtexttags 
+        LEFT JOIN archivedtexts on AgAtID = AtID) 
         WHERE AtID IS NULL", ''
     );
 }
@@ -273,13 +273,13 @@ elseif (isset($_REQUEST['op'])) {
     if ($_REQUEST['op'] == 'Change') {
         $oldtext = get_first_value(
             'select AtText as value 
-            from ' . $tbpref . 'archivedtexts 
+            from archivedtexts 
             where AtID = ' . $_REQUEST["AtID"]
         );
         $textsdiffer = (convert_string_to_sqlsyntax($_REQUEST["AtText"]) != 
         convert_string_to_sqlsyntax($oldtext));
         $message = runsql(
-            'UPDATE ' . $tbpref . 'archivedtexts SET ' .
+            'UPDATE archivedtexts SET ' .
             'AtLgID = ' . $_REQUEST["AtLgID"] . ', ' .
             'AtTitle = ' . convert_string_to_sqlsyntax($_REQUEST["AtTitle"]) . ', ' .
             'AtText = ' . convert_string_to_sqlsyntax($_REQUEST["AtText"]) . ', ' .
@@ -290,7 +290,7 @@ elseif (isset($_REQUEST['op'])) {
         );
         if ($message == 'Updated: 1' && $textsdiffer) {
             runsql(
-                "update " . $tbpref . "archivedtexts set 
+                "update archivedtexts set 
                 AtAnnotatedText = '' 
                 where AtID = " . $_REQUEST["AtID"], 
                 ""
@@ -308,7 +308,7 @@ if (isset($_REQUEST['chg'])) {
     
     $sql = 'select AtLgID, AtTitle, AtText, AtAudioURI, AtSourceURI, 
     length(AtAnnotatedText) as annotlen 
-    from ' . $tbpref . 'archivedtexts 
+    from archivedtexts 
     where AtID = ' . $_REQUEST['chg'];
     $res = do_mysqli_query($sql);
     if ($record = mysqli_fetch_assoc($res)) {
@@ -387,8 +387,8 @@ else {
 
     $sql = 'select count(*) as value from (select AtID 
     from (
-        ' . $tbpref . 'archivedtexts 
-        left JOIN ' . $tbpref . 'archtexttags 
+        archivedtexts 
+        left JOIN archtexttags 
         ON AtID = AgAtID
     ) where (1=1) ' . $wh_lang . $wh_query . ' 
     group by AtID ' . $wh_tag . ') as dummy';
@@ -554,12 +554,12 @@ Marked Texts:&nbsp;
         ) AS taglist
         from (
             (
-                {$tbpref}archivedtexts 
-                left JOIN {$tbpref}archtexttags 
+                archivedtexts 
+                left JOIN archtexttags 
                 ON AtID = AgAtID
-            ) left join {$tbpref}tags2 
+            ) left join tags2 
             on T2ID = AgT2ID
-        ), {$tbpref}languages 
+        ), languages 
         where LgID=AtLgID $wh_lang$wh_query 
         group by AtID $wh_tag 
         order by {$sorts[$currentsort-1]} 

--- a/edit_feeds.php
+++ b/edit_feeds.php
@@ -20,19 +20,19 @@ if(isset($_SESSION['wizard'])) {
 
 if (isset($_REQUEST['markaction'])) {
     if ($_REQUEST['markaction']=='del') {
-        $message= runsql('delete from ' . $tbpref . 'feedlinks where FlNfID in(' . $currentfeed . ')', "Article item(s) deleted");
-        $message.= runsql('delete from ' . $tbpref . 'newsfeeds where NfID in(' . $currentfeed . ')', " / Newsfeed(s) deleted");
+        $message= runsql('delete from feedlinks where FlNfID in(' . $currentfeed . ')', "Article item(s) deleted");
+        $message.= runsql('delete from newsfeeds where NfID in(' . $currentfeed . ')', " / Newsfeed(s) deleted");
         echo error_message_with_hide($message, 0);unset($message);
     }
 
     if ($_REQUEST['markaction']=='del_art') {
-        $message= runsql('delete from ' . $tbpref . 'feedlinks where FlNfID in(' . $currentfeed . ')', "Article item(s) deleted");
+        $message= runsql('delete from feedlinks where FlNfID in(' . $currentfeed . ')', "Article item(s) deleted");
         echo error_message_with_hide($message, 0);unset($message);
-        do_mysqli_query('UPDATE ' . $tbpref . 'newsfeeds SET NfUpdate="'.time().'" where NfID in(' . $currentfeed . ')');
+        do_mysqli_query('UPDATE newsfeeds SET NfUpdate="'.time().'" where NfID in(' . $currentfeed . ')');
     }
 
     if ($_REQUEST['markaction']=='res_art') {
-        $message= runsql('UPDATE ' . $tbpref . 'feedlinks SET FlLink=TRIM(FlLink) where FlNfID in (' . $currentfeed . ')', "Article(s) reset");
+        $message= runsql('UPDATE feedlinks SET FlLink=TRIM(FlLink) where FlNfID in (' . $currentfeed . ')', "Article(s) reset");
         echo error_message_with_hide($message, 0);unset($message);
     }
 }
@@ -50,17 +50,17 @@ $(".hide_message").delay(2500).slideUp(1000);
 
 if(isset($_REQUEST['update_feed'])) {
     $currentfeed = $_REQUEST['NfID'];
-    runsql('UPDATE ' . $tbpref . 'newsfeeds SET NfLgID=' . convert_string_to_sqlsyntax($_REQUEST['NfLgID']) .',NfName=' . convert_string_to_sqlsyntax($_REQUEST['NfName']) .',NfSourceURI=' . convert_string_to_sqlsyntax($_REQUEST['NfSourceURI']) .',NfArticleSectionTags=' . convert_string_to_sqlsyntax($_REQUEST['NfArticleSectionTags']) .',NfFilterTags=' . convert_string_to_sqlsyntax_nonull($_REQUEST['NfFilterTags']) .',NfOptions=' . convert_string_to_sqlsyntax_nonull(rtrim($_REQUEST['NfOptions'], ',')) .' where NfID='.$_REQUEST['NfID'], "");
+    runsql('UPDATE newsfeeds SET NfLgID=' . convert_string_to_sqlsyntax($_REQUEST['NfLgID']) .',NfName=' . convert_string_to_sqlsyntax($_REQUEST['NfName']) .',NfSourceURI=' . convert_string_to_sqlsyntax($_REQUEST['NfSourceURI']) .',NfArticleSectionTags=' . convert_string_to_sqlsyntax($_REQUEST['NfArticleSectionTags']) .',NfFilterTags=' . convert_string_to_sqlsyntax_nonull($_REQUEST['NfFilterTags']) .',NfOptions=' . convert_string_to_sqlsyntax_nonull(rtrim($_REQUEST['NfOptions'], ',')) .' where NfID='.$_REQUEST['NfID'], "");
 }
 
 if(isset($_REQUEST['save_feed'])) {
-    runsql('insert into ' . $tbpref . 'newsfeeds (NfLgID,NfName,NfSourceURI,NfArticleSectionTags,NfFilterTags,NfOptions) VALUES (' . convert_string_to_sqlsyntax($_REQUEST['NfLgID']) .',' . convert_string_to_sqlsyntax($_REQUEST['NfName']) .',' . convert_string_to_sqlsyntax($_REQUEST['NfSourceURI']) .',' . convert_string_to_sqlsyntax($_REQUEST['NfArticleSectionTags']) .',' . convert_string_to_sqlsyntax_nonull($_REQUEST['NfFilterTags']) .',' . convert_string_to_sqlsyntax_nonull(rtrim($_REQUEST['NfOptions'], ',')) .')', "");
+    runsql('insert into newsfeeds (NfLgID,NfName,NfSourceURI,NfArticleSectionTags,NfFilterTags,NfOptions) VALUES (' . convert_string_to_sqlsyntax($_REQUEST['NfLgID']) .',' . convert_string_to_sqlsyntax($_REQUEST['NfName']) .',' . convert_string_to_sqlsyntax($_REQUEST['NfSourceURI']) .',' . convert_string_to_sqlsyntax($_REQUEST['NfArticleSectionTags']) .',' . convert_string_to_sqlsyntax_nonull($_REQUEST['NfFilterTags']) .',' . convert_string_to_sqlsyntax_nonull(rtrim($_REQUEST['NfOptions'], ',')) .')', "");
 }
 if(isset($_REQUEST['load_feed']) || isset($_REQUEST['check_autoupdate']) || (isset($_REQUEST['markaction']) && $_REQUEST['markaction']=='update')) {
     load_feeds($currentfeed);
 }    
 elseif(isset($_REQUEST['new_feed'])) {
-    $result = do_mysqli_query("SELECT LgName,LgID FROM " . $tbpref . "languages where LgName<>'' ORDER BY LgName");
+    $result = do_mysqli_query("SELECT LgName,LgID FROM languages where LgName<>'' ORDER BY LgName");
     ?>
 <h4>New Feed <a target="_blank" href="docs/info.html#new_feed"><img src="icn/question-frame.png" title="Help" alt="Help" /></a> </h4>
 <a href="do_feeds.php?page=1"> My Feeds</a> &nbsp; | &nbsp;
@@ -125,9 +125,9 @@ $('[type="submit"]').on('click', function(){
 }
 
 elseif(isset($_REQUEST['edit_feed'])) {
-    $result = do_mysqli_query("SELECT * FROM " . $tbpref . "newsfeeds WHERE NfID=$currentfeed");
+    $result = do_mysqli_query("SELECT * FROM newsfeeds WHERE NfID=$currentfeed");
     $row = mysqli_fetch_assoc($result);
-    $result = do_mysqli_query("SELECT LgName,LgID FROM " . $tbpref . "languages where LgName<>'' ORDER BY LgName");
+    $result = do_mysqli_query("SELECT LgName,LgID FROM languages where LgName<>'' ORDER BY LgName");
     ?>
 <h4>Edit Feed <a target="_blank" href="docs/info.html#new_feed"><img src="icn/question-frame.png" title="Help" alt="Help" /></a> </h4>
 <a href="do_feeds.php?page=1"> My Feeds</a> &nbsp; | &nbsp;
@@ -254,10 +254,10 @@ $('[type="submit"]').on('click', function(){
 
 elseif(isset($_REQUEST['multi_load_feed'])) {
     if(!empty($currentlang)) {
-        $result = do_mysqli_query("SELECT NfName,NfID,NfUpdate FROM " . $tbpref . "newsfeeds WHERE NfLgID=$currentlang ORDER BY NfUpdate DESC");
+        $result = do_mysqli_query("SELECT NfName,NfID,NfUpdate FROM newsfeeds WHERE NfLgID=$currentlang ORDER BY NfUpdate DESC");
     }
     else{
-        $result = do_mysqli_query("SELECT NfName,NfID,NfUpdate FROM " . $tbpref . "newsfeeds ORDER BY NfUpdate DESC");
+        $result = do_mysqli_query("SELECT NfName,NfID,NfUpdate FROM newsfeeds ORDER BY NfUpdate DESC");
     }
     ?>
 <form name="form1" action="do_feeds.php" onsubmit="document.form1.querybutton.click(); return false;">
@@ -348,7 +348,7 @@ Feed Name (Wildc.=*):
 <option value="del">Delete</option>
 </select></td></tr>
     <?php
-        $sql = 'select count(*) as value from ' . $tbpref . 'newsfeeds where '; if($currentlang>0) { $sql .= 'NfLgID ='.$currentlang . $wh_query; 
+        $sql = 'select count(*) as value from newsfeeds where '; if($currentlang>0) { $sql .= 'NfLgID ='.$currentlang . $wh_query; 
         }else { $sql .= '1=1' . $wh_query; 
         }
         $recno = (int) get_first_value($sql);
@@ -373,10 +373,10 @@ Feed Name (Wildc.=*):
             echo '</th><th class="th1">';
             makePager($currentpage, $pages, 'edit_feeds.php', 'form1');
             if(!empty($currentlang)) {
-                $result = do_mysqli_query("SELECT * FROM " . $tbpref . "newsfeeds WHERE NfLgID=$currentlang $wh_query ORDER BY " . $sorts[$currentsort-1]);
+                $result = do_mysqli_query("SELECT * FROM newsfeeds WHERE NfLgID=$currentlang $wh_query ORDER BY " . $sorts[$currentsort-1]);
             }
             else{
-                $result = do_mysqli_query("SELECT * FROM " . $tbpref . "newsfeeds WHERE (1=1) $wh_query ORDER BY " . $sorts[$currentsort-1]);
+                $result = do_mysqli_query("SELECT * FROM newsfeeds WHERE (1=1) $wh_query ORDER BY " . $sorts[$currentsort-1]);
             }
             ?>
         </th>

--- a/edit_languages.php
+++ b/edit_languages.php
@@ -71,15 +71,15 @@ function edit_languages_refresh($lid)
 {
     global $tbpref;
     $message2 = runsql(
-        'delete from ' . $tbpref . 'sentences where SeLgID = ' . $lid, 
+        'delete from sentences where SeLgID = ' . $lid, 
         "Sentences deleted"
     );
     $message3 = runsql(
-        'delete from ' . $tbpref . 'textitems2 where Ti2LgID = ' . $lid, 
+        'delete from textitems2 where Ti2LgID = ' . $lid, 
         "Text items deleted"
     );
     adjust_autoincr('sentences', 'SeID');
-    $sql = "select TxID, TxText from " . $tbpref . "texts 
+    $sql = "select TxID, TxText from texts 
     where TxLgID = " . $lid . " 
     order by TxID";
     $res = do_mysqli_query($sql);
@@ -93,12 +93,12 @@ function edit_languages_refresh($lid)
     " / " . $message3 . 
     " / Sentences added: " . get_first_value(
         'select count(*) as value 
-        from ' . $tbpref . 'sentences 
+        from sentences 
         where SeLgID = ' . $lid
     ) . 
     " / Text items added: " . get_first_value(
         'select count(*) as value 
-        from ' . $tbpref . 'textitems2 
+        from textitems2 
         where Ti2LgID = ' . $lid
     );
     return $message;
@@ -120,29 +120,29 @@ function edit_languages_delete($lid)
     global $tbpref;
     $anztexts = get_first_value(
         'select count(TxID) as value 
-        from ' . $tbpref . 'texts 
+        from texts 
         where TxLgID = ' . $lid
     );
     $anzarchtexts = get_first_value(
         'select count(AtID) as value 
-        from ' . $tbpref . 'archivedtexts 
+        from archivedtexts 
         where AtLgID = ' . $lid
     );
     $anzwords = get_first_value(
         'select count(WoID) as value 
-        from ' . $tbpref . 'words 
+        from words 
         where WoLgID = ' . $lid
     );
     $anzfeeds = get_first_value(
         'select count(NfID) as value 
-        from ' . $tbpref . 'newsfeeds 
+        from newsfeeds 
         where NfLgID = ' . $lid
     );
     if ($anztexts > 0 || $anzarchtexts > 0 || $anzwords > 0 || $anzfeeds > 0) {
         $message = 'You must first delete texts, archived texts, newsfeeds and words with this language!';
     } else {
         $message = runsql(
-            'UPDATE ' . $tbpref . 'languages 
+            'UPDATE languages 
             SET LgName = "", LgDict1URI = "", LgDict2URI = "", 
             LgGoogleTranslateURI = "", LgExportTemplate = "", LgTextSize = DEFAULT, 
             LgCharacterSubstitutions = "", LgRegexpSplitSentences = "", 
@@ -168,12 +168,12 @@ function edit_languages_op_save()
     global $tbpref;
     $val = get_first_value(
         'select min(LgID) as value 
-        from ' . $tbpref . 'languages 
+        from languages 
         where LgName=""'
     );
     if (! isset($val)) {
         $message = runsql(
-            'insert into ' . $tbpref . 'languages (
+            'insert into languages (
                 LgName, LgDict1URI, LgDict2URI, LgGoogleTranslateURI, 
                 LgExportTemplate, LgTextSize, LgCharacterSubstitutions, 
                 LgRegexpSplitSentences, LgExceptionsSplitSentences, 
@@ -199,7 +199,7 @@ function edit_languages_op_save()
     }
     else {
         $message = runsql(
-            'update ' . $tbpref . 'languages set ' . 
+            'update languages set ' . 
             'LgName = ' . convert_string_to_sqlsyntax($_REQUEST["LgName"]) . ', ' . 
             'LgDict1URI = ' . convert_string_to_sqlsyntax($_REQUEST["LgDict1URI"]) . ', ' .
             'LgDict2URI = ' . convert_string_to_sqlsyntax($_REQUEST["LgDict2URI"]) . ', ' .
@@ -233,7 +233,7 @@ function edit_languages_op_change($lid)
 {
     global $tbpref;
     // Get old values
-    $sql = "select * from " . $tbpref . "languages where LgID=" . $lid;
+    $sql = "select * from languages where LgID=" . $lid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     if ($record == false) { 
@@ -264,7 +264,7 @@ function edit_languages_op_change($lid)
     
 
     $message = runsql(
-        'update ' . $tbpref . 'languages set ' . 
+        'update languages set ' . 
         'LgName = ' . convert_string_to_sqlsyntax($_REQUEST["LgName"]) . ', ' . 
         'LgDict1URI = ' . convert_string_to_sqlsyntax($_REQUEST["LgDict1URI"]) . ', ' .
         'LgDict2URI = ' . convert_string_to_sqlsyntax($_REQUEST["LgDict2URI"]) . ', ' .
@@ -284,23 +284,23 @@ function edit_languages_op_change($lid)
     
     if ($needReParse) {
         runsql(
-            'delete from ' . $tbpref . 'sentences where SeLgID = ' . $lid, 
+            'delete from sentences where SeLgID = ' . $lid, 
             "Sentences deleted"
         );
         runsql(
-            'delete from ' . $tbpref . 'textitems2 where Ti2LgID = ' . $lid, 
+            'delete from textitems2 where Ti2LgID = ' . $lid, 
             "Text items deleted"
         );
         adjust_autoincr('sentences', 'SeID');
         runsql(
-            "UPDATE  " . $tbpref . "words 
+            "UPDATE  words 
             SET WoWordCount  = 0 
             where WoLgID = " . $lid, 
             ''
         );
         init_word_count();
         $sql = "select TxID, TxText 
-        from " . $tbpref . "texts 
+        from texts 
         where TxLgID = " . $lid . " 
         order by TxID";
         $res = do_mysqli_query($sql);
@@ -452,7 +452,7 @@ function edit_languages_new()
 function edit_languages_change($lid)
 {
     global $tbpref;
-    $sql = 'select * from ' . $tbpref . 'languages where LgID = ' . $lid;
+    $sql = 'select * from languages where LgID = ' . $lid;
     $res = do_mysqli_query($sql);
     if ($record = mysqli_fetch_assoc($res)) {
     
@@ -584,7 +584,7 @@ function edit_languages_display($message)
     
     $recno = get_first_value(
         'SELECT COUNT(*) AS value 
-        FROM ' . $tbpref . 'languages 
+        FROM languages 
         WHERE LgName<>""'
     ); 
     
@@ -621,7 +621,7 @@ function edit_languages_display($message)
     <?php
 
     $sql = 'SELECT LgID, LgName, LgExportTemplate 
-    FROM ' . $tbpref . 'languages 
+    FROM languages 
     WHERE LgName<>"" ORDER BY LgName';
     if ($debug) { 
         echo $sql; 
@@ -629,7 +629,7 @@ function edit_languages_display($message)
     // May be refactored with KISS principle
     $res = do_mysqli_query(
         'select NfLgID, count(*) as value 
-        from ' . $tbpref . 'newsfeeds 
+        from newsfeeds 
         group by NfLgID'
     );
     $newsfeedcount = null;
@@ -639,7 +639,7 @@ function edit_languages_display($message)
     // May be refactored with KISS principle
     $res = do_mysqli_query(
         'SELECT NfLgID, count(*) AS value 
-        FROM ' . $tbpref . 'newsfeeds, ' . $tbpref . 'feedlinks 
+        FROM newsfeeds, feedlinks 
         WHERE NfID=FlNfID 
         GROUP BY NfLgID'
     );
@@ -652,19 +652,19 @@ function edit_languages_display($message)
         $lid = (int)$record['LgID'];
         $foo = get_first_value(
             'select count(TxID) as value 
-            from ' . $tbpref . 'texts 
+            from texts 
             where TxLgID=' . $lid
         );
         $textcount = is_numeric($foo) ? (int)$foo : 0;
         $foo = get_first_value(
             'select count(AtID) as value 
-            from ' . $tbpref . 'archivedtexts 
+            from archivedtexts 
             where AtLgID=' . $lid
         );
         $archtextcount = is_numeric($foo) ? (int)$foo : 0;
         $foo = get_first_value(
             'select count(WoID) as value 
-            from ' . $tbpref . 'words 
+            from words 
             where WoLgID=' . $lid
         );
         $wordcount = is_numeric($foo) ? (int)$foo : 0;

--- a/edit_languages.php
+++ b/edit_languages.php
@@ -65,7 +65,7 @@ function edit_languages_alert_duplicate()
  * 
  * @return {string} Number of sentences and textitems refreshed
  * 
- * @global {string} $tbpref Database table prefix
+ *
  */
 function edit_languages_refresh($lid)
 {
@@ -113,7 +113,7 @@ function edit_languages_refresh($lid)
  * 
  * @return {string} Info on the number of languages deleted
  * 
- * @global {string} $tbpref Database table prefix
+ *
  */
 function edit_languages_delete($lid)
 {
@@ -161,7 +161,7 @@ function edit_languages_delete($lid)
  * 
  * @return {string} Success or error message
  * 
- * @global {string} $tbpref Database table prefix
+ *
  */
 function edit_languages_op_save()
 {
@@ -227,7 +227,7 @@ function edit_languages_op_save()
  * 
  * @return {string} Number of texts updated and items reparsed.
  * 
- * @global {string} $tbpref Database table prefix
+ *
  */
 function edit_languages_op_change($lid) 
 {
@@ -569,7 +569,7 @@ function edit_languages_change($lid)
  * 
  * @param {string} $message An information message to display.
  * 
- * @global {string} $tbpref Database table prefix
+ *
  * @global {int}    $debug 1 to display debugging data
  * 
  * @return void

--- a/edit_languages.php
+++ b/edit_languages.php
@@ -69,7 +69,7 @@ function edit_languages_alert_duplicate()
  */
 function edit_languages_refresh($lid)
 {
-    global $tbpref;
+
     $message2 = runsql(
         'delete from sentences where SeLgID = ' . $lid, 
         "Sentences deleted"
@@ -117,7 +117,7 @@ function edit_languages_refresh($lid)
  */
 function edit_languages_delete($lid)
 {
-    global $tbpref;
+
     $anztexts = get_first_value(
         'select count(TxID) as value 
         from texts 
@@ -165,7 +165,7 @@ function edit_languages_delete($lid)
  */
 function edit_languages_op_save()
 {
-    global $tbpref;
+
     $val = get_first_value(
         'select min(LgID) as value 
         from languages 
@@ -231,7 +231,7 @@ function edit_languages_op_save()
  */
 function edit_languages_op_change($lid) 
 {
-    global $tbpref;
+
     // Get old values
     $sql = "select * from languages where LgID=" . $lid;
     $res = do_mysqli_query($sql);
@@ -451,7 +451,7 @@ function edit_languages_new()
  */
 function edit_languages_change($lid)
 {
-    global $tbpref;
+
     $sql = 'select * from languages where LgID = ' . $lid;
     $res = do_mysqli_query($sql);
     if ($record = mysqli_fetch_assoc($res)) {
@@ -576,7 +576,7 @@ function edit_languages_change($lid)
  */
 function edit_languages_display($message)
 {
-    global $tbpref, $debug;
+    global $debug;
 
     echo error_message_with_hide($message, 0);
     

--- a/edit_mword.php
+++ b/edit_mword.php
@@ -183,7 +183,7 @@ function edit_mword_do_insert($term)
     echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
 
     $message = runsql(
-        "INSERT INTO {$tbpref}words (
+        "INSERT INTO words (
             WoLgID, WoTextLC, WoText, WoStatus, WoTranslation, WoSentence, 
             WoRomanization, WoWordCount, WoStatusChanged," 
             .  make_score_random_insert_update('iv') . '
@@ -234,7 +234,7 @@ function edit_mword_do_update($term, $newstatus)
     }
 
     $message = runsql(
-        'UPDATE ' . $tbpref . 'words set 
+        'UPDATE words set 
         WoText = ' . convert_string_to_sqlsyntax($term->text) . ', 
         WoTranslation = ' . convert_string_to_sqlsyntax($term->translation) . ', 
         WoSentence = ' . convert_string_to_sqlsyntax(
@@ -296,19 +296,19 @@ function edit_mword_new($text, $tid, $ord, $len)
 
     $term = new Term();
     $term->lgid = get_first_value(
-        "SELECT TxLgID AS value FROM {$tbpref}texts WHERE TxID = $tid"
+        "SELECT TxLgID AS value FROM texts WHERE TxID = $tid"
     );
     $term->text = prepare_textdata($text);
     $term->textlc = mb_strtolower($term->text, 'UTF-8');
 
     $term->id = get_first_value(
-        "SELECT WoID AS value FROM {$tbpref}words 
+        "SELECT WoID AS value FROM words 
         WHERE WoLgID = $term->lgid AND WoTextLC = " . 
         convert_string_to_sqlsyntax($term->textlc)
     );
     if (isset($term->id)) { 
         $term->text = get_first_value(
-            "SELECT WoText AS value FROM {$tbpref}words WHERE WoID = $term->id"
+            "SELECT WoText AS value FROM words WHERE WoID = $term->id"
         ); 
     }
     edit_mword_display_new($term, $tid, $ord, $len);
@@ -333,7 +333,7 @@ function edit_mword_update($wid, $tid, $ord)
     $term = new Term();
 
     $term->id = (int) $wid;
-    $sql = "SELECT WoText, WoLgID FROM {$tbpref}words WHERE WoID = $term->id";
+    $sql = "SELECT WoText, WoLgID FROM words WHERE WoID = $term->id";
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     if (!$record) {
@@ -364,7 +364,7 @@ function edit_mword_display_new($term, $tid, $ord, $len)
     $scrdir = getScriptDirectionTag($term->lgid);
     $seid = get_first_value(
         "SELECT Ti2SeID AS value 
-        FROM {$tbpref}textitems2 
+        FROM textitems2 
         WHERE Ti2TxID = $tid AND Ti2Order = $ord"
     );
     $sent = getSentence(
@@ -460,7 +460,7 @@ function edit_mword_display_change($term, $tid, $ord)
     global $tbpref;
     $scrdir = getScriptDirectionTag($term->lgid);
     $sql = 'SELECT WoTranslation, WoSentence, WoRomanization, WoStatus 
-    FROM ' . $tbpref . 'words WHERE WoID = ' . $term->id;
+    FROM words WHERE WoID = ' . $term->id;
     $res = do_mysqli_query($sql);
     if ($record = mysqli_fetch_assoc($res)) {
         $status = $record['WoStatus'];
@@ -471,7 +471,7 @@ function edit_mword_display_change($term, $tid, $ord)
         if ($sentence == '') {
             $seid = get_first_value(
                 "SELECT Ti2SeID AS value 
-                FROM " . $tbpref . "textitems2 
+                FROM textitems2 
                 WHERE Ti2TxID = $tid AND Ti2Order = $ord"
             );
             $sent = getSentence(
@@ -583,7 +583,7 @@ function edit_mword_page()
         // No ID provided: check if text exists in database.
         if ($str_id == "" || !is_numeric($str_id)) {
             $lgid = get_first_value(
-                "SELECT TxLgID AS value FROM {$tbpref}texts 
+                "SELECT TxLgID AS value FROM texts 
                 WHERE TxID = " . ((int) getreq('tid'))
             );
             $textlc = convert_string_to_sqlsyntax(
@@ -591,7 +591,7 @@ function edit_mword_page()
             );
 
             $str_id = get_first_value(
-                "SELECT WoID AS value FROM {$tbpref}words 
+                "SELECT WoID AS value FROM words 
                 WHERE WoLgID = $lgid AND WoTextLC = $textlc"
             );
         }
@@ -604,7 +604,7 @@ function edit_mword_page()
         } else {
             // edit_mword.php?tid=..&ord=..&wid=.. for multi-word edit.
             $text = get_first_value(
-                "SELECT WoText AS value FROM {$tbpref}words WHERE WoID = $str_id"
+                "SELECT WoText AS value FROM words WHERE WoID = $str_id"
             );
             pagestart_nobody("Edit Term: " . $text);
             edit_mword_update(

--- a/edit_mword.php
+++ b/edit_mword.php
@@ -170,14 +170,14 @@ function edit_mword_do_operation($term)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  * 
  * @since 2.5.2-fork Use the "wordcount" attribute of $term instead of the 
  * wrong word_count.
  */
 function edit_mword_do_insert($term)
 {
-    global $tbpref;
+
     $titletext = "New Term: " . tohtml($term->textlc);
     pagestart_nobody($titletext);
     echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
@@ -218,11 +218,11 @@ function edit_mword_do_insert($term)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function edit_mword_do_update($term, $newstatus)
 {
-    global $tbpref;
+
     $titletext = "Edit Term: " . tohtml($term->textlc);
     pagestart_nobody($titletext);
     echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
@@ -288,11 +288,11 @@ function edit_mword_do_update($term, $newstatus)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function edit_mword_new($text, $tid, $ord, $len) 
 {
-    global $tbpref;
+
 
     $term = new Term();
     $term->lgid = get_first_value(
@@ -324,11 +324,11 @@ function edit_mword_new($text, $tid, $ord, $len)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function edit_mword_update($wid, $tid, $ord) 
 {
-    global $tbpref;
+
 
     $term = new Term();
 
@@ -356,11 +356,11 @@ function edit_mword_update($wid, $tid, $ord)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function edit_mword_display_new($term, $tid, $ord, $len)
 {
-    global $tbpref;
+
     $scrdir = getScriptDirectionTag($term->lgid);
     $seid = get_first_value(
         "SELECT Ti2SeID AS value 
@@ -453,11 +453,11 @@ function edit_mword_display_new($term, $tid, $ord, $len)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function edit_mword_display_change($term, $tid, $ord)
 {
-    global $tbpref;
+
     $scrdir = getScriptDirectionTag($term->lgid);
     $sql = 'SELECT WoTranslation, WoSentence, WoRomanization, WoStatus 
     FROM words WHERE WoID = ' . $term->id;
@@ -568,11 +568,11 @@ function edit_mword_display_change($term, $tid, $ord)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function edit_mword_page()
 {
-    global $tbpref;
+
 
     if (isset($_REQUEST['op'])) {
         // INS/UPD

--- a/edit_tags.php
+++ b/edit_tags.php
@@ -44,8 +44,8 @@ if (isset($_REQUEST['markaction'])) {
                 }
                 $list .= ")";
                 if ($markaction == 'del') {
-                    $message = runsql('delete from ' . $tbpref . 'tags where TgID in ' . $list, "Deleted");
-                    runsql("DELETE " . $tbpref . "wordtags FROM (" . $tbpref . "wordtags LEFT JOIN " . $tbpref . "tags on WtTgID = TgID) WHERE TgID IS NULL", '');
+                    $message = runsql('delete from tags where TgID in ' . $list, "Deleted");
+                    runsql("DELETE wordtags FROM (wordtags LEFT JOIN tags on WtTgID = TgID) WHERE TgID IS NULL", '');
                     adjust_autoincr('tags', 'TgID');
                 }
             }
@@ -59,8 +59,8 @@ if (isset($_REQUEST['markaction'])) {
 if (isset($_REQUEST['allaction'])) {
     $allaction = $_REQUEST['allaction'];
     if ($allaction == 'delall') {
-        $message = runsql('delete from ' . $tbpref . 'tags where (1=1) ' . $wh_query, "Deleted");
-        runsql("DELETE " . $tbpref . "wordtags FROM (" . $tbpref . "wordtags LEFT JOIN " . $tbpref . "tags on WtTgID = TgID) WHERE TgID IS NULL", '');
+        $message = runsql('delete from tags where (1=1) ' . $wh_query, "Deleted");
+        runsql("DELETE wordtags FROM (wordtags LEFT JOIN tags on WtTgID = TgID) WHERE TgID IS NULL", '');
         adjust_autoincr('tags', 'TgID');
     }
 }
@@ -68,8 +68,8 @@ if (isset($_REQUEST['allaction'])) {
 // DEL
 
 elseif (isset($_REQUEST['del'])) {
-    $message = runsql('delete from ' . $tbpref . 'tags where TgID = ' . $_REQUEST['del'], "Deleted");
-    runsql("DELETE " . $tbpref . "wordtags FROM (" . $tbpref . "wordtags LEFT JOIN " . $tbpref . "tags on WtTgID = TgID) WHERE TgID IS NULL", '');
+    $message = runsql('delete from tags where TgID = ' . $_REQUEST['del'], "Deleted");
+    runsql("DELETE wordtags FROM (wordtags LEFT JOIN tags on WtTgID = TgID) WHERE TgID IS NULL", '');
     adjust_autoincr('tags', 'TgID');
 }
 
@@ -82,7 +82,7 @@ elseif (isset($_REQUEST['op'])) {
     if ($_REQUEST['op'] == 'Save') {
     
         $message = runsql(
-            'insert into ' . $tbpref . 'tags (TgText, TgComment) values(' . 
+            'insert into tags (TgText, TgComment) values(' . 
             convert_string_to_sqlsyntax($_REQUEST["TgText"]) . ', ' .
             convert_string_to_sqlsyntax_nonull($_REQUEST["TgComment"]) . ')', "Saved", $sqlerrdie = false
         );
@@ -94,7 +94,7 @@ elseif (isset($_REQUEST['op'])) {
     elseif ($_REQUEST['op'] == 'Change') {
 
         $message = runsql(
-            'update ' . $tbpref . 'tags set TgText = ' . 
+            'update tags set TgText = ' . 
             convert_string_to_sqlsyntax($_REQUEST["TgText"]) . ', TgComment = ' . 
             convert_string_to_sqlsyntax_nonull($_REQUEST["TgComment"]) . ' where TgID = ' . $_REQUEST["TgID"], "Updated", $sqlerrdie = false
         );
@@ -139,7 +139,7 @@ if (isset($_REQUEST['new'])) {
 
 elseif (isset($_REQUEST['chg'])) {
     
-    $sql = 'select * from ' . $tbpref . 'tags where TgID = ' . $_REQUEST['chg'];
+    $sql = 'select * from tags where TgID = ' . $_REQUEST['chg'];
     $res = do_mysqli_query($sql);
     if ($record = mysqli_fetch_assoc($res)) {
         ?>
@@ -185,7 +185,7 @@ else {
     
     get_tags($refresh = 1);   // refresh tags cache
 
-    $sql = 'select count(TgID) as value from ' . $tbpref . 'tags where (1=1) ' . $wh_query;
+    $sql = 'select count(TgID) as value from tags where (1=1) ' . $wh_query;
     $recno = (int) get_first_value($sql);
     if ($debug) { 
         echo $sql . ' ===&gt; ' . $recno; 
@@ -278,13 +278,13 @@ Multi Actions <img src="icn/lightning.png" title="Multi Actions" alt="Multi Acti
 
         <?php
 
-        $sql = 'select TgID, TgText, TgComment from ' . $tbpref . 'tags where (1=1) ' . $wh_query . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit;
+        $sql = 'select TgID, TgText, TgComment from tags where (1=1) ' . $wh_query . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit;
         if ($debug) { 
             echo $sql; 
         }
         $res = do_mysqli_query($sql);
         while ($record = mysqli_fetch_assoc($res)) {
-            $c = get_first_value('select count(*) as value from ' . $tbpref . 'wordtags where WtTgID=' . $record['TgID']);
+            $c = get_first_value('select count(*) as value from wordtags where WtTgID=' . $record['TgID']);
             echo '<tr>';
             echo '<td class="td1 center"><a name="rec' . $record['TgID'] . '"><input name="marked[]" type="checkbox" class="markcheck" value="' . $record['TgID'] . '" ' . checkTest($record['TgID'], 'marked') . ' /></a></td>';
             echo '<td class="td1 center" nowrap="nowrap">&nbsp;<a href="' . $_SERVER['PHP_SELF'] . '?chg=' . $record['TgID'] . '"><img src="icn/document--pencil.png" title="Edit" alt="Edit" /></a>&nbsp; <a class="confirmdelete" href="' . $_SERVER['PHP_SELF'] . '?del=' . $record['TgID'] . '"><img src="icn/minus-button.png" title="Delete" alt="Delete" /></a>&nbsp;</td>';

--- a/edit_texts.php
+++ b/edit_texts.php
@@ -139,13 +139,13 @@ function edit_texts_get_wh_tag($currentlang)
  * 
  * @return string[2] Number of rows edited, the second string is always null.
  * 
- * @global string $tbpref Database table prefix
+ *
  * 
  * @since 2.4.1-fork The second return field is always null 
  */
 function edit_texts_mark_action($markaction, $marked, $actiondata)
 {
-    global $tbpref;
+
     $message = "Multiple Actions: 0";
     if (!isset($marked) || !is_array($marked)) {
         return array($message, null);
@@ -330,11 +330,11 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
  * 
  * @return string Texts, sentences, and text items deleted. 
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function edit_texts_delete($txid)
 {
-    global $tbpref;
+
     $message3 = runsql(
         'DELETE FROM textitems2 where Ti2TxID = ' . $txid,
         "Text items deleted"
@@ -372,11 +372,11 @@ function edit_texts_delete($txid)
  * @return string Number of archives saved, texts deleted, sentences deleted, 
  *                text items deleted.
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function edit_texts_archive($txid)
 {
-    global $tbpref;
+
     $message3 = runsql(
         "DELETE FROM textitems2 WHERE Ti2TxID = $txid",
         "Text items deleted"
@@ -430,13 +430,13 @@ function edit_texts_archive($txid)
  * 
  * @return string Edition message (number of rows edited)
  * 
- * @global string $tbpref Database table prefix
+ *
  * 
  * @since 2.4.1-fork $message1 is unnused
  */
 function edit_texts_do_operation($op, $message1, $no_pagestart)
 {
-    global $tbpref;
+
     if (strlen(prepare_textdata($_REQUEST['TxText'])) > 65000) {
         $message = "Error: Text too long, must be below 65000 Bytes";
         $currentlang = (int) validateLang(
@@ -644,11 +644,11 @@ function edit_texts_new($lid)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function edit_texts_change($txid)
 {
-    global $tbpref;
+
     $sql = "SELECT TxLgID, TxTitle, TxText, TxAudioURI, TxSourceURI, LENGTH(TxAnnotatedText) AS annotlen 
     FROM texts 
     WHERE TxID = {$txid}";
@@ -1134,12 +1134,12 @@ function edit_texts_texts_form($currentlang, $showCounts, $sql, $recno)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  * @global int    $debug  Debug mode active or not
  */
 function edit_texts_display($message)
 {
-    global $tbpref, $debug;
+    global $debug;
 
     // Page, Sort, etc.
 

--- a/edit_texts.php
+++ b/edit_texts.php
@@ -162,25 +162,25 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
 
     if ($markaction == 'del') {
         $message3 = runsql(
-            'delete from ' . $tbpref . 'textitems2 where Ti2TxID in ' . $list, 
+            'delete from textitems2 where Ti2TxID in ' . $list, 
             "Text items deleted"
         );
         $message2 = runsql(
-            'delete from ' . $tbpref . 'sentences where SeTxID in ' . $list, 
+            'delete from sentences where SeTxID in ' . $list, 
             "Sentences deleted"
         );
         $message1 = runsql(
-            'delete from ' . $tbpref . 'texts where TxID in ' . $list, 
+            'delete from texts where TxID in ' . $list, 
             "Texts deleted"
         );
         $message = $message1 . " / " . $message2 . " / " . $message3;
         adjust_autoincr('texts', 'TxID');
         adjust_autoincr('sentences', 'SeID');
         runsql(
-            "DELETE " . $tbpref . "texttags 
+            "DELETE texttags 
             FROM (
-                " . $tbpref . "texttags 
-                LEFT JOIN " . $tbpref . "texts 
+                texttags 
+                LEFT JOIN texts 
                 ON TtTxID = TxID
             ) 
             WHERE TxID IS NULL", 
@@ -188,43 +188,43 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
         );
     } elseif ($markaction == 'arch') {
         runsql(
-            'delete from ' . $tbpref . 'textitems2 where Ti2TxID in ' . $list, 
+            'delete from textitems2 where Ti2TxID in ' . $list, 
             ""
         );
         runsql(
-            'delete from ' . $tbpref . 'sentences where SeTxID in ' . $list, 
+            'delete from sentences where SeTxID in ' . $list, 
             ""
         );
         $count = 0;
-        $sql = "select TxID from " . $tbpref . "texts where TxID in " . $list;
+        $sql = "select TxID from texts where TxID in " . $list;
         $res = do_mysqli_query($sql);
         while ($record = mysqli_fetch_assoc($res)) {
             $id = $record['TxID'];
             $count += (int)runsql(
-                'insert into ' . $tbpref . 'archivedtexts (
+                'insert into archivedtexts (
                     AtLgID, AtTitle, AtText, AtAnnotatedText, AtAudioURI, AtSourceURI
                 ) 
                 select TxLgID, TxTitle, TxText, TxAnnotatedText, TxAudioURI, TxSourceURI 
-                from ' . $tbpref . 'texts where TxID = ' . $id, 
+                from texts where TxID = ' . $id, 
                 ""
             );
             $aid = get_last_key();
             runsql(
-                'insert into ' . $tbpref . 'archtexttags (AgAtID, AgT2ID) 
+                'insert into archtexttags (AgAtID, AgT2ID) 
                 select ' . $aid . ', TtT2ID 
-                from ' . $tbpref . 'texttags 
+                from texttags 
                 where TtTxID = ' . $id, 
                 ""
             );
         }
         mysqli_free_result($res);
         $message = 'Text(s) archived: ' . $count;
-        runsql('delete from ' . $tbpref . 'texts where TxID in ' . $list, "");
+        runsql('delete from texts where TxID in ' . $list, "");
         runsql(
-            "DELETE " . $tbpref . "texttags 
+            "DELETE texttags 
             FROM (
-                " . $tbpref . "texttags 
-                LEFT JOIN " . $tbpref . "texts 
+                texttags 
+                LEFT JOIN texts 
                 on TtTxID = TxID
             ) 
             WHERE TxID IS NULL", 
@@ -241,7 +241,7 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
     } elseif ($markaction == 'setsent') {
         $count = 0;
         $sql = "select WoID, WoTextLC, min(Ti2SeID) as SeID 
-        from " . $tbpref . "words, " . $tbpref . "textitems2 
+        from words, textitems2 
         where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in " . $list . " and 
         ifnull(WoSentence,'') not like concat('%{',WoText,'}%') 
         group by WoID order by WoID, min(Ti2SeID)";
@@ -254,7 +254,7 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
                 (int) getSettingWithDefault('set-term-sentence-count')
             );
             $count += (int) runsql(
-                'UPDATE ' . $tbpref . 'words 
+                'UPDATE words 
                 SET WoSentence = ' . convert_string_to_sqlsyntax(repl_tab_nl($sent[1])) . ' 
                 WHERE WoID = ' . $record['WoID'], 
                 ''
@@ -265,7 +265,7 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
     } elseif ($markaction == 'setactsent') {
         $count = 0;
         $sql = "SELECT WoID, WoTextLC, MIN(Ti2SeID) AS SeID 
-        FROM " . $tbpref . "words, " . $tbpref . "textitems2 
+        FROM words, textitems2 
         WHERE Ti2LgID = WoLgID AND WoStatus != 98 AND WoStatus != 99 AND 
         Ti2WoID = WoID AND Ti2TxID IN " . $list . " AND 
         IFNULL(WoSentence,'') NOT LIKE CONCAT('%{',WoText,'}%') 
@@ -280,7 +280,7 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
                 (int) getSettingWithDefault('set-term-sentence-count')
             );
             $count += (int) runsql(
-                'update ' . $tbpref . 'words 
+                'update words 
                 set WoSentence = ' . convert_string_to_sqlsyntax(repl_tab_nl($sent[1])) . ' 
                 where WoID = ' . $record['WoID'], 
                 ''
@@ -290,22 +290,22 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
         $message = 'Term Sentences set from Text(s): ' . $count;
     } elseif ($markaction == 'rebuild') {
         $count = 0;
-        $sql = "select TxID, TxLgID from " . $tbpref . "texts where TxID in " . $list;
+        $sql = "select TxID, TxLgID from texts where TxID in " . $list;
         $res = do_mysqli_query($sql);
         while ($record = mysqli_fetch_assoc($res)) {
             $id = (int)$record['TxID'];
             runsql(
-                'delete from ' . $tbpref . 'sentences where SeTxID = ' . $id, 
+                'delete from sentences where SeTxID = ' . $id, 
                 "Sentences deleted"
             );
             runsql(
-                'delete from ' . $tbpref . 'textitems2 where Ti2TxID = ' . $id, 
+                'delete from textitems2 where Ti2TxID = ' . $id, 
                 "Text items deleted"
             );
             adjust_autoincr('sentences', 'SeID');
             splitCheckText(
                 get_first_value(
-                    'select TxText as value from ' . $tbpref . 'texts where TxID = ' . $id
+                    'select TxText as value from texts where TxID = ' . $id
                 ),
                 $record['TxLgID'], $id 
             );
@@ -314,7 +314,7 @@ function edit_texts_mark_action($markaction, $marked, $actiondata)
         mysqli_free_result($res);
         $message = 'Text(s) reparsed: ' . $count;
     } elseif ($markaction == 'test' ) {
-        $_SESSION['testsql'] = ' ' . $tbpref . 'words, ' . $tbpref . 'textitems2 
+        $_SESSION['testsql'] = ' words, textitems2 
         WHERE Ti2LgID = WoLgID AND Ti2WoID = WoID AND Ti2TxID IN ' . $list . ' ';
         header("Location: do_test.php?selection=1");
         exit();
@@ -336,25 +336,25 @@ function edit_texts_delete($txid)
 {
     global $tbpref;
     $message3 = runsql(
-        'DELETE FROM ' . $tbpref . 'textitems2 where Ti2TxID = ' . $txid,
+        'DELETE FROM textitems2 where Ti2TxID = ' . $txid,
         "Text items deleted"
     );
     $message2 = runsql(
-        'DELETE FROM ' . $tbpref . 'sentences where SeTxID = ' . $txid,
+        'DELETE FROM sentences where SeTxID = ' . $txid,
         "Sentences deleted"
     );
     $message1 = runsql(
-        'DELETE FROM ' . $tbpref . 'texts where TxID = ' . $txid,
+        'DELETE FROM texts where TxID = ' . $txid,
         "Texts deleted"
     );
     $message = $message1 . " / " . $message2 . " / " . $message3;
     adjust_autoincr('texts', 'TxID');
     adjust_autoincr('sentences', 'SeID');
     runsql(
-        "DELETE {$tbpref}texttags 
+        "DELETE texttags 
         FROM (
-            {$tbpref}texttags 
-            LEFT JOIN {$tbpref}texts 
+            texttags 
+            LEFT JOIN texts 
             ON TtTxID = TxID
         ) 
         WHERE TxID IS NULL", 
@@ -378,41 +378,41 @@ function edit_texts_archive($txid)
 {
     global $tbpref;
     $message3 = runsql(
-        "DELETE FROM {$tbpref}textitems2 WHERE Ti2TxID = $txid",
+        "DELETE FROM textitems2 WHERE Ti2TxID = $txid",
         "Text items deleted"
     );
     $message2 = runsql(
-        "DELETE FROM {$tbpref}sentences WHERE SeTxID = $txid",
+        "DELETE FROM sentences WHERE SeTxID = $txid",
         "Sentences deleted"
     );
     $message4 = runsql(
-        "INSERT INTO {$tbpref}archivedtexts (
+        "INSERT INTO archivedtexts (
             AtLgID, AtTitle, AtText, AtAnnotatedText, AtAudioURI, AtSourceURI
         ) SELECT TxLgID, TxTitle, TxText, TxAnnotatedText, TxAudioURI, TxSourceURI 
-        FROM {$tbpref}texts 
+        FROM texts 
         WHERE TxID = $txid", 
         "Archived Texts saved"
     );
     $id = get_last_key();
     runsql(
-        "INSERT INTO {$tbpref}archtexttags (AgAtID, AgT2ID) 
+        "INSERT INTO archtexttags (AgAtID, AgT2ID) 
         SELECT $id, TtT2ID 
-        FROM {$tbpref}texttags 
+        FROM texttags 
         WHERE TtTxID = $txid", 
         ""
     );
     $message1 = runsql(
-        "DELETE FROM {$tbpref}texts WHERE TxID = $txid", 
+        "DELETE FROM texts WHERE TxID = $txid", 
         "Texts deleted"
     );
     $message = $message4 . " / " . $message1 . " / " . $message2 . " / " . $message3;
     adjust_autoincr('texts', 'TxID');
     adjust_autoincr('sentences', 'SeID');
     runsql(
-        "DELETE {$tbpref}texttags 
+        "DELETE texttags 
         FROM (
-            {$tbpref}texttags 
-            LEFT JOIN {$tbpref}texts 
+            texttags 
+            LEFT JOIN texts 
             ON TtTxID = TxID
         ) 
         WHERE TxID IS NULL", 
@@ -469,7 +469,7 @@ function edit_texts_do_operation($op, $message1, $no_pagestart)
 
     elseif (substr($op, 0, 4) == 'Save') {
         runsql(
-            'insert into ' . $tbpref . 'texts (
+            'insert into texts (
                 TxLgID, TxTitle, TxText, TxAnnotatedText, 
                 TxAudioURI, TxSourceURI
             ) values( ' . 
@@ -490,14 +490,14 @@ function edit_texts_do_operation($op, $message1, $no_pagestart)
         /*
         $oldtext = get_first_value(
             'SELECT TxText AS value 
-            FROM ' . $tbpref . 'texts 
+            FROM texts 
             WHERE TxID = ' . $_REQUEST["TxID"]
         );
         (convert_string_to_sqlsyntax(remove_soft_hyphens($_REQUEST["TxText"])) 
         != convert_string_to_sqlsyntax($oldtext));
         */
         runsql(
-            'update ' . $tbpref . 'texts set ' .
+            'update texts set ' .
             'TxLgID = ' . $_REQUEST["TxLgID"] . ', ' .
             'TxTitle = ' . convert_string_to_sqlsyntax($_REQUEST["TxTitle"]) . ', ' .
             'TxText = ' . convert_string_to_sqlsyntax(remove_soft_hyphens($_REQUEST["TxText"])) . ', ' .
@@ -510,18 +510,18 @@ function edit_texts_do_operation($op, $message1, $no_pagestart)
     }
 
     $message1 = runsql(
-        'delete from ' . $tbpref . 'sentences where SeTxID = ' . $id,
+        'delete from sentences where SeTxID = ' . $id,
         "Sentences deleted"
     );
     $message2 = runsql(
-        'delete from ' . $tbpref . 'textitems2 where Ti2TxID = ' . $id,
+        'delete from textitems2 where Ti2TxID = ' . $id,
         "Textitems deleted"
     );
     adjust_autoincr('sentences', 'SeID');
 
     splitCheckText(
         get_first_value(
-            'SELECT TxText AS value FROM ' . $tbpref . 'texts 
+            'SELECT TxText AS value FROM texts 
             WHERE TxID = ' . $id
         ),
         $_REQUEST["TxLgID"], $id 
@@ -530,12 +530,12 @@ function edit_texts_do_operation($op, $message1, $no_pagestart)
     $message = $message1 . " / " . $message2 . 
     " / Sentences added: " . get_first_value(
         "SELECT COUNT(*) AS value 
-        FROM {$tbpref}sentences 
+        FROM sentences 
         WHERE SeTxID = $id"
     ) . 
     " / Text items added: " . get_first_value(
         "SELECT COUNT(*) AS value 
-        FROM {$tbpref}textitems2 
+        FROM textitems2 
         WHERE Ti2TxID = $id"
     );
 
@@ -650,7 +650,7 @@ function edit_texts_change($txid)
 {
     global $tbpref;
     $sql = "SELECT TxLgID, TxTitle, TxText, TxAudioURI, TxSourceURI, LENGTH(TxAnnotatedText) AS annotlen 
-    FROM {$tbpref}texts 
+    FROM texts 
     WHERE TxID = {$txid}";
     $res = do_mysqli_query($sql);
     if ($record = mysqli_fetch_assoc($res)) {
@@ -1179,8 +1179,8 @@ function edit_texts_display($message)
     FROM (
         SELECT TxID 
         FROM (
-            {$tbpref}texts 
-            LEFT JOIN {$tbpref}texttags 
+            texts 
+            LEFT JOIN texttags 
             ON TxID = TtTxID
         ) WHERE (1=1) {$wh_lang}{$wh_query}
         GROUP BY TxID {$wh_tag}
@@ -1262,9 +1262,9 @@ function edit_texts_display($message)
             )
         ) AS taglist
         FROM (
-            ({$tbpref}texts LEFT JOIN {$tbpref}texttags ON TxID = TtTxID) 
-            LEFT JOIN {$tbpref}tags2 ON T2ID = TtT2ID
-        ), {$tbpref}languages
+            (texts LEFT JOIN texttags ON TxID = TtTxID) 
+            LEFT JOIN tags2 ON T2ID = TtT2ID
+        ), languages
         WHERE LgID=TxLgID {$wh_lang}{$wh_query} 
         GROUP BY TxID $wh_tag
         ORDER BY {$sorts[$currentsort-1]} 

--- a/edit_texttags.php
+++ b/edit_texttags.php
@@ -43,9 +43,9 @@ if (isset($_REQUEST['markaction'])) {
                 }
                 $list .= ")";
                 if ($markaction == 'del') {
-                    $message = runsql('delete from ' . $tbpref . 'tags2 where T2ID in ' . $list, "Deleted");
-                    runsql("DELETE " . $tbpref . "texttags FROM (" . $tbpref . "texttags LEFT JOIN " . $tbpref . "tags2 on TtT2ID = T2ID) WHERE T2ID IS NULL", '');
-                    runsql("DELETE " . $tbpref . "archtexttags FROM (" . $tbpref . "archtexttags LEFT JOIN " . $tbpref . "tags2 on AgT2ID = T2ID) WHERE T2ID IS NULL", '');
+                    $message = runsql('delete from tags2 where T2ID in ' . $list, "Deleted");
+                    runsql("DELETE texttags FROM (texttags LEFT JOIN tags2 on TtT2ID = T2ID) WHERE T2ID IS NULL", '');
+                    runsql("DELETE archtexttags FROM (archtexttags LEFT JOIN tags2 on AgT2ID = T2ID) WHERE T2ID IS NULL", '');
                     adjust_autoincr('tags2', 'T2ID');
                 }
             }
@@ -59,9 +59,9 @@ if (isset($_REQUEST['markaction'])) {
 if (isset($_REQUEST['allaction'])) {
     $allaction = $_REQUEST['allaction'];
     if ($allaction == 'delall') {
-        $message = runsql('delete from ' . $tbpref . 'tags2 where (1=1) ' . $wh_query, "Deleted");
-        runsql("DELETE " . $tbpref . "texttags FROM (" . $tbpref . "texttags LEFT JOIN " . $tbpref . "tags2 on TtT2ID = T2ID) WHERE T2ID IS NULL", '');
-        runsql("DELETE " . $tbpref . "archtexttags FROM (" . $tbpref . "archtexttags LEFT JOIN " . $tbpref . "tags2 on AgT2ID = T2ID) WHERE T2ID IS NULL", '');
+        $message = runsql('delete from tags2 where (1=1) ' . $wh_query, "Deleted");
+        runsql("DELETE texttags FROM (texttags LEFT JOIN tags2 on TtT2ID = T2ID) WHERE T2ID IS NULL", '');
+        runsql("DELETE archtexttags FROM (archtexttags LEFT JOIN tags2 on AgT2ID = T2ID) WHERE T2ID IS NULL", '');
         adjust_autoincr('tags2', 'T2ID');
     }
 }
@@ -69,9 +69,9 @@ if (isset($_REQUEST['allaction'])) {
 // DEL
 
 elseif (isset($_REQUEST['del'])) {
-    $message = runsql('delete from ' . $tbpref . 'tags2 where T2ID = ' . $_REQUEST['del'], "Deleted");
-    runsql("DELETE " . $tbpref . "texttags FROM (" . $tbpref . "texttags LEFT JOIN " . $tbpref . "tags2 on TtT2ID = T2ID) WHERE T2ID IS NULL", '');
-    runsql("DELETE " . $tbpref . "archtexttags FROM (" . $tbpref . "archtexttags LEFT JOIN " . $tbpref . "tags2 on AgT2ID = T2ID) WHERE T2ID IS NULL", '');
+    $message = runsql('delete from tags2 where T2ID = ' . $_REQUEST['del'], "Deleted");
+    runsql("DELETE texttags FROM (texttags LEFT JOIN tags2 on TtT2ID = T2ID) WHERE T2ID IS NULL", '');
+    runsql("DELETE archtexttags FROM (archtexttags LEFT JOIN tags2 on AgT2ID = T2ID) WHERE T2ID IS NULL", '');
     adjust_autoincr('tags2', 'T2ID');
 }
 
@@ -84,7 +84,7 @@ elseif (isset($_REQUEST['op'])) {
     if ($_REQUEST['op'] == 'Save') {
     
         $message = runsql(
-            'insert into ' . $tbpref . 'tags2 (T2Text, T2Comment) values(' . 
+            'insert into tags2 (T2Text, T2Comment) values(' . 
             convert_string_to_sqlsyntax($_REQUEST["T2Text"]) . ', ' .
             convert_string_to_sqlsyntax_nonull($_REQUEST["T2Comment"]) . ')', "Saved", $sqlerrdie = false
         );
@@ -96,7 +96,7 @@ elseif (isset($_REQUEST['op'])) {
     elseif ($_REQUEST['op'] == 'Change') {
 
         $message = runsql(
-            'update ' . $tbpref . 'tags2 set T2Text = ' . 
+            'update tags2 set T2Text = ' . 
             convert_string_to_sqlsyntax($_REQUEST["T2Text"]) . ', T2Comment = ' . 
             convert_string_to_sqlsyntax_nonull($_REQUEST["T2Comment"]) . ' where T2ID = ' . $_REQUEST["T2ID"], "Updated", $sqlerrdie = false
         );
@@ -141,7 +141,7 @@ if (isset($_REQUEST['new'])) {
 
 elseif (isset($_REQUEST['chg'])) {
     
-    $sql = 'select * from ' . $tbpref . 'tags2 where T2ID = ' . $_REQUEST['chg'];
+    $sql = 'select * from tags2 where T2ID = ' . $_REQUEST['chg'];
     $res = do_mysqli_query($sql);
     if ($record = mysqli_fetch_assoc($res)) {
         ?>
@@ -186,7 +186,7 @@ else {
     
     get_texttags($refresh = 1);   // refresh tags cache
 
-    $sql = 'select count(T2ID) as value from ' . $tbpref . 'tags2 where (1=1) ' . $wh_query;
+    $sql = 'select count(T2ID) as value from tags2 where (1=1) ' . $wh_query;
     $recno = (int) get_first_value($sql);
     if ($debug) { 
         echo $sql . ' ===&gt; ' . $recno; 
@@ -278,14 +278,14 @@ Multi Actions <img src="icn/lightning.png" title="Multi Actions" alt="Multi Acti
 
         <?php
 
-        $sql = 'select T2ID, T2Text, T2Comment from ' . $tbpref . 'tags2 where (1=1) ' . $wh_query . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit;
+        $sql = 'select T2ID, T2Text, T2Comment from tags2 where (1=1) ' . $wh_query . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit;
         if ($debug) { 
             echo $sql; 
         }
         $res = do_mysqli_query($sql);
         while ($record = mysqli_fetch_assoc($res)) {
-            $c = get_first_value('select count(*) as value from ' . $tbpref . 'texttags where TtT2ID=' . $record['T2ID']);
-            $ca = get_first_value('select count(*) as value from ' . $tbpref . 'archtexttags where AgT2ID=' . $record['T2ID']);
+            $c = get_first_value('select count(*) as value from texttags where TtT2ID=' . $record['T2ID']);
+            $ca = get_first_value('select count(*) as value from archtexttags where AgT2ID=' . $record['T2ID']);
             echo '<tr>';
             echo '<td class="td1 center"><a name="rec' . $record['T2ID'] . '"><input name="marked[]" type="checkbox" class="markcheck" value="' . $record['T2ID'] . '" ' . checkTest($record['T2ID'], 'marked') . ' /></a></td>';
             echo '<td class="td1 center" nowrap="nowrap">&nbsp;<a href="' . $_SERVER['PHP_SELF'] . '?chg=' . $record['T2ID'] . '"><img src="icn/document--pencil.png" title="Edit" alt="Edit" /></a>&nbsp; <a class="confirmdelete" href="' . $_SERVER['PHP_SELF'] . '?del=' . $record['T2ID'] . '"><img src="icn/minus-button.png" title="Delete" alt="Delete" /></a>&nbsp;</td>';

--- a/edit_tword.php
+++ b/edit_tword.php
@@ -53,7 +53,7 @@ if (isset($_REQUEST['op'])) {
             }
         
             runsql(
-                'update ' . $tbpref . 'words set WoText = ' . 
+                'update words set WoText = ' . 
                 convert_string_to_sqlsyntax($_REQUEST["WoText"]) . ', WoTranslation = ' . 
                 convert_string_to_sqlsyntax($translation) . ', WoSentence = ' . 
                 convert_string_to_sqlsyntax(repl_tab_nl($_REQUEST["WoSentence"])) . ', WoRomanization = ' .
@@ -84,11 +84,11 @@ if (isset($_REQUEST['op'])) {
 
     <?php
 
-    $lang = get_first_value('select WoLgID as value from ' . $tbpref . 'words where WoID = ' . $wid);
+    $lang = get_first_value('select WoLgID as value from words where WoID = ' . $wid);
     if (!isset($lang)) { 
         my_die('Cannot retrieve language in edit_tword.php'); 
     }
-    $regexword = get_first_value('select LgRegexpWordCharacters as value from ' . $tbpref . 'languages where LgID = ' . $lang);
+    $regexword = get_first_value('select LgRegexpWordCharacters as value from languages where LgID = ' . $lang);
     if (!isset($regexword)) {
         my_die('Cannot retrieve language data in edit_tword.php'); 
     }
@@ -139,7 +139,7 @@ else {  // if (! isset($_REQUEST['op']))
     if ($wid == '') { my_die("Term ID missing in edit_tword.php"); 
     }
     
-    $sql = 'select WoText, WoLgID, WoTranslation, WoSentence, WoRomanization, WoStatus from ' . $tbpref . 'words where WoID = ' . $wid;
+    $sql = 'select WoText, WoLgID, WoTranslation, WoSentence, WoRomanization, WoStatus from words where WoID = ' . $wid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     if ($record ) {

--- a/edit_word.php
+++ b/edit_word.php
@@ -28,7 +28,7 @@ require_once 'inc/simterms.php';
  */
 function insert_new_word($textlc, $translation)
 {
-    global $tbpref;
+
 
     $titletext = "New Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
     pagestart_nobody($titletext);
@@ -69,7 +69,7 @@ function insert_new_word($textlc, $translation)
  */
 function edit_term($translation)
 {
-    global $tbpref;
+
 
     $titletext = "Edit Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
     pagestart_nobody($titletext);

--- a/edit_word.php
+++ b/edit_word.php
@@ -35,7 +35,7 @@ function insert_new_word($textlc, $translation)
     echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
 
     $message = runsql(
-        'INSERT INTO ' . $tbpref . 'words 
+        'INSERT INTO words 
         (
             WoLgID, WoTextLC, WoText, WoStatus, WoTranslation, 
             WoSentence, WoWordCount, WoRomanization, WoStatusChanged,' 
@@ -53,7 +53,7 @@ function insert_new_word($textlc, $translation)
     );
     $wid = get_last_key();
     do_mysqli_query(
-        'UPDATE ' . $tbpref . 'textitems2 SET Ti2WoID = ' . $wid . ' 
+        'UPDATE textitems2 SET Ti2WoID = ' . $wid . ' 
         WHERE Ti2LgID = ' . $_REQUEST["WoLgID"] . ' AND LOWER(Ti2Text) =' . 
         convert_string_to_sqlsyntax_notrim_nonull($textlc)
     );
@@ -83,7 +83,7 @@ function edit_term($translation)
     }
 
     $message = runsql(
-        'update ' . $tbpref . 'words set WoText = ' . 
+        'update words set WoText = ' . 
         convert_string_to_sqlsyntax($_REQUEST["WoText"]) . ', WoTranslation = ' . 
         convert_string_to_sqlsyntax($translation) . ', WoSentence = ' . 
         convert_string_to_sqlsyntax(repl_tab_nl($_REQUEST["WoSentence"])) . ', WoRomanization = ' .
@@ -248,7 +248,7 @@ else {  // if (! isset($_REQUEST['op']))
     
     if ($wid == '') {    
         $sql = 
-        'SELECT Ti2Text, Ti2LgID FROM ' . $tbpref . 'textitems2 
+        'SELECT Ti2Text, Ti2LgID FROM textitems2 
         WHERE Ti2TxID = ' . $_REQUEST['tid'] . ' AND Ti2WordCount = 1 AND Ti2Order = ' . $_REQUEST['ord'];
         $res = do_mysqli_query($sql);
         $record = mysqli_fetch_assoc($res);
@@ -264,13 +264,13 @@ else {  // if (! isset($_REQUEST['op']))
         
         $wid = get_first_value(
             "SELECT WoID AS value 
-            FROM " . $tbpref . "words 
+            FROM words 
             WHERE WoLgID = " . $lang . " AND WoTextLC = " . convert_string_to_sqlsyntax($termlc)
         ); 
         
     } else {
 
-        $sql = 'SELECT WoText, WoLgID FROM ' . $tbpref . 'words WHERE WoID = ' . $wid;
+        $sql = 'SELECT WoText, WoLgID FROM words WHERE WoID = ' . $wid;
         $res = do_mysqli_query($sql);
         $record = mysqli_fetch_assoc($res);
         if ($record ) {
@@ -303,7 +303,7 @@ else {  // if (! isset($_REQUEST['op']))
     if ($new) {
          
         $seid = get_first_value(
-            "SELECT Ti2SeID AS value FROM " . $tbpref . "textitems2 
+            "SELECT Ti2SeID AS value FROM textitems2 
             WHERE Ti2TxID = " . $_REQUEST['tid'] . " AND Ti2WordCount = 1 AND Ti2Order = " . $_REQUEST['ord']
         );
         $sent = getSentence($seid, $termlc, (int) getSettingWithDefault('set-term-sentence-count'));
@@ -364,7 +364,7 @@ else {  // if (! isset($_REQUEST['op']))
     
     else {
         
-        $sql = 'select WoTranslation, WoSentence, WoRomanization, WoStatus from ' . $tbpref . 'words where WoID = ' . $wid;
+        $sql = 'select WoTranslation, WoSentence, WoRomanization, WoStatus from words where WoID = ' . $wid;
         $res = do_mysqli_query($sql);
         if ($record = mysqli_fetch_assoc($res)) {
             
@@ -376,7 +376,7 @@ else {  // if (! isset($_REQUEST['op']))
             }
             $sentence = repl_tab_nl($record['WoSentence']);
             if ($sentence == '' && isset($_REQUEST['tid']) && isset($_REQUEST['ord'])) {
-                $seid = get_first_value("select Ti2SeID as value from " . $tbpref . "textitems2 where Ti2TxID = " . $_REQUEST['tid'] . " and Ti2WordCount = 1 and Ti2Order = " . $_REQUEST['ord']);
+                $seid = get_first_value("select Ti2SeID as value from textitems2 where Ti2TxID = " . $_REQUEST['tid'] . " and Ti2WordCount = 1 and Ti2Order = " . $_REQUEST['ord']);
                 $sent = getSentence($seid, $termlc, (int) getSettingWithDefault('set-term-sentence-count'));
                 $sentence = repl_tab_nl($sent[1]);
             }

--- a/edit_words.php
+++ b/edit_words.php
@@ -144,11 +144,11 @@ if (isset($_REQUEST['markaction'])) {
                 }
                 $list .= ")";
                 if ($markaction == 'del') {
-                    $message = runsql('delete from ' . $tbpref . 'words where WoID in ' . $list, "Deleted");
-                    do_mysqli_query('update ' . $tbpref . 'textitems2 set Ti2WoID = 0 where Ti2WordCount = 1 and Ti2WoID in ' . $list);
-                    do_mysqli_query('delete from ' . $tbpref . 'textitems2 where Ti2WoID in ' . $list);
+                    $message = runsql('delete from words where WoID in ' . $list, "Deleted");
+                    do_mysqli_query('update textitems2 set Ti2WoID = 0 where Ti2WordCount = 1 and Ti2WoID in ' . $list);
+                    do_mysqli_query('delete from textitems2 where Ti2WoID in ' . $list);
                     adjust_autoincr('words', 'WoID');
-                    runsql("DELETE " . $tbpref . "wordtags FROM (" . $tbpref . "wordtags LEFT JOIN " . $tbpref . "words on WtWoID = WoID) WHERE WoID IS NULL", '');
+                    runsql("DELETE wordtags FROM (wordtags LEFT JOIN words on WtWoID = WoID) WHERE WoID IS NULL", '');
                 }
                 elseif ($markaction == 'addtag' ) {
                     $message = addtaglist($actiondata, $list);
@@ -159,46 +159,46 @@ if (isset($_REQUEST['markaction'])) {
                     exit();
                 }
                 elseif ($markaction == 'spl1' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoStatus=WoStatus+1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoStatus in (1,2,3,4) and WoID in ' . $list, "Updated Status (+1)");
+                    $message = runsql('update words set WoStatus=WoStatus+1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoStatus in (1,2,3,4) and WoID in ' . $list, "Updated Status (+1)");
                 }
                 elseif ($markaction == 'smi1' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoStatus=WoStatus-1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoStatus in (2,3,4,5) and WoID in ' . $list, "Updated Status (-1)");
+                    $message = runsql('update words set WoStatus=WoStatus-1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoStatus in (2,3,4,5) and WoID in ' . $list, "Updated Status (-1)");
                 }
                 elseif ($markaction == 's5' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoStatus=5, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status (=5)");
+                    $message = runsql('update words set WoStatus=5, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status (=5)");
                 }
                 elseif ($markaction == 's1' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoStatus=1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status (=1)");
+                    $message = runsql('update words set WoStatus=1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status (=1)");
                 }
                 elseif ($markaction == 's99' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoStatus=99, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status (=99)");
+                    $message = runsql('update words set WoStatus=99, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status (=99)");
                 }
                 elseif ($markaction == 's98' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoStatus=98, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status (=98)");
+                    $message = runsql('update words set WoStatus=98, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status (=98)");
                 }
                 elseif ($markaction == 'today' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status Date (= Now)");
+                    $message = runsql('update words set WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID in ' . $list, "Updated Status Date (= Now)");
                 }
                 elseif ($markaction == 'delsent' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoSentence = NULL where WoID in ' . $list, "Term Sentence(s) deleted");
+                    $message = runsql('update words set WoSentence = NULL where WoID in ' . $list, "Term Sentence(s) deleted");
                 }
                 elseif ($markaction == 'lower' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoText = WoTextLC where WoID in ' . $list, "Term(s) set to lowercase");
+                    $message = runsql('update words set WoText = WoTextLC where WoID in ' . $list, "Term(s) set to lowercase");
                 }
                 elseif ($markaction == 'cap' ) {
-                    $message = runsql('update ' . $tbpref . 'words set WoText = CONCAT(UPPER(LEFT(WoTextLC,1)),SUBSTRING(WoTextLC,2)) where WoID in ' . $list, "Term(s) capitalized");
+                    $message = runsql('update words set WoText = CONCAT(UPPER(LEFT(WoTextLC,1)),SUBSTRING(WoTextLC,2)) where WoID in ' . $list, "Term(s) capitalized");
                 }
                 elseif ($markaction == 'exp' ) {
-                    anki_export('select distinct WoID, LgRightToLeft, LgRegexpWordCharacters, LgName, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages where WoLgID = LgID AND WoTranslation != \'\' AND WoTranslation != \'*\' and WoSentence like concat(\'%{\',WoText,\'}%\') and WoID in ' . $list . ' group by WoID');
+                    anki_export('select distinct WoID, LgRightToLeft, LgRegexpWordCharacters, LgName, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages where WoLgID = LgID AND WoTranslation != \'\' AND WoTranslation != \'*\' and WoSentence like concat(\'%{\',WoText,\'}%\') and WoID in ' . $list . ' group by WoID');
                 }
                 elseif ($markaction == 'exp2' ) {
-                    tsv_export('select distinct WoID, LgName, WoText, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages where WoLgID = LgID and WoID in ' . $list . ' group by WoID');
+                    tsv_export('select distinct WoID, LgName, WoText, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages where WoLgID = LgID and WoID in ' . $list . ' group by WoID');
                 }
                 elseif ($markaction == 'exp3' ) {
-                    flexible_export('select distinct WoID, LgName, LgExportTemplate, LgRightToLeft, WoText, WoTextLC, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages where WoLgID = LgID and WoID in ' . $list . ' group by WoID');
+                    flexible_export('select distinct WoID, LgName, LgExportTemplate, LgRightToLeft, WoText, WoTextLC, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages where WoLgID = LgID and WoID in ' . $list . ' group by WoID');
                 }
                 elseif ($markaction == 'test' ) {
-                    $_SESSION['testsql'] = ' ' . $tbpref . 'words where WoID in ' . $list . ' ';
+                    $_SESSION['testsql'] = ' words where WoID in ' . $list . ' ';
                     header("Location: do_test.php?selection=1");
                     exit();
                 }
@@ -215,9 +215,9 @@ if (isset($_REQUEST['allaction'])) {
     $actiondata = getreq('data');
     if ($allaction == 'delall' || $allaction == 'spl1all' || $allaction == 'smi1all' || $allaction == 's5all' || $allaction == 's1all' || $allaction == 's99all' || $allaction == 's98all' || $allaction == 'todayall' || $allaction == 'addtagall' || $allaction == 'deltagall' || $allaction == 'delsentall' || $allaction == 'lowerall' || $allaction == 'capall') {
         if ($currenttext == '') {
-            $sql = 'select distinct WoID from (' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) where (1=1) ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag;
+            $sql = 'select distinct WoID from (words left JOIN wordtags ON WoID = WtWoID) where (1=1) ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag;
         } else {
-            $sql = 'select distinct WoID from (' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID), ' . $tbpref . 'textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext. ')' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag;
+            $sql = 'select distinct WoID from (words left JOIN wordtags ON WoID = WtWoID), textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext. ')' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag;
         }
         $cnt=0;
         $res = do_mysqli_query($sql);
@@ -225,9 +225,9 @@ if (isset($_REQUEST['allaction'])) {
             $id = $record['WoID'];
             $message='0';
             if ($allaction == 'delall' ) {
-                $message = runsql('delete from ' . $tbpref . 'words where WoID = ' . $id, "");
-                do_mysqli_query('update ' . $tbpref . 'textitems2 set Ti2WoID = 0 where Ti2WordCount = 1 and Ti2WoID = ' . $id);
-                do_mysqli_query('delete from ' . $tbpref . 'textitems2 where Ti2WoID  = ' . $id);
+                $message = runsql('delete from words where WoID = ' . $id, "");
+                do_mysqli_query('update textitems2 set Ti2WoID = 0 where Ti2WordCount = 1 and Ti2WoID = ' . $id);
+                do_mysqli_query('delete from textitems2 where Ti2WoID  = ' . $id);
             }
             elseif ($allaction == 'addtagall' ) {
                 addtaglist($actiondata, '(' . $id . ')');
@@ -238,34 +238,34 @@ if (isset($_REQUEST['allaction'])) {
                 $message = 1;
             }
             elseif ($allaction == 'spl1all' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoStatus=WoStatus+1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoStatus in (1,2,3,4) and WoID = ' . $id, "");
+                $message = runsql('update words set WoStatus=WoStatus+1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoStatus in (1,2,3,4) and WoID = ' . $id, "");
             }
             elseif ($allaction == 'smi1all' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoStatus=WoStatus-1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoStatus in (2,3,4,5) and WoID = ' . $id, "");
+                $message = runsql('update words set WoStatus=WoStatus-1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoStatus in (2,3,4,5) and WoID = ' . $id, "");
             }
             elseif ($allaction == 's5all' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoStatus=5, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
+                $message = runsql('update words set WoStatus=5, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
             }
             elseif ($allaction == 's1all' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoStatus=1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
+                $message = runsql('update words set WoStatus=1, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
             }
             elseif ($allaction == 's99all' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoStatus=99, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
+                $message = runsql('update words set WoStatus=99, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
             }
             elseif ($allaction == 's98all' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoStatus=98, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
+                $message = runsql('update words set WoStatus=98, WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
             }
             elseif ($allaction == 'todayall' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
+                $message = runsql('update words set WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' where WoID = ' . $id, "");
             }
             elseif ($allaction == 'delsentall' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoSentence = NULL where WoID = ' . $id, "");
+                $message = runsql('update words set WoSentence = NULL where WoID = ' . $id, "");
             }
             elseif ($allaction == 'lowerall' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoText = WoTextLC where WoID = ' . $id, "");
+                $message = runsql('update words set WoText = WoTextLC where WoID = ' . $id, "");
             }
             elseif ($allaction == 'capall' ) {
-                $message = runsql('update ' . $tbpref . 'words set WoText = CONCAT(UPPER(LEFT(WoTextLC,1)),SUBSTRING(WoTextLC,2)) where WoID = ' . $id, "");
+                $message = runsql('update words set WoText = CONCAT(UPPER(LEFT(WoTextLC,1)),SUBSTRING(WoTextLC,2)) where WoID = ' . $id, "");
             }
             $cnt += (int)$message;
         }
@@ -280,7 +280,7 @@ if (isset($_REQUEST['allaction'])) {
         else if ($allaction == 'delall') {
             $message = "Deleted: $cnt Terms";
             adjust_autoincr('words', 'WoID');
-            runsql("DELETE " . $tbpref . "wordtags FROM (" . $tbpref . "wordtags LEFT JOIN " . $tbpref . "words on WtWoID = WoID) WHERE WoID IS NULL", '');
+            runsql("DELETE wordtags FROM (wordtags LEFT JOIN words on WtWoID = WoID) WHERE WoID IS NULL", '');
         }
         else {
             $message = "$cnt Terms changed";
@@ -289,33 +289,33 @@ if (isset($_REQUEST['allaction'])) {
 
     elseif ($allaction == 'expall' ) {
         if ($currenttext == '') {
-            anki_export('select distinct WoID, LgRightToLeft, LgRegexpWordCharacters, LgName, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages where WoLgID = LgID AND WoTranslation != \'*\' and WoSentence like concat(\'%{\',WoText,\'}%\') ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag);
+            anki_export('select distinct WoID, LgRightToLeft, LgRegexpWordCharacters, LgName, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages where WoLgID = LgID AND WoTranslation != \'*\' and WoSentence like concat(\'%{\',WoText,\'}%\') ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag);
         } else {
-            anki_export('select distinct WoID, LgRightToLeft, LgRegexpWordCharacters, LgName, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages, ' . $tbpref . 'textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . ' and WoLgID = LgID AND WoTranslation != \'*\' and WoSentence like concat(\'%{\',WoText,\'}%\') ' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag);
+            anki_export('select distinct WoID, LgRightToLeft, LgRegexpWordCharacters, LgName, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages, textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . ' and WoLgID = LgID AND WoTranslation != \'*\' and WoSentence like concat(\'%{\',WoText,\'}%\') ' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag);
         }
     }
     
     elseif ($allaction == 'expall2' ) {
         if ($currenttext == '') {
-            tsv_export('select distinct WoID, LgName, WoText, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages where WoLgID = LgID ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag);
+            tsv_export('select distinct WoID, LgName, WoText, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages where WoLgID = LgID ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag);
         } else {
-            tsv_export('select distinct WoID, LgName, WoText, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages, ' . $tbpref . 'textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . ' and WoLgID = LgID ' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag);
+            tsv_export('select distinct WoID, LgName, WoText, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages, textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . ' and WoLgID = LgID ' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag);
         }
     }
     
     elseif ($allaction == 'expall3' ) {
         if ($currenttext == '') {
-            flexible_export('select distinct WoID, LgName, LgExportTemplate, LgRightToLeft, WoText, WoTextLC, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages where WoLgID = LgID ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag);
+            flexible_export('select distinct WoID, LgName, LgExportTemplate, LgRightToLeft, WoText, WoTextLC, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages where WoLgID = LgID ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag);
         } else {
-            flexible_export('select distinct WoID, LgName, LgExportTemplate, LgRightToLeft, WoText, WoTextLC, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages, ' . $tbpref . 'textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . ' and WoLgID = LgID ' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag);
+            flexible_export('select distinct WoID, LgName, LgExportTemplate, LgRightToLeft, WoText, WoTextLC, WoTranslation, WoRomanization, WoSentence, WoStatus, ifnull(group_concat(distinct TgText order by TgText separator \' \'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages, textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . ' and WoLgID = LgID ' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag);
         }
     }
     
     elseif ($allaction == 'testall' ) {
         if ($currenttext == '') {
-            $sql = 'select distinct WoID from (' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) where (1=1) ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag;
+            $sql = 'select distinct WoID from (words left JOIN wordtags ON WoID = WtWoID) where (1=1) ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag;
         } else {
-            $sql = 'select distinct WoID from (' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID), ' . $tbpref . 'textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag;
+            $sql = 'select distinct WoID from (words left JOIN wordtags ON WoID = WtWoID), textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag;
         }
         $cnt = 0;
         $list = '(';
@@ -327,7 +327,7 @@ if (isset($_REQUEST['allaction'])) {
         }    
         $list .= ")";
         mysqli_free_result($res);
-        $_SESSION['testsql'] = ' ' . $tbpref . 'words where WoID in ' . $list . ' ';
+        $_SESSION['testsql'] = ' words where WoID in ' . $list . ' ';
         header("Location: do_test.php?selection=1");
         exit();
     }
@@ -337,11 +337,11 @@ if (isset($_REQUEST['allaction'])) {
 // DEL
 
 elseif (isset($_REQUEST['del'])) {
-    $message = runsql('delete from ' . $tbpref . 'words where WoID = ' . $_REQUEST['del'], "Deleted");
+    $message = runsql('delete from words where WoID = ' . $_REQUEST['del'], "Deleted");
     adjust_autoincr('words', 'WoID');
-    do_mysqli_query('update ' . $tbpref . 'textitems2 set Ti2WoID = 0 where Ti2WordCount = 1 and Ti2WoID = ' . $_REQUEST['del']);
-    do_mysqli_query('delete from ' . $tbpref . 'textitems2 where Ti2WoID  = ' . $_REQUEST['del']);
-    runsql("DELETE " . $tbpref . "wordtags FROM (" . $tbpref . "wordtags LEFT JOIN " . $tbpref . "words on WtWoID = WoID) WHERE WoID IS NULL", '');
+    do_mysqli_query('update textitems2 set Ti2WoID = 0 where Ti2WordCount = 1 and Ti2WoID = ' . $_REQUEST['del']);
+    do_mysqli_query('delete from textitems2 where Ti2WoID  = ' . $_REQUEST['del']);
+    runsql("DELETE wordtags FROM (wordtags LEFT JOIN words on WtWoID = WoID) WHERE WoID IS NULL", '');
 }
 
 // INS/UPD
@@ -359,7 +359,7 @@ elseif (isset($_REQUEST['op'])) {
     if ($_REQUEST['op'] == 'Save') {
     
         $message = runsql(
-            'insert into ' . $tbpref . 'words (WoLgID, WoTextLC, WoText, ' .
+            'insert into words (WoLgID, WoTextLC, WoText, ' .
             'WoStatus, WoTranslation, WoSentence, WoRomanization, WoStatusChanged,' .  make_score_random_insert_update('iv') . ') values( ' . 
             $_REQUEST["WoLgID"] . ', ' .
             convert_string_to_sqlsyntax(mb_strtolower($_REQUEST["WoText"], 'UTF-8')) . ', ' .
@@ -373,13 +373,13 @@ elseif (isset($_REQUEST['op'])) {
 
         $wid = get_last_key();
         init_word_count();
-        $len = get_first_value('select WoWordCount as value from ' . $tbpref . 'words where WoID = ' . $wid);
+        $len = get_first_value('select WoWordCount as value from words where WoID = ' . $wid);
         $textlc = mb_strtolower($_REQUEST["WoText"], 'UTF-8');
         if($len > 1) {
             insertExpressions($textlc, $_REQUEST["WoLgID"], $wid, $len, 1);
         }
         else {
-            do_mysqli_query('UPDATE ' . $tbpref . 'textitems2 SET Ti2WoID = ' . $wid . ' WHERE Ti2LgID = ' . $_REQUEST["WoLgID"] . ' AND LOWER(Ti2Text) = ' . convert_string_to_sqlsyntax_notrim_nonull($textlc));
+            do_mysqli_query('UPDATE textitems2 SET Ti2WoID = ' . $wid . ' WHERE Ti2LgID = ' . $_REQUEST["WoLgID"] . ' AND LOWER(Ti2Text) = ' . convert_string_to_sqlsyntax_notrim_nonull($textlc));
         }
     }    
     
@@ -395,7 +395,7 @@ elseif (isset($_REQUEST['op'])) {
         }
         $wid = (int)$_REQUEST["WoID"];
         $message = runsql(
-            'update ' . $tbpref . 'words set WoText = ' . 
+            'update words set WoText = ' . 
             convert_string_to_sqlsyntax($_REQUEST["WoText"]) . ', WoTextLC = ' . 
             convert_string_to_sqlsyntax(mb_strtolower($_REQUEST["WoText"], 'UTF-8')) . ', WoTranslation = ' . 
             convert_string_to_sqlsyntax($translation) . ', WoSentence = ' . 
@@ -475,7 +475,7 @@ if (isset($_REQUEST['new']) && isset($_REQUEST['lang'])) {
 
 elseif (isset($_REQUEST['chg'])) {
     
-    $sql = 'select * from ' . $tbpref . 'words, ' . $tbpref . 'languages where LgID = WoLgID and WoID = ' . $_REQUEST['chg'];
+    $sql = 'select * from words, languages where LgID = WoLgID and WoID = ' . $_REQUEST['chg'];
     $res = do_mysqli_query($sql);
     if ($record = mysqli_fetch_assoc($res)) {
         
@@ -560,9 +560,9 @@ else {
     echo error_message_with_hide($message, 0);
 
     if ($currenttext == '') {
-        $sql = 'select count(*) as value from (select WoID from (' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) where (1=1) ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag .') as dummy';
+        $sql = 'select count(*) as value from (select WoID from (words left JOIN wordtags ON WoID = WtWoID) where (1=1) ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag .') as dummy';
     } else {
-        $sql = 'select count(*) as value from (select WoID from (' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID), ' . $tbpref . 'textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag .') as dummy';
+        $sql = 'select count(*) as value from (select WoID from (words left JOIN wordtags ON WoID = WtWoID), textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ')' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag .') as dummy';
     }
     $recno = (int) get_first_value($sql);
     if ($debug) { 
@@ -737,21 +737,21 @@ if ($currentsort == 7) {
         $sql = ''; 
     }
     else {
-        $sql = 'select WoID, 0 AS textswordcount, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like concat(\'%{\',WoText,\'}%\') as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist, WoTextLC, WoTodayScore from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages where WoLgID = LgID and WoID NOT IN (SELECT DISTINCT Ti2WoID from ' . $tbpref . 'textitems2 where Ti2LgID = LgID) ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag . ' UNION '; 
+        $sql = 'select WoID, 0 AS textswordcount, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like concat(\'%{\',WoText,\'}%\') as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist, WoTextLC, WoTodayScore from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages where WoLgID = LgID and WoID NOT IN (SELECT DISTINCT Ti2WoID from textitems2 where Ti2LgID = LgID) ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag . ' UNION '; 
     }
-    $sql .= 'select WoID, count(WoID) AS textswordcount, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like concat(\'%{\',WoText,\'}%\') as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist, WoTextLC, WoTodayScore from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages, ' . $tbpref . 'textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and WoLgID = LgID ';
+    $sql .= 'select WoID, count(WoID) AS textswordcount, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like concat(\'%{\',WoText,\'}%\') as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist, WoTextLC, WoTodayScore from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages, textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and WoLgID = LgID ';
     if ($currenttext != '') { $sql .= 'and Ti2TxID in (' . $currenttext . ')' . ' '; 
     }
     $sql .= $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit;
 } else {
     if ($currenttext == '') {
         if($wh_tag=='') {
-            $sql = 'select WoID, WoText, WoTranslation, WoRomanization, WoSentence,  SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI,  Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist from (select WoID, WoTextLC, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like concat(\'%{\',WoText,\'}%\') as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore, WoTomorrowScore from ' . $tbpref . 'words, ' . $tbpref . 'languages where WoLgID = LgID ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID order by ' . $sorts[$currentsort-1] . ' ' . $limit . ') AS AA left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID left join ' . $tbpref . 'tags on TgID = WtTgID group by WoID order by ' . $sorts[$currentsort-1]; 
+            $sql = 'select WoID, WoText, WoTranslation, WoRomanization, WoSentence,  SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI,  Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist from (select WoID, WoTextLC, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like concat(\'%{\',WoText,\'}%\') as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore, WoTomorrowScore from words, languages where WoLgID = LgID ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID order by ' . $sorts[$currentsort-1] . ' ' . $limit . ') AS AA left JOIN wordtags ON WoID = WtWoID left join tags on TgID = WtTgID group by WoID order by ' . $sorts[$currentsort-1]; 
         } else { 
-            $sql = 'select WoID, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like concat(\'%{\',WoText,\'}%\') as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages where WoLgID = LgID ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit; 
+            $sql = 'select WoID, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like concat(\'%{\',WoText,\'}%\') as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages where WoLgID = LgID ' . $wh_lang . $wh_stat .  $wh_query . ' group by WoID ' . $wh_tag . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit; 
         }
     } else {
-        $sql = 'select distinct WoID, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like \'%{%}%\' as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist from ((' . $tbpref . 'words left JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) left join ' . $tbpref . 'tags on TgID = WtTgID), ' . $tbpref . 'languages, ' . $tbpref . 'textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ') and WoLgID = LgID ' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit;
+        $sql = 'select distinct WoID, WoText, WoTranslation, WoRomanization, WoSentence, ifnull(WoSentence,\'\') like \'%{%}%\' as SentOK, WoStatus, LgName, LgRightToLeft, LgGoogleTranslateURI, DATEDIFF( NOW( ) , WoStatusChanged ) AS Days, WoTodayScore AS Score, WoTomorrowScore AS Score2, ifnull(concat(\'[\',group_concat(distinct TgText order by TgText separator \', \'),\']\'),\'\') as taglist from ((words left JOIN wordtags ON WoID = WtWoID) left join tags on TgID = WtTgID), languages, textitems2 where Ti2LgID = WoLgID and Ti2WoID = WoID and Ti2TxID in (' . $currenttext . ') and WoLgID = LgID ' . $wh_lang . $wh_stat . $wh_query . ' group by WoID ' . $wh_tag . ' order by ' . $sorts[$currentsort-1] . ' ' . $limit;
     }
 }
 

--- a/feed_wizard.php
+++ b/feed_wizard.php
@@ -22,7 +22,7 @@ function feed_wizard_edit_options()
         
     $result = do_mysqli_query(
         "SELECT LgName, LgID 
-        FROM " . $tbpref . "languages 
+        FROM languages 
         WHERE LgName<>'' 
         ORDER BY LgName"
     );
@@ -510,7 +510,7 @@ function feed_wizard_select_text()
         $_SESSION['wizard']['edit_feed']=$_REQUEST['edit_feed'];
         $result = do_mysqli_query(
             "SELECT * 
-            FROM " . $tbpref . "newsfeeds 
+            FROM newsfeeds 
             WHERE NfID=".$_REQUEST['edit_feed']
         );
         $row = mysqli_fetch_assoc($result);

--- a/feed_wizard.php
+++ b/feed_wizard.php
@@ -5,7 +5,7 @@ require_once 'inc/session_utility.php';
 
 function feed_wizard_edit_options()
 {
-    global $tbpref;
+
     pagestart('Feed Wizard', false);
     if(isset($_REQUEST['filter_tags'])) { 
         $_SESSION['wizard']['filter_tags']=$_REQUEST['filter_tags']; 
@@ -505,7 +505,7 @@ function feed_wizard_filter_text()
 
 function feed_wizard_select_text()
 {
-    global $tbpref;
+
     if(isset($_REQUEST['edit_feed']) && !isset($_SESSION['wizard'])) {
         $_SESSION['wizard']['edit_feed']=$_REQUEST['edit_feed'];
         $result = do_mysqli_query(

--- a/inc/ajax_add_term_transl.php
+++ b/inc/ajax_add_term_transl.php
@@ -30,7 +30,7 @@ function add_new_term_transl($text, $lang, $data)
     global $tbpref;
     $textlc = mb_strtolower($text, 'UTF-8');
     $dummy = runsql(
-        'INSERT INTO ' . $tbpref . 'words (
+        'INSERT INTO words (
             WoLgID, WoTextLC, WoText, WoStatus, WoTranslation, 
             WoSentence, WoRomanization, WoStatusChanged, 
             ' .  make_score_random_insert_update('iv') . '
@@ -48,7 +48,7 @@ function add_new_term_transl($text, $lang, $data)
     }
     $wid = get_last_key();
     do_mysqli_query(
-        'UPDATE ' . $tbpref . 'textitems2 
+        'UPDATE textitems2 
         SET Ti2WoID = ' . $wid . ' 
         WHERE Ti2LgID = ' . $lang . ' AND LOWER(Ti2Text) =' . convert_string_to_sqlsyntax_notrim_nonull($textlc)
     );
@@ -70,7 +70,7 @@ function edit_term_transl($wid, $new_trans)
     global $tbpref;
     $oldtrans = get_first_value(
         "SELECT WoTranslation AS value 
-        FROM " . $tbpref . "words 
+        FROM words 
         WHERE WoID = " . $wid
     );
     
@@ -84,14 +84,14 @@ function edit_term_transl($wid, $new_trans)
             $oldtrans .= ' ' . get_first_sepa() . ' ' . $new_trans;
         }
         runsql(
-            'UPDATE ' . $tbpref . 'words 
+            'UPDATE words 
             SET WoTranslation = ' . convert_string_to_sqlsyntax($oldtrans) . ' 
             WHERE WoID = ' . $wid, ""
         );
     }
     return get_first_value(
         "SELECT WoTextLC AS value 
-        FROM " . $tbpref . "words 
+        FROM words 
         WHERE WoID = " . $wid
     );
 }
@@ -125,7 +125,7 @@ function do_ajax_add_term_transl($wid, $data)
     } else {
         $cnt_words = (int)get_first_value(
             "SELECT COUNT(WoID) AS value 
-            FROM " . $tbpref . "words 
+            FROM words 
             WHERE WoID = " . $wid
         );
         if ($cnt_words == 1) {

--- a/inc/ajax_add_term_transl.php
+++ b/inc/ajax_add_term_transl.php
@@ -23,11 +23,11 @@ require_once __DIR__ . '/session_utility.php';
  * 
  * @return string Error message if failure, lowercase $text otherwise
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function add_new_term_transl($text, $lang, $data) 
 {
-    global $tbpref;
+
     $textlc = mb_strtolower($text, 'UTF-8');
     $dummy = runsql(
         'INSERT INTO words (
@@ -63,11 +63,11 @@ function add_new_term_transl($text, $lang, $data)
  * 
  * @return string WoTextLC, lower version of the word
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function edit_term_transl($wid, $new_trans)
 {
-    global $tbpref;
+
     $oldtrans = get_first_value(
         "SELECT WoTranslation AS value 
         FROM words 
@@ -104,11 +104,11 @@ function edit_term_transl($wid, $new_trans)
  * 
  * @return string Database alteration message
  * 
- * @global string $tbpref
+ *
  */
 function do_ajax_add_term_transl($wid, $data)
 {
-    global $tbpref;
+
     chdir('..');
     /// Save data
     $success = "";

--- a/inc/ajax_chg_term_status.php
+++ b/inc/ajax_chg_term_status.php
@@ -58,12 +58,12 @@ function update_word_status($wid, $currstatus)
     global $tbpref;
     if (($currstatus >= 1 && $currstatus <= 5) || $currstatus == 99 || $currstatus == 98) {
         $m1 = (int)runsql(
-            'UPDATE ' . $tbpref . 'words 
+            'UPDATE words 
             SET WoStatus = ' . $currstatus . ', WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . '
             WHERE WoID = ' . $wid, ''
         );
         if ($m1 == 1) {
-            $currstatus = get_first_value('SELECT WoStatus as value FROM ' . $tbpref . 'words where WoID = ' . $wid);
+            $currstatus = get_first_value('SELECT WoStatus as value FROM words where WoID = ' . $wid);
             if (!isset($currstatus)) {
                 return null;
             }
@@ -91,7 +91,7 @@ function do_ajax_chg_term_status($wid, $up)
 
     $tempstatus = get_first_value(
         'SELECT WoStatus as value 
-        FROM ' . $tbpref . 'words 
+        FROM words 
         WHERE WoID = ' . $wid
     );
     if (!isset($tempstatus)) {

--- a/inc/ajax_chg_term_status.php
+++ b/inc/ajax_chg_term_status.php
@@ -51,11 +51,11 @@ function get_new_status($oldstatus, $up)
  * 
  * @return string|null HTML-formatted string with plus/minus controls if a success. 
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function update_word_status($wid, $currstatus)
 {
-    global $tbpref;
+
     if (($currstatus >= 1 && $currstatus <= 5) || $currstatus == 99 || $currstatus == 98) {
         $m1 = (int)runsql(
             'UPDATE words 
@@ -82,11 +82,11 @@ function update_word_status($wid, $currstatus)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function do_ajax_chg_term_status($wid, $up)
 {
-    global $tbpref;
+
     chdir('..');
 
     $tempstatus = get_first_value(

--- a/inc/ajax_edit_impr_text.php
+++ b/inc/ajax_edit_impr_text.php
@@ -28,7 +28,7 @@ require_once __DIR__ . '/session_utility.php';
  */
 function make_trans($i, $wid, $trans, $word, $lang): string 
 {
-    global $tbpref;    
+
     $trans = trim($trans);
     $widset = is_numeric($wid);
     if ($widset) {
@@ -102,11 +102,11 @@ function make_trans($i, $wid, $trans, $word, $lang): string
  * 
  * @return string[] $r and $rr.
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function make_form($textid, $wordlc)
 { 
-    global $tbpref;
+
     $sql = 'SELECT TxLgID, TxAnnotatedText FROM texts WHERE TxID = ' . $textid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);

--- a/inc/ajax_edit_impr_text.php
+++ b/inc/ajax_edit_impr_text.php
@@ -32,7 +32,7 @@ function make_trans($i, $wid, $trans, $word, $lang): string
     $trans = trim($trans);
     $widset = is_numeric($wid);
     if ($widset) {
-        $alltrans = get_first_value("SELECT WoTranslation AS value FROM " . $tbpref . "words WHERE WoID = " . $wid);
+        $alltrans = get_first_value("SELECT WoTranslation AS value FROM words WHERE WoID = " . $wid);
         $transarr = preg_split('/[' . get_sepas()  . ']/u', $alltrans);
         $r = "";
         $set = false;
@@ -107,7 +107,7 @@ function make_trans($i, $wid, $trans, $word, $lang): string
 function make_form($textid, $wordlc)
 { 
     global $tbpref;
-    $sql = 'SELECT TxLgID, TxAnnotatedText FROM ' . $tbpref . 'texts WHERE TxID = ' . $textid;
+    $sql = 'SELECT TxLgID, TxAnnotatedText FROM texts WHERE TxID = ' . $textid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $langid = $record['TxLgID'];
@@ -117,7 +117,7 @@ function make_form($textid, $wordlc)
     }
     mysqli_free_result($res);
     
-    $sql = 'SELECT LgTextSize, LgRightToLeft FROM ' . $tbpref . 'languages WHERE LgID = ' . $langid;
+    $sql = 'SELECT LgTextSize, LgRightToLeft FROM languages WHERE LgID = ' . $langid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $textsize = (int)$record['LgTextSize'];
@@ -166,7 +166,7 @@ function make_form($textid, $wordlc)
                 if (is_numeric($wid)) {
                     $temp_wid = (int)get_first_value(
                         "SELECT COUNT(WoID) AS value 
-                        FROM " . $tbpref . "words 
+                        FROM words 
                         WHERE WoID = ". $wid
                     );
                     if ($temp_wid < 1) { 

--- a/inc/ajax_load_feed.php
+++ b/inc/ajax_load_feed.php
@@ -36,7 +36,7 @@ function get_feeds_list($feed, $nfid)
         $d_feed=convert_string_to_sqlsyntax($nfid);
         $valuesArr[] = "($d_title,$d_link,$d_text,$d_desc,$d_date,$d_audio,$d_feed)";
     }
-    $sql = 'INSERT IGNORE INTO ' . $tbpref . 'feedlinks (FlTitle,FlLink,FlText,FlDescription,FlDate,FlAudio,FlNfID) 
+    $sql = 'INSERT IGNORE INTO feedlinks (FlTitle,FlLink,FlText,FlDescription,FlDate,FlAudio,FlNfID) 
     VALUES ' . implode(',', $valuesArr);
     do_mysqli_query($sql);
     $imported_feed = mysqli_affected_rows($GLOBALS["DBCONNECTION"]);
@@ -62,7 +62,7 @@ function print_feed_result($imported_feed, $nif, $nfname, $nfid, $nfoptions)
 {
     global $tbpref;
     do_mysqli_query(
-        'UPDATE ' . $tbpref . 'newsfeeds 
+        'UPDATE newsfeeds 
         SET NfUpdate="' . time() . '" 
         WHERE NfID=' . $nfid
     );
@@ -92,14 +92,14 @@ function print_feed_result($imported_feed, $nif, $nfname, $nfid, $nfoptions)
     }
     $result=do_mysqli_query(
         "SELECT COUNT(*) AS total 
-        FROM " . $tbpref . "feedlinks 
+        FROM feedlinks 
         WHERE FlNfID IN (".$nfid.")"
     );
     $row = mysqli_fetch_assoc($result);
     $to = ($row['total'] - $nf_max_links);
     if ($to>0) {
         do_mysqli_query(
-            "DELETE FROM " . $tbpref . "feedlinks 
+            "DELETE FROM feedlinks 
             WHERE FlNfID in (".$nfid.") 
             ORDER BY FlDate 
             LIMIT $to"

--- a/inc/ajax_load_feed.php
+++ b/inc/ajax_load_feed.php
@@ -20,11 +20,11 @@ require_once __DIR__ . '/session_utility.php';
  * 
  * @return array{0: string|int, 1: int} Number of imported feeds and number of duplicated feeds.
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function get_feeds_list($feed, $nfid)
 {
-    global $tbpref;
+
     $valuesArr = array();
     foreach ($feed as $data) {
         $d_title=convert_string_to_sqlsyntax($data['title']);
@@ -56,11 +56,11 @@ function get_feeds_list($feed, $nfid)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function print_feed_result($imported_feed, $nif, $nfname, $nfid, $nfoptions)
 {
-    global $tbpref;
+
     do_mysqli_query(
         'UPDATE newsfeeds 
         SET NfUpdate="' . time() . '" 

--- a/inc/ajax_save_impr_text.php
+++ b/inc/ajax_save_impr_text.php
@@ -23,11 +23,11 @@ require_once __DIR__ . '/session_utility.php';
  * 
  * @return string Success string
  * 
- * @global string $tbpref Database table prefix.
+ *
  */
 function save_impr_text_data($textid, $line, $val)
 {
-    global $tbpref;
+
     $success = "NOTOK";
     $ann = get_first_value(
         "SELECT TxAnnotatedText AS value 

--- a/inc/ajax_save_impr_text.php
+++ b/inc/ajax_save_impr_text.php
@@ -31,7 +31,7 @@ function save_impr_text_data($textid, $line, $val)
     $success = "NOTOK";
     $ann = get_first_value(
         "SELECT TxAnnotatedText AS value 
-        FROM " . $tbpref . "texts 
+        FROM texts 
         WHERE TxID = " . $textid
     );
     $items = preg_split('/[\n]/u', $ann);
@@ -41,7 +41,7 @@ function save_impr_text_data($textid, $line, $val)
             $vals[3] = $val;
             $items[$line-1] = implode("\t", $vals);
             runsql(
-                'UPDATE ' . $tbpref . 'texts 
+                'UPDATE texts 
                 SET TxAnnotatedText = ' . convert_string_to_sqlsyntax(implode("\n", $items)) . ' 
                 WHERE TxID = ' . $textid, ""
             );

--- a/inc/ajax_save_text_position.php
+++ b/inc/ajax_save_text_position.php
@@ -25,11 +25,11 @@ require_once __DIR__ . '/session_utility.php';
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function save_text_position($textid, $position)
 {
-    global $tbpref;
+
     runsql(
         'UPDATE texts 
         SET TxPosition = ' . $position . ' 
@@ -46,11 +46,11 @@ function save_text_position($textid, $position)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function save_audio_position($textid, $audioposition) 
 {
-    global $tbpref;
+
     runsql(
         'UPDATE texts 
         SET TxAudioPosition = ' . $audioposition . ' 

--- a/inc/ajax_save_text_position.php
+++ b/inc/ajax_save_text_position.php
@@ -31,7 +31,7 @@ function save_text_position($textid, $position)
 {
     global $tbpref;
     runsql(
-        'UPDATE ' . $tbpref . 'texts 
+        'UPDATE texts 
         SET TxPosition = ' . $position . ' 
         WHERE TxID = ' . $textid, 
         ""
@@ -52,7 +52,7 @@ function save_audio_position($textid, $audioposition)
 {
     global $tbpref;
     runsql(
-        'UPDATE ' . $tbpref . 'texts 
+        'UPDATE texts 
         SET TxAudioPosition = ' . $audioposition . ' 
         WHERE TxID = ' . $textid, 
         ""

--- a/inc/ajax_show_imported_terms.php
+++ b/inc/ajax_show_imported_terms.php
@@ -123,8 +123,8 @@ function show_imported_terms($last_update, $limit, $rtl)
         ), \'\'
     ) AS taglist 
     FROM (
-        (' . $tbpref . 'words LEFT JOIN ' . $tbpref . 'wordtags ON WoID = WtWoID) 
-        LEFT JOIN ' . $tbpref . 'tags ON TgID = WtTgID
+        (words LEFT JOIN wordtags ON WoID = WtWoID) 
+        LEFT JOIN tags ON TgID = WtTgID
     ) 
     WHERE WoStatusChanged > ' . convert_string_to_sqlsyntax($last_update) . ' 
     GROUP BY WoID ' . $limit;

--- a/inc/ajax_show_imported_terms.php
+++ b/inc/ajax_show_imported_terms.php
@@ -102,7 +102,7 @@ function get_imported_terms($recno, $currentpage, $last_update)
  */
 function show_imported_terms($last_update, $limit, $rtl)
 {
-    global $tbpref;
+
     echo '<table class="sortable tab1"  cellspacing="0" cellpadding="5">
     <tr>';
     ?>

--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -197,7 +197,7 @@ function validateLang($currentlang): string
         return '';
     }
     $sql_string = 'SELECT count(LgID) AS value 
-    FROM ' . $tbpref . 'languages 
+    FROM languages 
     WHERE LgID=' . $currentlang;
     if (get_first_value($sql_string) == 0) {  
         return ''; 
@@ -221,7 +221,7 @@ function validateText($currenttext): string
         return '';
     }
     $sql_string = 'SELECT count(TxID) AS value 
-    FROM ' . $tbpref . 'texts WHERE TxID=' . 
+    FROM texts WHERE TxID=' . 
     $currenttext;
     if (get_first_value($sql_string) == 0) {  
         return ''; 
@@ -238,17 +238,17 @@ function validateTag($currenttag,$currentlang)
         $sql = "SELECT (
             " . $currenttag . " IN (
                 SELECT TgID 
-                FROM " . $tbpref . "words, " . $tbpref . "tags, " . $tbpref . "wordtags 
+                FROM words, tags, wordtags 
                 WHERE TgID = WtTgID AND WtWoID = WoID" . 
                 ($currentlang != '' ? " AND WoLgID = " . $currentlang : '') .
                 " group by TgID order by TgText
             )
         ) AS value";
         /*if ($currentlang == '') {
-            $sql = "select (" . $currenttag . " in (select TgID from " . $tbpref . "words, " . $tbpref . "tags, " . $tbpref . "wordtags where TgID = WtTgID and WtWoID = WoID group by TgID order by TgText)) as value"; 
+            $sql = "select (" . $currenttag . " in (select TgID from words, tags, wordtags where TgID = WtTgID and WtWoID = WoID group by TgID order by TgText)) as value"; 
         }
         else {
-            $sql = "select (" . $currenttag . " in (select TgID from " . $tbpref . "words, " . $tbpref . "tags, " . $tbpref . "wordtags where TgID = WtTgID and WtWoID = WoID and WoLgID = " . $currentlang . " group by TgID order by TgText)) as value"; 
+            $sql = "select (" . $currenttag . " in (select TgID from words, tags, wordtags where TgID = WtTgID and WtWoID = WoID and WoLgID = " . $currentlang . " group by TgID order by TgText)) as value"; 
         }*/
         $r = get_first_value($sql);
         if ($r == 0) { 
@@ -268,9 +268,9 @@ function validateArchTextTag($currenttag,$currentlang)
             $sql = "select (
                 " . $currenttag . " in (
                     select T2ID 
-                    from " . $tbpref . "archivedtexts, 
-                    " . $tbpref . "tags2, 
-                    " . $tbpref . "archtexttags 
+                    from archivedtexts, 
+                    tags2, 
+                    archtexttags 
                     where T2ID = AgT2ID and AgAtID = AtID 
                     group by T2ID order by T2Text
                 )
@@ -280,9 +280,9 @@ function validateArchTextTag($currenttag,$currentlang)
             $sql = "select (
                 " . $currenttag . " in (
                     select T2ID 
-                    from " . $tbpref . "archivedtexts, 
-                    " . $tbpref . "tags2, 
-                    " . $tbpref . "archtexttags 
+                    from archivedtexts, 
+                    tags2, 
+                    archtexttags 
                     where T2ID = AgT2ID and AgAtID = AtID and AtLgID = " . $currentlang . " 
                     group by T2ID order by T2Text
                 )
@@ -306,9 +306,9 @@ function validateTextTag($currenttag,$currentlang)
             $sql = "select (
                 " . $currenttag . " in (
                     select T2ID 
-                    from " . $tbpref . "texts, 
-                    " . $tbpref . "tags2, 
-                    " . $tbpref . "texttags 
+                    from texts, 
+                    tags2, 
+                    texttags 
                     where T2ID = TtT2ID and TtTxID = TxID 
                     group by T2ID 
                     order by T2Text
@@ -319,9 +319,9 @@ function validateTextTag($currenttag,$currentlang)
             $sql = "select (
                 " . $currenttag . " in (
                     select T2ID 
-                    from " . $tbpref . "texts, 
-                    " . $tbpref . "tags2, 
-                    " . $tbpref . "texttags 
+                    from texts, 
+                    tags2, 
+                    texttags 
                     where T2ID = TtT2ID and TtTxID = TxID and TxLgID = " . $currentlang . " 
                     group by T2ID order by T2Text
                 )
@@ -365,7 +365,7 @@ function getSetting($key)
     global $tbpref;
     $val = get_first_value(
         'SELECT StValue AS value 
-        FROM ' . $tbpref . 'settings 
+        FROM settings 
         WHERE StKey = ' . convert_string_to_sqlsyntax($key)
     );
     if (isset($val)) {
@@ -398,7 +398,7 @@ function getSettingWithDefault($key)
     $dft = get_setting_data();
     $val = get_first_value(
         'SELECT StValue AS value
-         FROM ' . $tbpref . 'settings
+         FROM settings
          WHERE StKey = ' . convert_string_to_sqlsyntax($key)
     );
     if (isset($val) && $val != '') {
@@ -432,7 +432,7 @@ function saveSetting($k, $v)
         return '';
     }
     runsql(
-        'DELETE FROM ' . $tbpref . 'settings 
+        'DELETE FROM settings 
         WHERE StKey = ' . convert_string_to_sqlsyntax($k), 
         ''
     );
@@ -446,7 +446,7 @@ function saveSetting($k, $v)
         }
     }
     $dum = runsql(
-        'INSERT INTO ' . $tbpref . 'settings (StKey, StValue) values(' .
+        'INSERT INTO settings (StKey, StValue) values(' .
         convert_string_to_sqlsyntax($k) . ', ' . 
         convert_string_to_sqlsyntax($v) . ')', 
         ''
@@ -574,7 +574,7 @@ function update_japanese_word_count($japid)
     $mecab_args = ' -F %m%t\\t -U %m%t\\t -E \\n ';
     $mecab = get_mecab_path($mecab_args);
 
-    $sql = "SELECT WoID, WoTextLC FROM {$tbpref}words 
+    $sql = "SELECT WoID, WoTextLC FROM words 
     WHERE WoLgID = $japid AND WoWordCount = 0";
     $res = do_mysqli_query($sql);
     $fp = fopen($db_to_mecab, 'w');
@@ -627,7 +627,7 @@ function update_japanese_word_count($japid)
     
     do_mysqli_query($sql);
     do_mysqli_query(
-        "UPDATE {$tbpref}words 
+        "UPDATE words 
         JOIN {$tbpref}mecab ON MID = WoID 
         SET WoWordCount = MWordCount"
     );
@@ -656,7 +656,7 @@ function init_word_count(): void
      */
     $japid = get_first_value(
         "SELECT group_concat(LgID) value 
-        FROM {$tbpref}languages 
+        FROM languages 
         WHERE UPPER(LgRegexpWordCharacters)='MECAB'"
     );
 
@@ -664,7 +664,7 @@ function init_word_count(): void
         update_japanese_word_count((int)$japid);
     }
     $sql = "SELECT WoID, WoTextLC, LgRegexpWordCharacters, LgSplitEachChar 
-    FROM {$tbpref}words, {$tbpref}languages 
+    FROM words, languages 
     WHERE WoWordCount = 0 AND WoLgID = LgID 
     ORDER BY WoID";
     $result = do_mysqli_query($sql);
@@ -680,7 +680,7 @@ function init_word_count(): void
         );
         if (++$i % 1000 == 0) {
             $max = $rec['WoID'];
-            $sqltext = "UPDATE  {$tbpref}words 
+            $sqltext = "UPDATE  words 
             SET WoWordCount = CASE WoID" . implode(' ', $sqlarr) . "
             END 
             WHERE WoWordCount=0 AND WoID BETWEEN $min AND $max";
@@ -691,7 +691,7 @@ function init_word_count(): void
     }
     mysqli_free_result($result);
     if (!empty($sqlarr)) {
-        $sqltext = "UPDATE  " . $tbpref . "words 
+        $sqltext = "UPDATE  words 
         SET WoWordCount = CASE WoID" . implode(' ', $sqlarr) . ' 
         END where WoWordCount=0';
         do_mysqli_query($sqltext);
@@ -754,7 +754,7 @@ function parse_japanese_text($text, $id)
     pclose($handle);
 
     runsql(
-        "CREATE TEMPORARY TABLE IF NOT EXISTS {$tbpref}temptextitems2 (
+        "CREATE TEMPORARY TABLE IF NOT EXISTS temptextitems2 (
             TiCount smallint(5) unsigned NOT NULL,
             TiSeID mediumint(8) unsigned NOT NULL,
             TiOrder smallint(5) unsigned NOT NULL,
@@ -770,14 +770,14 @@ function parse_japanese_text($text, $id)
             "SET @order:=0, @term_type:=0,
             @sid:=" . (
                 $id>0 ?
-                "(SELECT ifnull(max(`SeID`)+1,1) FROM `{$tbpref}sentences`)" 
+                "(SELECT ifnull(max(`SeID`)+1,1) FROM `sentences`)" 
                 : 1 
             ) . ", @count:=0,@last_term_type:=0;"
         );
         
         $sql = 
         "LOAD DATA LOCAL INFILE " . convert_string_to_sqlsyntax($file_name) . "
-        INTO TABLE {$tbpref}temptextitems2
+        INTO TABLE temptextitems2
         FIELDS TERMINATED BY '\\t' 
         LINES TERMINATED BY '" . PHP_EOL . "' 
         (@term, @node_type, @third)
@@ -806,7 +806,7 @@ function parse_japanese_text($text, $id)
             ELSE 0 
         END";
         do_mysqli_query($sql);
-        do_mysqli_query("DELETE FROM {$tbpref}temptextitems2 WHERE TiOrder=@order");
+        do_mysqli_query("DELETE FROM temptextitems2 WHERE TiOrder=@order");
     } else {
         $handle = fopen($file_name, 'r');
         $mecabed = fread($handle, filesize($file_name));
@@ -817,7 +817,7 @@ function parse_japanese_text($text, $id)
         if ($id > 0) {
             $sid = (int)get_first_value(
                 "SELECT IFNULL(MAX(`SeID`)+1,1) as value 
-                FROM {$tbpref}sentences"
+                FROM sentences"
             );
         }
         $term_type = 0;
@@ -850,23 +850,23 @@ function parse_japanese_text($text, $id)
             $values[] = "(" . implode(",", $row) . ")";
         }
         do_mysqli_query(
-            "INSERT INTO {$tbpref}temptextitems2 (
+            "INSERT INTO temptextitems2 (
                 TiSeID, TiCount, TiOrder, TiText, TiWordCount
             ) VALUES " . implode(',', $values)
         );
         // Delete elements TiOrder=@order
-        do_mysqli_query("DELETE FROM {$tbpref}temptextitems2 WHERE TiOrder=$order");
+        do_mysqli_query("DELETE FROM temptextitems2 WHERE TiOrder=$order");
     }
     do_mysqli_query(
-        "INSERT INTO {$tbpref}temptextitems (
+        "INSERT INTO temptextitems (
             TiCount, TiSeID, TiOrder, TiWordCount, TiText
         ) 
         SELECT MIN(TiCount) s, TiSeID, TiOrder, TiWordCount, 
         group_concat(TiText ORDER BY TiCount SEPARATOR '')
-        FROM {$tbpref}temptextitems2
+        FROM temptextitems2
         GROUP BY TiOrder"
     );
-    do_mysqli_query("DROP TABLE {$tbpref}temptextitems2");
+    do_mysqli_query("DROP TABLE temptextitems2");
     unlink($file_name);
 }
 
@@ -886,7 +886,7 @@ function parse_japanese_text($text, $id)
 function parse_standard_text($text, $id, $lid)
 {
     global $tbpref;
-    $sql = "SELECT * FROM {$tbpref}languages WHERE LgID=$lid";
+    $sql = "SELECT * FROM languages WHERE LgID=$lid";
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $removeSpaces = $record['LgRemoveSpaces'];
@@ -972,11 +972,11 @@ function parse_standard_text($text, $id, $lid)
         do_mysqli_query(
             "SET @order=0, 
             @sid=" . (
-                $id>0?"(SELECT ifnull(max(`SeID`)+1,1) FROM `{$tbpref}sentences`)" : 1) . 
+                $id>0?"(SELECT ifnull(max(`SeID`)+1,1) FROM `sentences`)" : 1) . 
             ", @count = 0;"
         );
         $sql = "LOAD DATA LOCAL INFILE " . convert_string_to_sqlsyntax($file_name) . "
-        INTO TABLE {$tbpref}temptextitems 
+        INTO TABLE temptextitems 
         FIELDS TERMINATED BY '\\t' LINES TERMINATED BY '\\n' (@word_count, @term)
         SET 
             TiSeID = @sid, 
@@ -1003,7 +1003,7 @@ function parse_standard_text($text, $id, $lid)
         if ($id > 0) {
             $sid = (int)get_first_value(
                 "SELECT IFNULL(MAX(`SeID`)+1,1) as value 
-                FROM {$tbpref}sentences"
+                FROM sentences"
             );
         }
         $count = 0;
@@ -1024,7 +1024,7 @@ function parse_standard_text($text, $id, $lid)
             $values[] = "(" . implode(",", $row) . ")";
         }
         do_mysqli_query(
-            "INSERT INTO {$tbpref}temptextitems (
+            "INSERT INTO temptextitems (
                 TiSeID, TiCount, TiOrder, TiText, TiWordCount
             ) VALUES " . implode(',', $values)
         );
@@ -1046,7 +1046,7 @@ function parse_standard_text($text, $id, $lid)
 function prepare_text_parsing($text, $id, $lid)
 {
     global $tbpref;
-    $sql = "SELECT * FROM " . $tbpref . "languages WHERE LgID=" . $lid;
+    $sql = "SELECT * FROM languages WHERE LgID=" . $lid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $termchar = $record['LgRegexpWordCharacters'];
@@ -1054,7 +1054,7 @@ function prepare_text_parsing($text, $id, $lid)
     mysqli_free_result($res);
     $text = prepare_textdata($text);
     //if(is_callable('normalizer_normalize')) $s = normalizer_normalize($s);
-    do_mysqli_query('TRUNCATE TABLE ' . $tbpref . 'temptextitems');
+    do_mysqli_query('TRUNCATE TABLE temptextitems');
 
     // because of sentence special characters
     $text = str_replace(array('}','{'), array(']','['), $text);    
@@ -1084,7 +1084,7 @@ function check_text_valid($lid)
     $wo = $nw = array();
     $res = do_mysqli_query(
         'SELECT GROUP_CONCAT(TiText order by TiOrder SEPARATOR "") 
-        Sent FROM ' . $tbpref . 'temptextitems group by TiSeID'
+        Sent FROM temptextitems group by TiSeID'
     );
     echo '<h4>Sentences</h4><ol>';
     while($record = mysqli_fetch_assoc($res)){
@@ -1095,8 +1095,8 @@ function check_text_valid($lid)
     $res = do_mysqli_query(
         'SELECT count(`TiOrder`) cnt, if(0=TiWordCount,0,1) as len, 
         LOWER(TiText) as word, WoTranslation 
-        FROM ' . $tbpref . 'temptextitems 
-        LEFT JOIN ' . $tbpref . 'words ON lower(TiText)=WoTextLC AND WoLgID=' . $lid . ' 
+        FROM temptextitems 
+        LEFT JOIN words ON lower(TiText)=WoTextLC AND WoLgID=' . $lid . ' 
         GROUP BY lower(TiText)'
     );
     while ($record = mysqli_fetch_assoc($res)) {
@@ -1133,43 +1133,43 @@ function update_default_values($id, $lid, $sql)
 {
     global $tbpref;
     do_mysqli_query(
-        'ALTER TABLE ' . $tbpref . 'textitems2 
+        'ALTER TABLE textitems2 
         ALTER Ti2LgID SET DEFAULT ' . $lid . ', 
         ALTER Ti2TxID SET DEFAULT ' . $id
     );
     do_mysqli_query(
-        'INSERT INTO ' . $tbpref . 'textitems2 (
+        'INSERT INTO textitems2 (
             Ti2WoID, Ti2SeID, Ti2Order, Ti2WordCount, Ti2Text
         ) ' . $sql . '
         select  WoID, TiSeID, TiOrder, TiWordCount, TiText 
-        FROM ' . $tbpref . 'temptextitems 
-        left join ' . $tbpref . 'words 
+        FROM temptextitems 
+        left join words 
         on lower(TiText) = WoTextLC and TiWordCount=1 and WoLgID = ' . $lid . ' 
         order by TiOrder,TiWordCount'
     );
     do_mysqli_query(
-        'ALTER TABLE ' . $tbpref . 'sentences 
+        'ALTER TABLE sentences 
         ALTER SeLgID SET DEFAULT ' . $lid . ', 
         ALTER SeTxID SET DEFAULT ' . $id
     );
     do_mysqli_query('set @a=0;');
     do_mysqli_query(
-        'INSERT INTO ' . $tbpref . 'sentences (
+        'INSERT INTO sentences (
             SeOrder, SeFirstPos, SeText
         ) SELECT 
         @a:=@a+1, 
         min(if(TiWordCount=0,TiOrder+1,TiOrder)),
         GROUP_CONCAT(TiText order by TiOrder SEPARATOR "") 
-        FROM ' . $tbpref . 'temptextitems 
+        FROM temptextitems 
         group by TiSeID'
     );
     do_mysqli_query(
-        'ALTER TABLE ' . $tbpref . 'textitems2 
+        'ALTER TABLE textitems2 
         ALTER Ti2LgID DROP DEFAULT, 
         ALTER Ti2TxID DROP DEFAULT'
     );
     do_mysqli_query(
-        'ALTER TABLE ' . $tbpref . 'sentences 
+        'ALTER TABLE sentences 
         ALTER SeLgID DROP DEFAULT, 
         ALTER SeTxID DROP DEFAULT'
     );
@@ -1316,9 +1316,9 @@ function check_text_with_expressions($id, $lid, $wl, $wl_max, $mw_sql)
         ) word,
         if(@d=0 or ""=@z, NULL, lower(@z)) lword, 
         TiOrder,
-        n FROM ' . $tbpref . 'numbers , ' . $tbpref . 'temptextitems
+        n FROM ' . $tbpref . 'numbers , temptextitems
     ) ti, 
-    ' . $tbpref . 'words 
+    words 
     WHERE lword IS NOT NULL AND WoLgID=' . $lid . ' AND 
     WoTextLC=lword AND WoWordCount=n';
     $sql .= ($id>0) ? ' UNION ALL ' : ' GROUP BY WoID ORDER BY WoTextLC';
@@ -1347,7 +1347,7 @@ function splitCheckText($text, $lid, $id)
     $wl = array();
     $wl_max = 0;
     $mw_sql = '';
-    $sql = "SELECT LgRightToLeft FROM {$tbpref}languages WHERE LgID=$lid";
+    $sql = "SELECT LgRightToLeft FROM languages WHERE LgID=$lid";
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     // Just checking if LgID exists with ID should be enough
@@ -1377,7 +1377,7 @@ function splitCheckText($text, $lid, $id)
 
     $res = do_mysqli_query(
         "SELECT WoWordCount AS word_count, count(WoWordCount) AS cnt 
-        FROM {$tbpref}words 
+        FROM words 
         WHERE WoLgID = $lid AND WoWordCount > 1 
         GROUP BY WoWordCount"
     );
@@ -1402,7 +1402,7 @@ function splitCheckText($text, $lid, $id)
     if ($id == -1) {
         check_text($sql, (bool)$rtlScript, $wl);
     }
-    do_mysqli_query("TRUNCATE TABLE {$tbpref}temptextitems");
+    do_mysqli_query("TRUNCATE TABLE temptextitems");
 }
 
 
@@ -1414,18 +1414,18 @@ function splitCheckText($text, $lid, $id)
 function reparse_all_texts(): void 
 {
     global $tbpref;
-    runsql('TRUNCATE ' . $tbpref . 'sentences', '');
-    runsql('TRUNCATE ' . $tbpref . 'textitems2', '');
+    runsql('TRUNCATE sentences', '');
+    runsql('TRUNCATE textitems2', '');
     adjust_autoincr('sentences', 'SeID');
     init_word_count();
-    $sql = "select TxID, TxLgID from " . $tbpref . "texts";
+    $sql = "select TxID, TxLgID from texts";
     $res = do_mysqli_query($sql);
     while ($record = mysqli_fetch_assoc($res)) {
         $id = (int) $record['TxID'];
         splitCheckText(
             get_first_value(
                 'select TxText as value 
-                from ' . $tbpref . 'texts 
+                from texts 
                 where TxID = ' . $id
             ), 
             $record['TxLgID'], $id 
@@ -1452,7 +1452,7 @@ function update_database($dbname)
     $res = mysqli_query(
         $GLOBALS['DBCONNECTION'], 
         "select StValue as value 
-        from " . $tbpref . "settings 
+        from settings 
         where StKey = 'dbversion'"
     );
     if (mysqli_errno($GLOBALS['DBCONNECTION']) != 0) { 
@@ -1495,41 +1495,41 @@ function update_database($dbname)
         if ($debug) { 
             echo "<p>DEBUG: do DB updates: $dbversion --&gt; $currversion</p>"; 
         }
-        runsql("ALTER TABLE " . $tbpref . "words ADD WoTodayScore DOUBLE NOT NULL DEFAULT 0, ADD WoTomorrowScore DOUBLE NOT NULL DEFAULT 0, ADD WoRandom DOUBLE NOT NULL DEFAULT 0", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "words ADD WoWordCount tinyint(3) unsigned NOT NULL DEFAULT 0 AFTER WoSentence", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "words ADD INDEX WoTodayScore (WoTodayScore), ADD INDEX WoTomorrowScore (WoTomorrowScore), ADD INDEX WoRandom (WoRandom)", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "languages ADD LgRightToLeft tinyint(1) UNSIGNED NOT NULL DEFAULT  0", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "texts ADD TxAnnotatedText LONGTEXT NOT NULL AFTER TxText", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "archivedtexts ADD AtAnnotatedText LONGTEXT NOT NULL AFTER AtText", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "tags CHANGE TgComment TgComment VARCHAR(200) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT ''", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "tags2 CHANGE T2Comment T2Comment VARCHAR(200) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT ''", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "languages CHANGE LgGoogleTTSURI LgExportTemplate VARCHAR(1000) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "texts ADD TxSourceURI VARCHAR(1000) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "archivedtexts ADD AtSourceURI VARCHAR(1000) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "texts ADD TxPosition smallint(5) NOT NULL DEFAULT  0", '', $sqlerrdie = false);
-        runsql("ALTER TABLE " . $tbpref . "texts ADD TxAudioPosition float NOT NULL DEFAULT  0", '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'wordtags` DROP INDEX WtWoID', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'texttags` DROP INDEX TtTxID', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'archtexttags` DROP INDEX AgAtID', '', $sqlerrdie = false);
+        runsql("ALTER TABLE words ADD WoTodayScore DOUBLE NOT NULL DEFAULT 0, ADD WoTomorrowScore DOUBLE NOT NULL DEFAULT 0, ADD WoRandom DOUBLE NOT NULL DEFAULT 0", '', $sqlerrdie = false);
+        runsql("ALTER TABLE words ADD WoWordCount tinyint(3) unsigned NOT NULL DEFAULT 0 AFTER WoSentence", '', $sqlerrdie = false);
+        runsql("ALTER TABLE words ADD INDEX WoTodayScore (WoTodayScore), ADD INDEX WoTomorrowScore (WoTomorrowScore), ADD INDEX WoRandom (WoRandom)", '', $sqlerrdie = false);
+        runsql("ALTER TABLE languages ADD LgRightToLeft tinyint(1) UNSIGNED NOT NULL DEFAULT  0", '', $sqlerrdie = false);
+        runsql("ALTER TABLE texts ADD TxAnnotatedText LONGTEXT NOT NULL AFTER TxText", '', $sqlerrdie = false);
+        runsql("ALTER TABLE archivedtexts ADD AtAnnotatedText LONGTEXT NOT NULL AFTER AtText", '', $sqlerrdie = false);
+        runsql("ALTER TABLE tags CHANGE TgComment TgComment VARCHAR(200) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT ''", '', $sqlerrdie = false);
+        runsql("ALTER TABLE tags2 CHANGE T2Comment T2Comment VARCHAR(200) CHARACTER SET utf8 COLLATE utf8_general_ci NOT NULL DEFAULT ''", '', $sqlerrdie = false);
+        runsql("ALTER TABLE languages CHANGE LgGoogleTTSURI LgExportTemplate VARCHAR(1000) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL", '', $sqlerrdie = false);
+        runsql("ALTER TABLE texts ADD TxSourceURI VARCHAR(1000) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL", '', $sqlerrdie = false);
+        runsql("ALTER TABLE archivedtexts ADD AtSourceURI VARCHAR(1000) CHARACTER SET utf8 COLLATE utf8_general_ci NULL DEFAULT NULL", '', $sqlerrdie = false);
+        runsql("ALTER TABLE texts ADD TxPosition smallint(5) NOT NULL DEFAULT  0", '', $sqlerrdie = false);
+        runsql("ALTER TABLE texts ADD TxAudioPosition float NOT NULL DEFAULT  0", '', $sqlerrdie = false);
+        runsql('ALTER TABLE `wordtags` DROP INDEX WtWoID', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `texttags` DROP INDEX TtTxID', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `archtexttags` DROP INDEX AgAtID', '', $sqlerrdie = false);
 
-        runsql('ALTER TABLE `' . $tbpref . 'archivedtexts` MODIFY COLUMN `AtLgID` tinyint(3) unsigned NOT NULL, MODIFY COLUMN `AtID` smallint(5) unsigned NOT NULL, ADD INDEX AtLgIDSourceURI (AtSourceURI(20),AtLgID)', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'languages` MODIFY COLUMN `LgID` tinyint(3) unsigned NOT NULL AUTO_INCREMENT, MODIFY COLUMN `LgRemoveSpaces` tinyint(1) unsigned NOT NULL, MODIFY COLUMN `LgSplitEachChar` tinyint(1) unsigned NOT NULL, MODIFY COLUMN `LgRightToLeft` tinyint(1) unsigned NOT NULL', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'sentences` MODIFY COLUMN `SeID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT, MODIFY COLUMN `SeLgID` tinyint(3) unsigned NOT NULL, MODIFY COLUMN `SeTxID` smallint(5) unsigned NOT NULL, MODIFY COLUMN `SeOrder` smallint(5) unsigned NOT NULL', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'texts` MODIFY COLUMN `TxID` smallint(5) unsigned NOT NULL AUTO_INCREMENT, MODIFY COLUMN `TxLgID` tinyint(3) unsigned NOT NULL, ADD INDEX TxLgIDSourceURI (TxSourceURI(20),TxLgID)', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'words` MODIFY COLUMN `WoID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT, MODIFY COLUMN `WoLgID` tinyint(3) unsigned NOT NULL, MODIFY COLUMN `WoStatus` tinyint(4) NOT NULL', '', $sqlerrdie = false);        
-        runsql('ALTER TABLE `' . $tbpref . 'words` DROP INDEX WoTextLC', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'words` DROP INDEX WoLgIDTextLC, ADD UNIQUE INDEX WoTextLCLgID (WoTextLC,WoLgID)', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'words` ADD INDEX WoWordCount (WoWordCount)', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'archtexttags` MODIFY COLUMN `AgAtID` smallint(5) unsigned NOT NULL, MODIFY COLUMN `AgT2ID` smallint(5) unsigned NOT NULL', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'tags` MODIFY COLUMN `TgID` smallint(5) unsigned NOT NULL AUTO_INCREMENT', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'tags2` MODIFY COLUMN `T2ID` smallint(5) unsigned NOT NULL AUTO_INCREMENT', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'wordtags` MODIFY COLUMN `WtTgID` smallint(5) unsigned NOT NULL AUTO_INCREMENT', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'texttags` MODIFY COLUMN `TtTxID` smallint(5) unsigned NOT NULL, MODIFY COLUMN `TtT2ID` smallint(5) unsigned NOT NULL', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'temptextitems` ADD TiCount smallint(5) unsigned NOT NULL, DROP TiLgID, DROP TiTxID', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'temptextitems` ADD DROP INDEX TiTextLC', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'temptextitems` ADD  DROP TiTextLC', '', $sqlerrdie = false);
-        runsql('ALTER TABLE `' . $tbpref . 'temptextitems` ADD TiCount smallint(5) unsigned NOT NULL', '', $sqlerrdie = false);
-        runsql('UPDATE ' . $tbpref . 'sentences join ' . $tbpref . 'textitems2 on Ti2SeID=SeID and Ti2Order=SeFirstPos and Ti2WordCount=0 SET SeFirstPos=SeFirstPos+1', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `archivedtexts` MODIFY COLUMN `AtLgID` tinyint(3) unsigned NOT NULL, MODIFY COLUMN `AtID` smallint(5) unsigned NOT NULL, ADD INDEX AtLgIDSourceURI (AtSourceURI(20),AtLgID)', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `languages` MODIFY COLUMN `LgID` tinyint(3) unsigned NOT NULL AUTO_INCREMENT, MODIFY COLUMN `LgRemoveSpaces` tinyint(1) unsigned NOT NULL, MODIFY COLUMN `LgSplitEachChar` tinyint(1) unsigned NOT NULL, MODIFY COLUMN `LgRightToLeft` tinyint(1) unsigned NOT NULL', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `sentences` MODIFY COLUMN `SeID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT, MODIFY COLUMN `SeLgID` tinyint(3) unsigned NOT NULL, MODIFY COLUMN `SeTxID` smallint(5) unsigned NOT NULL, MODIFY COLUMN `SeOrder` smallint(5) unsigned NOT NULL', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `texts` MODIFY COLUMN `TxID` smallint(5) unsigned NOT NULL AUTO_INCREMENT, MODIFY COLUMN `TxLgID` tinyint(3) unsigned NOT NULL, ADD INDEX TxLgIDSourceURI (TxSourceURI(20),TxLgID)', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `words` MODIFY COLUMN `WoID` mediumint(8) unsigned NOT NULL AUTO_INCREMENT, MODIFY COLUMN `WoLgID` tinyint(3) unsigned NOT NULL, MODIFY COLUMN `WoStatus` tinyint(4) NOT NULL', '', $sqlerrdie = false);        
+        runsql('ALTER TABLE `words` DROP INDEX WoTextLC', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `words` DROP INDEX WoLgIDTextLC, ADD UNIQUE INDEX WoTextLCLgID (WoTextLC,WoLgID)', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `words` ADD INDEX WoWordCount (WoWordCount)', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `archtexttags` MODIFY COLUMN `AgAtID` smallint(5) unsigned NOT NULL, MODIFY COLUMN `AgT2ID` smallint(5) unsigned NOT NULL', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `tags` MODIFY COLUMN `TgID` smallint(5) unsigned NOT NULL AUTO_INCREMENT', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `tags2` MODIFY COLUMN `T2ID` smallint(5) unsigned NOT NULL AUTO_INCREMENT', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `wordtags` MODIFY COLUMN `WtTgID` smallint(5) unsigned NOT NULL AUTO_INCREMENT', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `texttags` MODIFY COLUMN `TtTxID` smallint(5) unsigned NOT NULL, MODIFY COLUMN `TtT2ID` smallint(5) unsigned NOT NULL', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `temptextitems` ADD TiCount smallint(5) unsigned NOT NULL, DROP TiLgID, DROP TiTxID', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `temptextitems` ADD DROP INDEX TiTextLC', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `temptextitems` ADD  DROP TiTextLC', '', $sqlerrdie = false);
+        runsql('ALTER TABLE `temptextitems` ADD TiCount smallint(5) unsigned NOT NULL', '', $sqlerrdie = false);
+        runsql('UPDATE sentences join textitems2 on Ti2SeID=SeID and Ti2Order=SeFirstPos and Ti2WordCount=0 SET SeFirstPos=SeFirstPos+1', '', $sqlerrdie = false);
         if ($debug) { 
             echo '<p>DEBUG: rebuilding tts</p>'; 
         }
@@ -1574,7 +1574,7 @@ function check_update_db($debug, $tbpref, $dbname): void
             echo '<p>DEBUG: rebuilding archivedtexts</p>'; 
         }
         runsql(
-            "CREATE TABLE IF NOT EXISTS " . $tbpref . "archivedtexts ( 
+            "CREATE TABLE IF NOT EXISTS archivedtexts ( 
                 AtID smallint(5) unsigned NOT NULL AUTO_INCREMENT, 
                 AtLgID tinyint(3) unsigned NOT NULL, 
                 AtTitle varchar(200) NOT NULL, 
@@ -1596,7 +1596,7 @@ function check_update_db($debug, $tbpref, $dbname): void
             echo '<p>DEBUG: rebuilding languages</p>'; 
         }
         runsql(
-            "CREATE TABLE IF NOT EXISTS " . $tbpref . "languages ( 
+            "CREATE TABLE IF NOT EXISTS languages ( 
                 LgID tinyint(3) unsigned NOT NULL AUTO_INCREMENT, 
                 LgName varchar(40) NOT NULL, 
                 LgDict1URI varchar(200) NOT NULL, 
@@ -1624,7 +1624,7 @@ function check_update_db($debug, $tbpref, $dbname): void
             echo '<p>DEBUG: rebuilding sentences</p>'; 
         }
         runsql(
-            "CREATE TABLE IF NOT EXISTS " . $tbpref . "sentences ( 
+            "CREATE TABLE IF NOT EXISTS sentences ( 
                 SeID mediumint(8) unsigned NOT NULL AUTO_INCREMENT, 
                 SeLgID tinyint(3) unsigned NOT NULL, 
                 SeTxID smallint(5) unsigned NOT NULL, 
@@ -1646,7 +1646,7 @@ function check_update_db($debug, $tbpref, $dbname): void
              echo '<p>DEBUG: rebuilding settings</p>'; 
         }
         runsql(
-            "CREATE TABLE IF NOT EXISTS " . $tbpref . "settings ( 
+            "CREATE TABLE IF NOT EXISTS settings ( 
                 StKey varchar(40) NOT NULL, 
                 StValue varchar(40) DEFAULT NULL, 
                 PRIMARY KEY (StKey)
@@ -1661,7 +1661,7 @@ function check_update_db($debug, $tbpref, $dbname): void
             echo '<p>DEBUG: rebuilding textitems2</p>'; 
         }
         runsql(
-            "CREATE TABLE IF NOT EXISTS " . $tbpref . "textitems2 (
+            "CREATE TABLE IF NOT EXISTS textitems2 (
                 Ti2WoID mediumint(8) unsigned NOT NULL, 
                 Ti2LgID tinyint(3) unsigned NOT NULL, 
                 Ti2TxID smallint(5) unsigned NOT NULL, 
@@ -1677,14 +1677,14 @@ function check_update_db($debug, $tbpref, $dbname): void
         // Add data from the old database system
         if (in_array($tbpref . 'textitems', $tables)) {
             runsql(
-                'INSERT INTO ' . $tbpref . 'textitems2 (
+                'INSERT INTO textitems2 (
                     Ti2WoID, Ti2LgID, Ti2TxID, Ti2SeID, Ti2Order, Ti2WordCount, Ti2Text
                 ) 
                 SELECT IFNULL(WoID,0), TiLgID, TiTxID, TiSeID, TiOrder, 
                 CASE WHEN TiIsNotWord = 1 THEN 0 ELSE TiWordCount END as WordCount, 
                 CASE WHEN STRCMP( TiText COLLATE utf8_bin ,TiTextLC)!=0 OR TiWordCount = 1 THEN TiText ELSE "" END as Text 
                 FROM ' . $tbpref . 'textitems 
-                LEFT JOIN ' . $tbpref . 'words ON TiTextLC=WoTextLC AND TiLgID=WoLgID 
+                LEFT JOIN words ON TiTextLC=WoTextLC AND TiLgID=WoLgID 
                 WHERE TiWordCount<2 OR WoID IS NOT NULL',
                 ''
             );
@@ -1698,79 +1698,79 @@ function check_update_db($debug, $tbpref, $dbname): void
         if ($debug) { 
             echo '<p>DEBUG: rebuilding temptextitems</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "temptextitems ( TiCount smallint(5) unsigned NOT NULL, TiSeID mediumint(8) unsigned NOT NULL, TiOrder smallint(5) unsigned NOT NULL, TiWordCount tinyint(3) unsigned NOT NULL, TiText varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL) ENGINE=MEMORY DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS temptextitems ( TiCount smallint(5) unsigned NOT NULL, TiSeID mediumint(8) unsigned NOT NULL, TiOrder smallint(5) unsigned NOT NULL, TiWordCount tinyint(3) unsigned NOT NULL, TiText varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL) ENGINE=MEMORY DEFAULT CHARSET=utf8", '');
     }
 
     if (!in_array($tbpref . 'tempwords', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding tempwords</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "tempwords (WoText varchar(250) DEFAULT NULL, WoTextLC varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, WoTranslation varchar(500) NOT NULL DEFAULT '*', WoRomanization varchar(100) DEFAULT NULL, WoSentence varchar(1000) DEFAULT NULL, WoTaglist varchar(255) DEFAULT NULL, PRIMARY KEY(WoTextLC) ) ENGINE=MEMORY DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS tempwords (WoText varchar(250) DEFAULT NULL, WoTextLC varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, WoTranslation varchar(500) NOT NULL DEFAULT '*', WoRomanization varchar(100) DEFAULT NULL, WoSentence varchar(1000) DEFAULT NULL, WoTaglist varchar(255) DEFAULT NULL, PRIMARY KEY(WoTextLC) ) ENGINE=MEMORY DEFAULT CHARSET=utf8", '');
     }
 
     if (!in_array($tbpref . 'texts', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding texts</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "texts ( TxID smallint(5) unsigned NOT NULL AUTO_INCREMENT, TxLgID tinyint(3) unsigned NOT NULL, TxTitle varchar(200) NOT NULL, TxText text NOT NULL, TxAnnotatedText longtext NOT NULL, TxAudioURI varchar(200) DEFAULT NULL, TxSourceURI varchar(1000) DEFAULT NULL, TxPosition smallint(5) DEFAULT 0, TxAudioPosition float DEFAULT 0, PRIMARY KEY (TxID), KEY TxLgID (TxLgID), KEY TxLgIDSourceURI (TxSourceURI(20),TxLgID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS texts ( TxID smallint(5) unsigned NOT NULL AUTO_INCREMENT, TxLgID tinyint(3) unsigned NOT NULL, TxTitle varchar(200) NOT NULL, TxText text NOT NULL, TxAnnotatedText longtext NOT NULL, TxAudioURI varchar(200) DEFAULT NULL, TxSourceURI varchar(1000) DEFAULT NULL, TxPosition smallint(5) DEFAULT 0, TxAudioPosition float DEFAULT 0, PRIMARY KEY (TxID), KEY TxLgID (TxLgID), KEY TxLgIDSourceURI (TxSourceURI(20),TxLgID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
     if (!in_array($tbpref . 'words', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding words</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "words ( WoID mediumint(8) unsigned NOT NULL AUTO_INCREMENT, WoLgID tinyint(3) unsigned NOT NULL, WoText varchar(250) NOT NULL, WoTextLC varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, WoStatus tinyint(4) NOT NULL, WoTranslation varchar(500) NOT NULL DEFAULT '*', WoRomanization varchar(100) DEFAULT NULL, WoSentence varchar(1000) DEFAULT NULL, WoWordCount tinyint(3) unsigned NOT NULL DEFAULT 0, WoCreated timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, WoStatusChanged timestamp NOT NULL DEFAULT '0000-00-00 00:00:00', WoTodayScore double NOT NULL DEFAULT '0', WoTomorrowScore double NOT NULL DEFAULT '0', WoRandom double NOT NULL DEFAULT '0', PRIMARY KEY (WoID), UNIQUE KEY WoTextLCLgID (WoTextLC,WoLgID), KEY WoLgID (WoLgID), KEY WoStatus (WoStatus), KEY WoTranslation (WoTranslation(20)), KEY WoCreated (WoCreated), KEY WoStatusChanged (WoStatusChanged), KEY WoWordCount(WoWordCount), KEY WoTodayScore (WoTodayScore), KEY WoTomorrowScore (WoTomorrowScore), KEY WoRandom (WoRandom) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS words ( WoID mediumint(8) unsigned NOT NULL AUTO_INCREMENT, WoLgID tinyint(3) unsigned NOT NULL, WoText varchar(250) NOT NULL, WoTextLC varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, WoStatus tinyint(4) NOT NULL, WoTranslation varchar(500) NOT NULL DEFAULT '*', WoRomanization varchar(100) DEFAULT NULL, WoSentence varchar(1000) DEFAULT NULL, WoWordCount tinyint(3) unsigned NOT NULL DEFAULT 0, WoCreated timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, WoStatusChanged timestamp NOT NULL DEFAULT '0000-00-00 00:00:00', WoTodayScore double NOT NULL DEFAULT '0', WoTomorrowScore double NOT NULL DEFAULT '0', WoRandom double NOT NULL DEFAULT '0', PRIMARY KEY (WoID), UNIQUE KEY WoTextLCLgID (WoTextLC,WoLgID), KEY WoLgID (WoLgID), KEY WoStatus (WoStatus), KEY WoTranslation (WoTranslation(20)), KEY WoCreated (WoCreated), KEY WoStatusChanged (WoStatusChanged), KEY WoWordCount(WoWordCount), KEY WoTodayScore (WoTodayScore), KEY WoTomorrowScore (WoTomorrowScore), KEY WoRandom (WoRandom) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
     if (!in_array($tbpref . 'tags', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding tags</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "tags ( TgID smallint(5) unsigned NOT NULL AUTO_INCREMENT, TgText varchar(20) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, TgComment varchar(200) NOT NULL DEFAULT '', PRIMARY KEY (TgID), UNIQUE KEY TgText (TgText) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS tags ( TgID smallint(5) unsigned NOT NULL AUTO_INCREMENT, TgText varchar(20) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, TgComment varchar(200) NOT NULL DEFAULT '', PRIMARY KEY (TgID), UNIQUE KEY TgText (TgText) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
     if (!in_array($tbpref . 'wordtags', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding wordtags</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "wordtags ( WtWoID mediumint(8) unsigned NOT NULL, WtTgID smallint(5) unsigned NOT NULL, PRIMARY KEY (WtWoID,WtTgID), KEY WtTgID (WtTgID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS wordtags ( WtWoID mediumint(8) unsigned NOT NULL, WtTgID smallint(5) unsigned NOT NULL, PRIMARY KEY (WtWoID,WtTgID), KEY WtTgID (WtTgID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
     if (!in_array($tbpref . 'tags2', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding tags2</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "tags2 ( T2ID smallint(5) unsigned NOT NULL AUTO_INCREMENT, T2Text varchar(20) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, T2Comment varchar(200) NOT NULL DEFAULT '', PRIMARY KEY (T2ID), UNIQUE KEY T2Text (T2Text) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS tags2 ( T2ID smallint(5) unsigned NOT NULL AUTO_INCREMENT, T2Text varchar(20) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, T2Comment varchar(200) NOT NULL DEFAULT '', PRIMARY KEY (T2ID), UNIQUE KEY T2Text (T2Text) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
     if (!in_array($tbpref . 'texttags', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding texttags</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "texttags ( TtTxID smallint(5) unsigned NOT NULL, TtT2ID smallint(5) unsigned NOT NULL, PRIMARY KEY (TtTxID,TtT2ID), KEY TtT2ID (TtT2ID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS texttags ( TtTxID smallint(5) unsigned NOT NULL, TtT2ID smallint(5) unsigned NOT NULL, PRIMARY KEY (TtTxID,TtT2ID), KEY TtT2ID (TtT2ID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
     if (!in_array($tbpref . 'newsfeeds', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding newsfeeds</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "newsfeeds (NfID tinyint(3) unsigned NOT NULL AUTO_INCREMENT,NfLgID tinyint(3) unsigned NOT NULL,NfName varchar(40) NOT NULL,NfSourceURI varchar(200) NOT NULL,NfArticleSectionTags text NOT NULL,NfFilterTags text NOT NULL,NfUpdate int(12) unsigned NOT NULL,NfOptions varchar(200) NOT NULL,PRIMARY KEY (NfID), KEY NfLgID (NfLgID), KEY NfUpdate (NfUpdate)) ENGINE=MyISAM  DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS newsfeeds (NfID tinyint(3) unsigned NOT NULL AUTO_INCREMENT,NfLgID tinyint(3) unsigned NOT NULL,NfName varchar(40) NOT NULL,NfSourceURI varchar(200) NOT NULL,NfArticleSectionTags text NOT NULL,NfFilterTags text NOT NULL,NfUpdate int(12) unsigned NOT NULL,NfOptions varchar(200) NOT NULL,PRIMARY KEY (NfID), KEY NfLgID (NfLgID), KEY NfUpdate (NfUpdate)) ENGINE=MyISAM  DEFAULT CHARSET=utf8", '');
     }
     
     if (!in_array($tbpref . 'feedlinks', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding feedlinks</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "feedlinks (FlID mediumint(8) unsigned NOT NULL AUTO_INCREMENT,FlTitle varchar(200) NOT NULL,FlLink varchar(400) NOT NULL,FlDescription text NOT NULL,FlDate datetime NOT NULL,FlAudio varchar(200) NOT NULL,FlText longtext NOT NULL,FlNfID tinyint(3) unsigned NOT NULL,PRIMARY KEY (FlID), KEY FlLink (FlLink), KEY FlDate (FlDate), UNIQUE KEY FlTitle (FlNfID,FlTitle)) ENGINE=MyISAM  DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS feedlinks (FlID mediumint(8) unsigned NOT NULL AUTO_INCREMENT,FlTitle varchar(200) NOT NULL,FlLink varchar(400) NOT NULL,FlDescription text NOT NULL,FlDate datetime NOT NULL,FlAudio varchar(200) NOT NULL,FlText longtext NOT NULL,FlNfID tinyint(3) unsigned NOT NULL,PRIMARY KEY (FlID), KEY FlLink (FlLink), KEY FlDate (FlDate), UNIQUE KEY FlTitle (FlNfID,FlTitle)) ENGINE=MyISAM  DEFAULT CHARSET=utf8", '');
     }
     
     if (!in_array($tbpref . 'archtexttags', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding archtexttags</p>'; 
         }
-        runsql("CREATE TABLE IF NOT EXISTS " . $tbpref . "archtexttags ( AgAtID smallint(5) unsigned NOT NULL, AgT2ID smallint(5) unsigned NOT NULL, PRIMARY KEY (AgAtID,AgT2ID), KEY AgT2ID (AgT2ID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
+        runsql("CREATE TABLE IF NOT EXISTS archtexttags ( AgAtID smallint(5) unsigned NOT NULL, AgT2ID smallint(5) unsigned NOT NULL, PRIMARY KEY (AgAtID,AgT2ID), KEY AgT2ID (AgT2ID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
-    runsql('ALTER TABLE `' . $tbpref . 'sentences`  ADD SeFirstPos smallint(5) NOT NULL', '', $sqlerrdie = false);
+    runsql('ALTER TABLE `sentences`  ADD SeFirstPos smallint(5) NOT NULL', '', $sqlerrdie = false);
     
     if ($count > 0) {        
         // Rebuild Text Cache if cache tables new
@@ -1790,13 +1790,13 @@ function check_update_db($debug, $tbpref, $dbname): void
         if ($debug) { 
             echo '<p>DEBUG: Doing score recalc. Today: ' . $today . ' / Last: ' . $lastscorecalc . '</p>'; 
         }
-        runsql("UPDATE " . $tbpref . "words SET " . make_score_random_insert_update('u') ." where WoTodayScore>=-100 and WoStatus<98", '');
-        runsql("DELETE " . $tbpref . "wordtags FROM (" . $tbpref . "wordtags LEFT JOIN " . $tbpref . "tags on WtTgID = TgID) WHERE TgID IS NULL", '');
-        runsql("DELETE " . $tbpref . "wordtags FROM (" . $tbpref . "wordtags LEFT JOIN " . $tbpref . "words on WtWoID = WoID) WHERE WoID IS NULL", '');
-        runsql("DELETE " . $tbpref . "texttags FROM (" . $tbpref . "texttags LEFT JOIN " . $tbpref . "tags2 on TtT2ID = T2ID) WHERE T2ID IS NULL", '');
-        runsql("DELETE " . $tbpref . "texttags FROM (" . $tbpref . "texttags LEFT JOIN " . $tbpref . "texts on TtTxID = TxID) WHERE TxID IS NULL", '');
-        runsql("DELETE " . $tbpref . "archtexttags FROM (" . $tbpref . "archtexttags LEFT JOIN " . $tbpref . "tags2 on AgT2ID = T2ID) WHERE T2ID IS NULL", '');
-        runsql("DELETE " . $tbpref . "archtexttags FROM (" . $tbpref . "archtexttags LEFT JOIN " . $tbpref . "archivedtexts on AgAtID = AtID) WHERE AtID IS NULL", '');
+        runsql("UPDATE words SET " . make_score_random_insert_update('u') ." where WoTodayScore>=-100 and WoStatus<98", '');
+        runsql("DELETE wordtags FROM (wordtags LEFT JOIN tags on WtTgID = TgID) WHERE TgID IS NULL", '');
+        runsql("DELETE wordtags FROM (wordtags LEFT JOIN words on WtWoID = WoID) WHERE WoID IS NULL", '');
+        runsql("DELETE texttags FROM (texttags LEFT JOIN tags2 on TtT2ID = T2ID) WHERE T2ID IS NULL", '');
+        runsql("DELETE texttags FROM (texttags LEFT JOIN texts on TtTxID = TxID) WHERE TxID IS NULL", '');
+        runsql("DELETE archtexttags FROM (archtexttags LEFT JOIN tags2 on AgT2ID = T2ID) WHERE T2ID IS NULL", '');
+        runsql("DELETE archtexttags FROM (archtexttags LEFT JOIN archivedtexts on AgAtID = AtID) WHERE AtID IS NULL", '');
         optimizedb();
         saveSetting('lastscorecalc', $today);
     }

--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -1569,7 +1569,7 @@ function check_update_db($debug, $tbpref, $dbname): void
     
     // Rebuild Tables if missing (current versions!)
     
-    if (!in_array($tbpref . 'archivedtexts', $tables)) {
+    if (!in_array('archivedtexts', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding archivedtexts</p>'; 
         }
@@ -1591,7 +1591,7 @@ function check_update_db($debug, $tbpref, $dbname): void
         );
     }
     
-    if (!in_array($tbpref . 'languages', $tables)) {
+    if (!in_array('languages', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding languages</p>'; 
         }
@@ -1619,7 +1619,7 @@ function check_update_db($debug, $tbpref, $dbname): void
         );
     }
     
-    if (!in_array($tbpref . 'sentences', $tables)) {
+    if (!in_array('sentences', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding sentences</p>'; 
         }
@@ -1641,7 +1641,7 @@ function check_update_db($debug, $tbpref, $dbname): void
         $count++;
     }
     
-    if (!in_array($tbpref . 'settings', $tables)) {
+    if (!in_array('settings', $tables)) {
         if ($debug) {
              echo '<p>DEBUG: rebuilding settings</p>'; 
         }
@@ -1656,7 +1656,7 @@ function check_update_db($debug, $tbpref, $dbname): void
         );
     }
     
-    if (!in_array($tbpref . 'textitems2', $tables)) {
+    if (!in_array('textitems2', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding textitems2</p>'; 
         }
@@ -1694,77 +1694,77 @@ function check_update_db($debug, $tbpref, $dbname): void
     }
 
 
-    if (!in_array($tbpref . 'temptextitems', $tables)) {
+    if (!in_array('temptextitems', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding temptextitems</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS temptextitems ( TiCount smallint(5) unsigned NOT NULL, TiSeID mediumint(8) unsigned NOT NULL, TiOrder smallint(5) unsigned NOT NULL, TiWordCount tinyint(3) unsigned NOT NULL, TiText varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL) ENGINE=MEMORY DEFAULT CHARSET=utf8", '');
     }
 
-    if (!in_array($tbpref . 'tempwords', $tables)) {
+    if (!in_array('tempwords', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding tempwords</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS tempwords (WoText varchar(250) DEFAULT NULL, WoTextLC varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, WoTranslation varchar(500) NOT NULL DEFAULT '*', WoRomanization varchar(100) DEFAULT NULL, WoSentence varchar(1000) DEFAULT NULL, WoTaglist varchar(255) DEFAULT NULL, PRIMARY KEY(WoTextLC) ) ENGINE=MEMORY DEFAULT CHARSET=utf8", '');
     }
 
-    if (!in_array($tbpref . 'texts', $tables)) {
+    if (!in_array('texts', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding texts</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS texts ( TxID smallint(5) unsigned NOT NULL AUTO_INCREMENT, TxLgID tinyint(3) unsigned NOT NULL, TxTitle varchar(200) NOT NULL, TxText text NOT NULL, TxAnnotatedText longtext NOT NULL, TxAudioURI varchar(200) DEFAULT NULL, TxSourceURI varchar(1000) DEFAULT NULL, TxPosition smallint(5) DEFAULT 0, TxAudioPosition float DEFAULT 0, PRIMARY KEY (TxID), KEY TxLgID (TxLgID), KEY TxLgIDSourceURI (TxSourceURI(20),TxLgID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
-    if (!in_array($tbpref . 'words', $tables)) {
+    if (!in_array('words', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding words</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS words ( WoID mediumint(8) unsigned NOT NULL AUTO_INCREMENT, WoLgID tinyint(3) unsigned NOT NULL, WoText varchar(250) NOT NULL, WoTextLC varchar(250) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, WoStatus tinyint(4) NOT NULL, WoTranslation varchar(500) NOT NULL DEFAULT '*', WoRomanization varchar(100) DEFAULT NULL, WoSentence varchar(1000) DEFAULT NULL, WoWordCount tinyint(3) unsigned NOT NULL DEFAULT 0, WoCreated timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP, WoStatusChanged timestamp NOT NULL DEFAULT '0000-00-00 00:00:00', WoTodayScore double NOT NULL DEFAULT '0', WoTomorrowScore double NOT NULL DEFAULT '0', WoRandom double NOT NULL DEFAULT '0', PRIMARY KEY (WoID), UNIQUE KEY WoTextLCLgID (WoTextLC,WoLgID), KEY WoLgID (WoLgID), KEY WoStatus (WoStatus), KEY WoTranslation (WoTranslation(20)), KEY WoCreated (WoCreated), KEY WoStatusChanged (WoStatusChanged), KEY WoWordCount(WoWordCount), KEY WoTodayScore (WoTodayScore), KEY WoTomorrowScore (WoTomorrowScore), KEY WoRandom (WoRandom) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
-    if (!in_array($tbpref . 'tags', $tables)) {
+    if (!in_array('tags', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding tags</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS tags ( TgID smallint(5) unsigned NOT NULL AUTO_INCREMENT, TgText varchar(20) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, TgComment varchar(200) NOT NULL DEFAULT '', PRIMARY KEY (TgID), UNIQUE KEY TgText (TgText) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
-    if (!in_array($tbpref . 'wordtags', $tables)) {
+    if (!in_array('wordtags', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding wordtags</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS wordtags ( WtWoID mediumint(8) unsigned NOT NULL, WtTgID smallint(5) unsigned NOT NULL, PRIMARY KEY (WtWoID,WtTgID), KEY WtTgID (WtTgID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
-    if (!in_array($tbpref . 'tags2', $tables)) {
+    if (!in_array('tags2', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding tags2</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS tags2 ( T2ID smallint(5) unsigned NOT NULL AUTO_INCREMENT, T2Text varchar(20) CHARACTER SET utf8 COLLATE utf8_bin NOT NULL, T2Comment varchar(200) NOT NULL DEFAULT '', PRIMARY KEY (T2ID), UNIQUE KEY T2Text (T2Text) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
-    if (!in_array($tbpref . 'texttags', $tables)) {
+    if (!in_array('texttags', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding texttags</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS texttags ( TtTxID smallint(5) unsigned NOT NULL, TtT2ID smallint(5) unsigned NOT NULL, PRIMARY KEY (TtTxID,TtT2ID), KEY TtT2ID (TtT2ID) ) ENGINE=MyISAM DEFAULT CHARSET=utf8", '');
     }
     
-    if (!in_array($tbpref . 'newsfeeds', $tables)) {
+    if (!in_array('newsfeeds', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding newsfeeds</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS newsfeeds (NfID tinyint(3) unsigned NOT NULL AUTO_INCREMENT,NfLgID tinyint(3) unsigned NOT NULL,NfName varchar(40) NOT NULL,NfSourceURI varchar(200) NOT NULL,NfArticleSectionTags text NOT NULL,NfFilterTags text NOT NULL,NfUpdate int(12) unsigned NOT NULL,NfOptions varchar(200) NOT NULL,PRIMARY KEY (NfID), KEY NfLgID (NfLgID), KEY NfUpdate (NfUpdate)) ENGINE=MyISAM  DEFAULT CHARSET=utf8", '');
     }
     
-    if (!in_array($tbpref . 'feedlinks', $tables)) {
+    if (!in_array('feedlinks', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding feedlinks</p>'; 
         }
         runsql("CREATE TABLE IF NOT EXISTS feedlinks (FlID mediumint(8) unsigned NOT NULL AUTO_INCREMENT,FlTitle varchar(200) NOT NULL,FlLink varchar(400) NOT NULL,FlDescription text NOT NULL,FlDate datetime NOT NULL,FlAudio varchar(200) NOT NULL,FlText longtext NOT NULL,FlNfID tinyint(3) unsigned NOT NULL,PRIMARY KEY (FlID), KEY FlLink (FlLink), KEY FlDate (FlDate), UNIQUE KEY FlTitle (FlNfID,FlTitle)) ENGINE=MyISAM  DEFAULT CHARSET=utf8", '');
     }
     
-    if (!in_array($tbpref . 'archtexttags', $tables)) {
+    if (!in_array('archtexttags', $tables)) {
         if ($debug) { 
             echo '<p>DEBUG: rebuilding archtexttags</p>'; 
         }

--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -1675,7 +1675,7 @@ function check_update_db($debug, $tbpref, $dbname): void
             ''
         );
         // Add data from the old database system
-        if (in_array($tbpref . 'textitems', $tables)) {
+        if (in_array('textitems', $tables)) {
             runsql(
                 'INSERT INTO textitems2 (
                     Ti2WoID, Ti2LgID, Ti2TxID, Ti2SeID, Ti2Order, Ti2WordCount, Ti2Text
@@ -1683,12 +1683,12 @@ function check_update_db($debug, $tbpref, $dbname): void
                 SELECT IFNULL(WoID,0), TiLgID, TiTxID, TiSeID, TiOrder, 
                 CASE WHEN TiIsNotWord = 1 THEN 0 ELSE TiWordCount END as WordCount, 
                 CASE WHEN STRCMP( TiText COLLATE utf8_bin ,TiTextLC)!=0 OR TiWordCount = 1 THEN TiText ELSE "" END as Text 
-                FROM ' . $tbpref . 'textitems 
+                FROM textitems 
                 LEFT JOIN words ON TiTextLC=WoTextLC AND TiLgID=WoLgID 
                 WHERE TiWordCount<2 OR WoID IS NOT NULL',
                 ''
             );
-            runsql('TRUNCATE ' . $tbpref . 'textitems', '');
+            runsql('TRUNCATE textitems', '');
         }
         $count++;
     }

--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -570,7 +570,7 @@ function update_japanese_word_count($japid)
     global $tbpref;
         
     // STEP 1: write the useful info to a file
-    $db_to_mecab = tempnam(sys_get_temp_dir(), "{$tbpref}db_to_mecab");
+    $db_to_mecab = tempnam(sys_get_temp_dir(), "db_to_mecab");
     $mecab_args = ' -F %m%t\\t -U %m%t\\t -E \\n ';
     $mecab = get_mecab_path($mecab_args);
 
@@ -592,7 +592,7 @@ function update_japanese_word_count($japid)
         unlink($db_to_mecab);
         return;
     }
-    $sql = "INSERT INTO {$tbpref}mecab (MID, MWordCount) values";
+    $sql = "INSERT INTO mecab (MID, MWordCount) values";
     $values = array();
     while (!feof($handle)) {
         $row = fgets($handle, 1024);
@@ -618,7 +618,7 @@ function update_japanese_word_count($japid)
 
     // STEP 3: edit the database
     do_mysqli_query(
-        "CREATE TEMPORARY TABLE {$tbpref}mecab ( 
+        "CREATE TEMPORARY TABLE mecab ( 
             MID mediumint(8) unsigned NOT NULL, 
             MWordCount tinyint(3) unsigned NOT NULL, 
             PRIMARY KEY (MID)
@@ -628,10 +628,10 @@ function update_japanese_word_count($japid)
     do_mysqli_query($sql);
     do_mysqli_query(
         "UPDATE words 
-        JOIN {$tbpref}mecab ON MID = WoID 
+        JOIN mecab ON MID = WoID 
         SET WoWordCount = MWordCount"
     );
-    do_mysqli_query("DROP TABLE {$tbpref}mecab");
+    do_mysqli_query("DROP TABLE mecab");
 
     unlink($db_to_mecab);
 }

--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -512,7 +512,7 @@ function adjust_autoincr($table, $key): void
 {
     global $tbpref;
     $val = get_first_value(
-        'SELECT max(' . $key .')+1 AS value FROM ' . $tbpref . $table
+        'SELECT max(' . $key .')+1 AS value FROM ' . $table
     );
     if (!isset($val)) { 
         $val = 1; 
@@ -1260,10 +1260,10 @@ function check_text_with_expressions($id, $lid, $wl, $wl_max, $mw_sql)
     }
     do_mysqli_query('set ' . $init_var . '@a1=0,@a0=0,@b=0,@c="",@d=0,@e=0,@f="",@h=0;');
     do_mysqli_query(
-        'CREATE TEMPORARY TABLE IF NOT EXISTS ' . $tbpref . 'numbers( n  tinyint(3) unsigned NOT NULL);'
+        'CREATE TEMPORARY TABLE IF NOT EXISTS numbers( n  tinyint(3) unsigned NOT NULL);'
     );
-    do_mysqli_query('TRUNCATE TABLE ' . $tbpref . 'numbers');
-    do_mysqli_query('INSERT IGNORE INTO ' . $tbpref . 'numbers(n) VALUES (' . implode('),(', $wl) . ');');
+    do_mysqli_query('TRUNCATE TABLE numbers');
+    do_mysqli_query('INSERT IGNORE INTO numbers(n) VALUES (' . implode('),(', $wl) . ');');
     if ($id>0) {
         $sql = 'SELECT straight_join WoID, sent, TiOrder - (2*(n-1)) TiOrder, n TiWordCount,word';
     } else {
@@ -1316,7 +1316,7 @@ function check_text_with_expressions($id, $lid, $wl, $wl_max, $mw_sql)
         ) word,
         if(@d=0 or ""=@z, NULL, lower(@z)) lword, 
         TiOrder,
-        n FROM ' . $tbpref . 'numbers , temptextitems
+        n FROM numbers , temptextitems
     ) ti, 
     words 
     WHERE lword IS NOT NULL AND WoLgID=' . $lid . ' AND 

--- a/inc/session_utility.php
+++ b/inc/session_utility.php
@@ -38,7 +38,7 @@ function get_tags($refresh = 0)
             return $_SESSION['TAGS'];
     }
     $tags = array();
-    $sql = 'SELECT TgText FROM ' . $tbpref . 'tags ORDER BY TgText';
+    $sql = 'SELECT TgText FROM tags ORDER BY TgText';
     $res = do_mysqli_query($sql);
     while ($record = mysqli_fetch_assoc($res)) {
         $tags[] = $record["TgText"];
@@ -70,7 +70,7 @@ function get_texttags($refresh = 0)
             return $_SESSION['TEXTTAGS']; 
     }
     $tags = array();
-    $sql = 'SELECT T2Text FROM ' . $tbpref . 'tags2 ORDER BY T2Text';
+    $sql = 'SELECT T2Text FROM tags2 ORDER BY T2Text';
     $res = do_mysqli_query($sql);
     while ($record = mysqli_fetch_assoc($res)) {
         $tags[] = $record["T2Text"];
@@ -88,7 +88,7 @@ function getTextTitle($textid): string
     global $tbpref;
     $text = get_first_value(
         "SELECT TxTitle AS value 
-        FROM " . $tbpref . "texts 
+        FROM texts 
         WHERE TxID=" . $textid
     );
     if (!isset($text)) { 
@@ -109,13 +109,13 @@ function get_tag_selectoptions($v,$l): string
     $r .= ">[Filter off]</option>";
     if ($l == '') {
         $sql = "select TgID, TgText 
-        from " . $tbpref . "words, " . $tbpref . "tags, " . $tbpref . "wordtags 
+        from words, tags, wordtags 
         where TgID = WtTgID and WtWoID = WoID 
         group by TgID 
         order by UPPER(TgText)"; 
     } else {
         $sql = "select TgID, TgText 
-        from " . $tbpref . "words, " . $tbpref . "tags, " . $tbpref . "wordtags 
+        from words, tags, wordtags 
         where TgID = WtTgID and WtWoID = WoID and WoLgID = " . $l . " 
         group by TgID 
         order by UPPER(TgText)"; 
@@ -148,13 +148,13 @@ function get_texttag_selectoptions($v,$l): string
     $r .= ">[Filter off]</option>";
     if ($l == '') {
         $sql = "select T2ID, T2Text 
-        from " . $tbpref . "texts, " . $tbpref . "tags2, " . $tbpref . "texttags 
+        from texts, tags2, texttags 
         where T2ID = TtT2ID and TtTxID = TxID 
         group by T2ID 
         order by UPPER(T2Text)"; 
     } else {
         $sql = "select T2ID, T2Text 
-        from " . $tbpref . "texts, " . $tbpref . "tags2, " . $tbpref . "texttags 
+        from texts, tags2, texttags 
         where T2ID = TtT2ID and TtTxID = TxID and TxLgID = " . $l . " 
         group by T2ID 
         order by UPPER(T2Text)"; 
@@ -188,9 +188,9 @@ function get_txtag_selectoptions($l,$v): string
     $r .= ">[Filter off]</option>";
     $sql = 'SELECT IFNULL(T2Text, 1) AS TagName, TtT2ID AS TagID, GROUP_CONCAT(TxID 
     ORDER BY TxID) AS TextID 
-    FROM ' . $tbpref . 'texts 
-    LEFT JOIN ' . $tbpref . 'texttags ON TxID = TtTxID
-    LEFT JOIN ' . $tbpref . 'tags2 ON TtT2ID = T2ID';
+    FROM texts 
+    LEFT JOIN texttags ON TxID = TtTxID
+    LEFT JOIN tags2 ON TtT2ID = T2ID';
     if ($l) {
         $sql .= ' WHERE TxLgID=' . $l; 
     }
@@ -223,14 +223,14 @@ function get_archivedtexttag_selectoptions($v,$l): string
     $r .= ">[Filter off]</option>";
     if ($l == '') {
         $sql = "select T2ID, T2Text 
-        from " . $tbpref . "archivedtexts, " . 
-        $tbpref . "tags2, " . $tbpref . "archtexttags 
+        from archivedtexts, " . 
+        $tbpref . "tags2, archtexttags 
         where T2ID = AgT2ID and AgAtID = AtID 
         group by T2ID 
         order by UPPER(T2Text)"; 
     } else {
         $sql = "select T2ID, T2Text 
-        from " . $tbpref . "archivedtexts, " . $tbpref . "tags2, " . 
+        from archivedtexts, tags2, " . 
         $tbpref . "archtexttags 
         where T2ID = AgT2ID and AgAtID = AtID and AtLgID = " . $l . " 
         group by T2ID 
@@ -261,7 +261,7 @@ function get_archivedtexttag_selectoptions($v,$l): string
 function saveWordTags($wid) 
 {
     global $tbpref;
-    runsql("DELETE from " . $tbpref . "wordtags WHERE WtWoID =" . $wid, '');
+    runsql("DELETE from wordtags WHERE WtWoID =" . $wid, '');
     if (!isset($_REQUEST['TermTags'])  
         || !is_array($_REQUEST['TermTags'])  
         || !isset($_REQUEST['TermTags']['TagList'])  
@@ -276,15 +276,15 @@ function saveWordTags($wid)
         $tag = $_REQUEST['TermTags']['TagList'][$i];
         if(!in_array($tag, $_SESSION['TAGS'])) {
             runsql(
-                "INSERT INTO {$tbpref}tags (TgText) 
+                "INSERT INTO tags (TgText) 
                 VALUES(" . convert_string_to_sqlsyntax($tag) . ")", 
                 ""
             );
         }
         runsql(
-            "INSERT INTO {$tbpref}wordtags (WtWoID, WtTgID) 
+            "INSERT INTO wordtags (WtWoID, WtTgID) 
             SELECT $wid, TgID 
-            FROM {$tbpref}tags 
+            FROM tags 
             WHERE TgText = " . convert_string_to_sqlsyntax($tag), 
             ""
         );
@@ -304,7 +304,7 @@ function saveTextTags($tid): void
 {
     global $tbpref;
     runsql(
-        "DELETE FROM " . $tbpref . "texttags WHERE TtTxID =" . $tid, 
+        "DELETE FROM texttags WHERE TtTxID =" . $tid, 
         ''
     );
     if (!isset($_REQUEST['TextTags']) 
@@ -321,15 +321,15 @@ function saveTextTags($tid): void
         $tag = $_REQUEST['TextTags']['TagList'][$i];
         if (!in_array($tag, $_SESSION['TEXTTAGS'])) {
             runsql(
-                "INSERT INTO {$tbpref}tags2 (T2Text) 
+                "INSERT INTO tags2 (T2Text) 
                 VALUES(" . convert_string_to_sqlsyntax($tag) . ")", 
                 ""
             );
         }
         runsql(
-            "INSERT INTO {$tbpref}texttags (TtTxID, TtT2ID) 
+            "INSERT INTO texttags (TtTxID, TtT2ID) 
             SELECT $tid, T2ID 
-            FROM {$tbpref}tags2 
+            FROM tags2 
             WHERE T2Text = " . convert_string_to_sqlsyntax($tag), 
             ""
         );
@@ -349,7 +349,7 @@ function saveTextTags($tid): void
 function saveArchivedTextTags($tid): void 
 {
     global $tbpref;
-    runsql("DELETE from " . $tbpref . "archtexttags WHERE AgAtID =" . $tid, '');
+    runsql("DELETE from archtexttags WHERE AgAtID =" . $tid, '');
     if (!isset($_REQUEST['TextTags']) 
         || !is_array($_REQUEST['TextTags']) 
         || !isset($_REQUEST['TextTags']['TagList']) 
@@ -363,15 +363,15 @@ function saveArchivedTextTags($tid): void
         $tag = $_REQUEST['TextTags']['TagList'][$i];
         if (!in_array($tag, $_SESSION['TEXTTAGS'])) {
             runsql(
-                'INSERT INTO {$tbpref}tags2 (T2Text) 
+                'INSERT INTO tags2 (T2Text) 
                 VALUES(' . convert_string_to_sqlsyntax($tag) . ')', 
                 ""
             );
         }
         runsql(
-            "INSERT INTO {$tbpref}archtexttags (AgAtID, AgT2ID) 
+            "INSERT INTO archtexttags (AgAtID, AgT2ID) 
             SELECT $tid, T2ID 
-            FROM {$tbpref}tags2 
+            FROM tags2 
             WHERE T2Text = " . convert_string_to_sqlsyntax($tag), 
             ""
         );
@@ -388,7 +388,7 @@ function getWordTags($wid): string
     $r = '<ul id="termtags">';
     if ($wid > 0) {
         $sql = 'select TgText 
-        from ' . $tbpref . 'wordtags, ' . $tbpref . 'tags 
+        from wordtags, tags 
         where TgID = WtTgID and WtWoID = ' . $wid . ' 
         order by TgText';
         $res = do_mysqli_query($sql);
@@ -416,7 +416,7 @@ function getTextTags($tid): string
     $r = '<ul id="texttags">';
     if ($tid > 0) {
         $sql = 'SELECT T2Text 
-        FROM ' . $tbpref . 'texttags, ' . $tbpref . 'tags2 
+        FROM texttags, tags2 
         WHERE T2ID = TtT2ID AND TtTxID = ' . $tid . ' 
         ORDER BY T2Text';
         $res = do_mysqli_query($sql);
@@ -445,7 +445,7 @@ function getArchivedTextTags($tid): string
     $r = '<ul id="texttags">';
     if ($tid > 0) {
         $sql = 'SELECT T2Text 
-        FROM ' . $tbpref . 'archtexttags, ' . $tbpref . 'tags2 
+        FROM archtexttags, tags2 
         WHERE T2ID = AgT2ID AND AgAtID = ' . $tid . ' 
         ORDER BY T2Text';
         $res = do_mysqli_query($sql);
@@ -465,31 +465,31 @@ function addtaglist($item, $list): string
     global $tbpref;
     $tagid = get_first_value(
         'select TgID as value 
-        from ' . $tbpref . 'tags 
+        from tags 
         where TgText = ' . convert_string_to_sqlsyntax($item)
     );
     if (!isset($tagid)) {
         runsql(
-            'insert into ' . $tbpref . 'tags (TgText) 
+            'insert into tags (TgText) 
             values(' . convert_string_to_sqlsyntax($item) . ')', 
             ""
         );
         $tagid = get_first_value(
             'select TgID as value 
-            from ' . $tbpref . 'tags 
+            from tags 
             where TgText = ' . convert_string_to_sqlsyntax($item)
         );
     }
     $sql = 'select WoID 
-    from ' . $tbpref . 'words 
-    LEFT JOIN ' . $tbpref . 'wordtags 
+    from words 
+    LEFT JOIN wordtags 
     ON WoID = WtWoID AND WtTgID = ' . $tagid . ' 
     WHERE WtTgID IS NULL AND WoID in ' . $list;
     $res = do_mysqli_query($sql);
     $cnt = 0;
     while ($record = mysqli_fetch_assoc($res)) {
         $cnt += (int) runsql(
-            'insert ignore into ' . $tbpref . 'wordtags (WtWoID, WtTgID) 
+            'insert ignore into wordtags (WtWoID, WtTgID) 
             values(' . $record['WoID'] . ', ' . $tagid . ')', 
             ""
         );
@@ -505,30 +505,30 @@ function addarchtexttaglist($item, $list): string
 {
     global $tbpref;
     $tagid = get_first_value(
-        'select T2ID as value from ' . $tbpref . 'tags2 
+        'select T2ID as value from tags2 
         where T2Text = ' . convert_string_to_sqlsyntax($item)
     );
     if (!isset($tagid)) {
         runsql(
-            'insert into ' . $tbpref . 'tags2 (T2Text) 
+            'insert into tags2 (T2Text) 
             values(' . convert_string_to_sqlsyntax($item) . ')', 
             ""
         );
         $tagid = get_first_value(
             'select T2ID as value 
-            from ' . $tbpref . 'tags2 
+            from tags2 
             where T2Text = ' . convert_string_to_sqlsyntax($item)
         );
     }
-    $sql = 'select AtID from ' . $tbpref . 'archivedtexts 
-    LEFT JOIN ' . $tbpref . 'archtexttags 
+    $sql = 'select AtID from archivedtexts 
+    LEFT JOIN archtexttags 
     ON AtID = AgAtID AND AgT2ID = ' . $tagid . ' 
     WHERE AgT2ID IS NULL AND AtID in ' . $list;
     $res = do_mysqli_query($sql);
     $cnt = 0;
     while ($record = mysqli_fetch_assoc($res)) {
         $cnt += (int) runsql(
-            'insert ignore into ' . $tbpref . 'archtexttags (AgAtID, AgT2ID) 
+            'insert ignore into archtexttags (AgAtID, AgT2ID) 
             values(' . $record['AtID'] . ', ' . $tagid . ')', 
             ""
         );
@@ -545,30 +545,30 @@ function addtexttaglist($item, $list): string
     global $tbpref;
     $tagid = get_first_value(
         'select T2ID as value 
-        from ' . $tbpref . 'tags2 
+        from tags2 
         where T2Text = ' . convert_string_to_sqlsyntax($item)
     );
     if (!isset($tagid)) {
         runsql(
-            'insert into ' . $tbpref . 'tags2 (T2Text) 
+            'insert into tags2 (T2Text) 
             values(' . convert_string_to_sqlsyntax($item) . ')', 
             ""
         );
         $tagid = get_first_value(
             'select T2ID as value 
-            from ' . $tbpref . 'tags2 
+            from tags2 
             where T2Text = ' . convert_string_to_sqlsyntax($item)
         );
     }
-    $sql = 'select TxID from ' . $tbpref . 'texts
-     LEFT JOIN ' . $tbpref . 'texttags 
+    $sql = 'select TxID from texts
+     LEFT JOIN texttags 
      ON TxID = TtTxID AND TtT2ID = ' . $tagid . ' 
      WHERE TtT2ID IS NULL AND TxID in ' . $list;
     $res = do_mysqli_query($sql);
     $cnt = 0;
     while ($record = mysqli_fetch_assoc($res)) {
         $cnt += (int) runsql(
-            'insert ignore into ' . $tbpref . 'texttags (TtTxID, TtT2ID) 
+            'insert ignore into texttags (TtTxID, TtT2ID) 
             values(' . $record['TxID'] . ', ' . $tagid . ')', 
             ""
         );
@@ -585,19 +585,19 @@ function removetaglist($item, $list): string
     global $tbpref;
     $tagid = get_first_value(
         'SELECT TgID AS value
-        FROM ' . $tbpref . 'tags
+        FROM tags
         WHERE TgText = ' . convert_string_to_sqlsyntax($item)
     );
     if (! isset($tagid)) { 
         return "Tag " . $item . " not found"; 
     }
-    $sql = 'select WoID from ' . $tbpref . 'words where WoID in ' . $list;
+    $sql = 'select WoID from words where WoID in ' . $list;
     $res = do_mysqli_query($sql);
     $cnt = 0;
     while ($record = mysqli_fetch_assoc($res)) {
         $cnt++;
         runsql(
-            'DELETE FROM ' . $tbpref . 'wordtags
+            'DELETE FROM wordtags
             WHERE WtWoID = ' . $record['WoID'] . ' AND WtTgID = ' . $tagid, 
             ""
         );
@@ -613,19 +613,19 @@ function removearchtexttaglist($item, $list): string
     global $tbpref;
     $tagid = get_first_value(
         'select T2ID as value 
-        from ' . $tbpref . 'tags2 
+        from tags2 
         where T2Text = ' . convert_string_to_sqlsyntax($item)
     );
     if (!isset($tagid)) { 
         return "Tag " . $item . " not found"; 
     }
-    $sql = 'select AtID from ' . $tbpref . 'archivedtexts where AtID in ' . $list;
+    $sql = 'select AtID from archivedtexts where AtID in ' . $list;
     $res = do_mysqli_query($sql);
     $cnt = 0;
     while ($record = mysqli_fetch_assoc($res)) {
         $cnt++;
         runsql(
-            'delete from ' . $tbpref . 'archtexttags 
+            'delete from archtexttags 
             where AgAtID = ' . $record['AtID'] . ' and AgT2ID = ' . $tagid, 
             ""
         );
@@ -640,19 +640,19 @@ function removetexttaglist($item, $list): string
 {
     global $tbpref;
     $tagid = get_first_value(
-        'select T2ID as value from ' . $tbpref . 'tags2 
+        'select T2ID as value from tags2 
         where T2Text = ' . convert_string_to_sqlsyntax($item)
     );
     if (!isset($tagid)) { 
         return "Tag " . $item . " not found"; 
     }
-    $sql = 'select TxID from ' . $tbpref . 'texts where TxID in ' . $list;
+    $sql = 'select TxID from texts where TxID in ' . $list;
     $res = do_mysqli_query($sql);
     $cnt = 0;
     while ($record = mysqli_fetch_assoc($res)) {
         $cnt++;
         runsql(
-            'delete from ' . $tbpref . 'texttags 
+            'delete from texttags 
             where TtTxID = ' . $record['TxID'] . ' and TtT2ID = ' . $tagid, 
             ""
         );
@@ -671,7 +671,7 @@ function load_feeds($currentfeed): void
     echo '<script type="text/javascript">';
     if (isset($_REQUEST['check_autoupdate'])) {
         $result = do_mysqli_query(
-            "SELECT * FROM " . $tbpref . "newsfeeds 
+            "SELECT * FROM newsfeeds 
             where `NfOptions` like '%autoupdate=%'"
         );
         while($row = mysqli_fetch_assoc($result)){
@@ -697,7 +697,7 @@ function load_feeds($currentfeed): void
         }
         mysqli_free_result($result);
     } else {
-        $sql="SELECT * FROM " . $tbpref . "newsfeeds WHERE NfID in ($currentfeed)";
+        $sql="SELECT * FROM newsfeeds WHERE NfID in ($currentfeed)";
         $result = do_mysqli_query($sql);
         while($row = mysqli_fetch_assoc($result)){
             $ajax[$cnt]=  "$.ajax({type: 'POST',beforeSend: function(){ $('#feed_" . $row['NfID'] . "').replaceWith( '<div id=\"feed_" . $row['NfID'] . "\" class=\"msgblue\"><p>". addslashes($row['NfName']).": loading</p></div>' );},url:'inc/ajax_load_feed.php', data: { NfID: '".$row['NfID']."', NfSourceURI: '". $row['NfSourceURI']."', NfName: '". addslashes($row['NfName'])."', NfOptions: '". $row['NfOptions']."', cnt: '". $cnt."' },success:function (data) {feedcnt+=1;$('#feedcount').text(feedcnt);$('#feed_" . $row['NfID'] . "').replaceWith( data );}})";
@@ -750,7 +750,7 @@ function write_rss_to_db($texts): string
                     foreach($text['TagList'] as $tag){
                         if(! in_array($tag, $_SESSION['TEXTTAGS'])) {
                             do_mysqli_query(
-                                'insert into ' . $tbpref . 'tags2 (T2Text) 
+                                'insert into tags2 (T2Text) 
                                 values (' . convert_string_to_sqlsyntax($tag) . ')'
                             );
                         }
@@ -760,7 +760,7 @@ function write_rss_to_db($texts): string
                 echo '<div class="msgblue"><p class="hide_message">+++ "' . 
                 $text['TxTitle']. '" added! +++</p></div>';
                 do_mysqli_query(
-                    'INSERT INTO ' . $tbpref . 'texts (
+                    'INSERT INTO texts (
                         TxLgID,TxTitle,TxText,TxAudioURI,TxSourceURI
                     ) VALUES (
                         '.$text['TxLgID'].',' . 
@@ -772,26 +772,26 @@ function write_rss_to_db($texts): string
                 $id = (int)get_last_key();
                 splitCheckText(
                     get_first_value(
-                        'select TxText as value from ' . $tbpref . 'texts 
+                        'select TxText as value from texts 
                         where TxID = ' . $id
                     ), 
                     get_first_value(
-                        'select TxLgID as value from ' . $tbpref . 'texts 
+                        'select TxLgID as value from texts 
                         where TxID = ' . $id
                     ), 
                     $id 
                 );
                 do_mysqli_query(
-                    'insert into ' . $tbpref . 'texttags (TtTxID, TtT2ID) 
-                    select ' . $id . ', T2ID from ' . $tbpref . 'tags2 
+                    'insert into texttags (TtTxID, TtT2ID) 
+                    select ' . $id . ', T2ID from tags2 
                     where T2Text in (' . $Nf_tag .')'
                 );        
             }
         }
         get_texttags(1);
         $result=do_mysqli_query(
-            "SELECT TtTxID FROM " . $tbpref . "texttags 
-            join " . $tbpref . "tags2 on TtT2ID=T2ID 
+            "SELECT TtTxID FROM texttags 
+            join tags2 on TtT2ID=T2ID 
             WHERE T2Text in (". $Nf_tag .")"
         );
         $text_count=0;
@@ -804,34 +804,34 @@ function write_rss_to_db($texts): string
             $text_item=array_slice($text_item, 0, $text_count-$nf_max_texts);
             foreach ($text_item as $text_ID){
                 $message3 += (int) runsql(
-                    'delete from ' . $tbpref . 'textitems2 
+                    'delete from textitems2 
                     where Ti2TxID = ' . $text_ID, 
                     ""
                 );
                 $message2 += (int) runsql(
-                    'delete from ' . $tbpref . 'sentences 
+                    'delete from sentences 
                     where SeTxID = ' . $text_ID, 
                     ""
                 );
                 $message4 += (int) runsql(
-                    'insert into ' . $tbpref . 'archivedtexts (
+                    'insert into archivedtexts (
                         AtLgID, AtTitle, AtText, AtAnnotatedText, 
                         AtAudioURI, AtSourceURI
                     ) select TxLgID, TxTitle, TxText, TxAnnotatedText, 
                     TxAudioURI, TxSourceURI 
-                    from ' . $tbpref . 'texts 
+                    from texts 
                     where TxID = ' . $text_ID, 
                     ""
                 );
                 $id = get_last_key();
                 runsql(
-                    'insert into ' . $tbpref . 'archtexttags (AgAtID, AgT2ID) 
-                    select ' . $id . ', TtT2ID from ' . $tbpref . 'texttags 
+                    'insert into archtexttags (AgAtID, AgT2ID) 
+                    select ' . $id . ', TtT2ID from texttags 
                     where TtTxID = ' . $text_ID, 
                     ""
                 );    
                 $message1 += (int) runsql(
-                    'delete from ' . $tbpref . 'texts 
+                    'delete from texts 
                     where TxID = ' . $text_ID, 
                     ""
                 );
@@ -839,10 +839,10 @@ function write_rss_to_db($texts): string
                 adjust_autoincr('texts', 'TxID');
                 adjust_autoincr('sentences', 'SeID');
                 runsql(
-                    "DELETE " . $tbpref . "texttags 
+                    "DELETE texttags 
                     FROM (" 
                         . $tbpref . "texttags 
-                        LEFT JOIN " . $tbpref . "texts on TtTxID = TxID
+                        LEFT JOIN texts on TtTxID = TxID
                     ) 
                     WHERE TxID IS NULL", 
                     ''
@@ -1209,7 +1209,7 @@ function get_text_from_rsslink($feed_data, $NfArticleSection, $NfFilterTags, $Nf
             $link = trim($feed_data[$key]['link']);
             if(substr($link, 0, 1)=='#') {
                 runsql(
-                    'UPDATE ' . $tbpref . 'feedlinks 
+                    'UPDATE feedlinks 
                     SET FlLink=' . convert_string_to_sqlsyntax($link) . ' 
                     where FlID = ' .substr($link, 1), 
                     ""
@@ -1518,11 +1518,11 @@ function getPreviousAndNextTextLinks($textid, $url, $onlyann, $add): string
         $sql = 
         'SELECT TxID 
         FROM (
-            (' . $tbpref . 'texts 
-                LEFT JOIN ' . $tbpref . 'texttags ON TxID = TtTxID
+            (texts 
+                LEFT JOIN texttags ON TxID = TtTxID
             ) 
-            LEFT JOIN ' . $tbpref . 'tags2 ON T2ID = TtT2ID
-        ), ' . $tbpref . 'languages 
+            LEFT JOIN tags2 ON T2ID = TtT2ID
+        ), languages 
         WHERE LgID = TxLgID AND LENGTH(TxAnnotatedText) > 0 ' 
         . $wh_lang . $wh_query . ' 
         GROUP BY TxID ' . $wh_tag . ' 
@@ -1532,11 +1532,11 @@ function getPreviousAndNextTextLinks($textid, $url, $onlyann, $add): string
         $sql = 
         'SELECT TxID 
         FROM (
-            (' . $tbpref . 'texts 
-                LEFT JOIN ' . $tbpref . 'texttags ON TxID = TtTxID
+            (texts 
+                LEFT JOIN texttags ON TxID = TtTxID
             ) 
-            LEFT JOIN ' . $tbpref . 'tags2 ON T2ID = TtT2ID
-        ), ' . $tbpref . 'languages 
+            LEFT JOIN tags2 ON T2ID = TtT2ID
+        ), languages 
         WHERE LgID = TxLgID ' . $wh_lang . $wh_query . ' 
         GROUP BY TxID ' . $wh_tag . ' 
         ORDER BY ' . $sorts[$currentsort-1]; 
@@ -2022,10 +2022,10 @@ function getWordTagList($wid, $before=' ', $brack=1, $tohtml=1): string
         "SELECT IFNULL(" . ($brack ? "CONCAT('['," : "") . 
         "GROUP_CONCAT(DISTINCT TgText ORDER BY TgText separator ', ')" . 
         ($brack ? ",']')" : "") . ",'') as value 
-        FROM ((" . $tbpref . "words 
-        LEFT JOIN " . $tbpref . "wordtags 
+        FROM ((words 
+        LEFT JOIN wordtags 
         ON WoID = WtWoID) 
-        LEFT JOIN " . $tbpref . "tags 
+        LEFT JOIN tags 
         ON TgID = WtTgID) 
         WHERE WoID = " . $wid
     );
@@ -2118,7 +2118,7 @@ function make_status_controls_test_table($score, $status, $wordid): string
 function get_languages_selectoptions($v,$dt): string 
 {
     global $tbpref;
-    $sql = "select LgID, LgName from " . $tbpref . "languages 
+    $sql = "select LgID, LgName from languages 
     where LgName<>'' order by LgName";
     $res = do_mysqli_query($sql);
     if (! isset($v) || trim($v) == '' ) {
@@ -2533,7 +2533,7 @@ function get_texts_selectoptions($lang, $v): string
     $r = "<option value=\"\"" . get_selected($v, '');
     $r .= ">[Filter off]</option>";
     $sql = "select TxID, TxTitle, LgName 
-    from " . $tbpref . "languages, " . $tbpref . "texts 
+    from languages, texts 
     where LgID = TxLgID " . $l . " 
     order by LgName, TxTitle";
     $res = do_mysqli_query($sql);
@@ -2726,7 +2726,7 @@ function createDictLinksInEditWin($lang,$word,$sentctljs,$openfirst): string
 {
     global $tbpref;
     $sql = 'SELECT LgDict1URI, LgDict2URI, LgGoogleTranslateURI 
-    FROM ' . $tbpref . 'languages 
+    FROM languages 
     WHERE LgID = ' . $lang;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
@@ -2810,7 +2810,7 @@ function createDictLinksInEditWin2($lang,$sentctljs,$wordctljs): string
 {
     global $tbpref;
     $sql = 'SELECT LgDict1URI, LgDict2URI, LgGoogleTranslateURI 
-    FROM ' . $tbpref . 'languages 
+    FROM languages 
     WHERE LgID = ' . $lang;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
@@ -2845,7 +2845,7 @@ function makeDictLinks($lang,$wordctljs): string
 {
     global $tbpref;
     $sql = 'SELECT LgDict1URI, LgDict2URI, LgGoogleTranslateURI 
-    FROM ' . $tbpref . 'languages WHERE LgID = ' . $lang;
+    FROM languages WHERE LgID = ' . $lang;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $wb1 = isset($record['LgDict1URI']) ? $record['LgDict1URI'] : "";
@@ -2879,7 +2879,7 @@ function createDictLinksInEditWin3($lang,$sentctljs,$wordctljs): string
 {
     global $tbpref;
     $sql = 'SELECT LgDict1URI, LgDict2URI, LgGoogleTranslateURI 
-    FROM ' . $tbpref . 'languages WHERE LgID = ' . $lang;
+    FROM languages WHERE LgID = ' . $lang;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     
@@ -3217,7 +3217,7 @@ function textwordcount($textID): void
     $res = do_mysqli_query(
         "SELECT Ti2TxID AS text, COUNT(DISTINCT LOWER(Ti2Text)) AS value, 
         COUNT(LOWER(Ti2Text)) AS total
-		FROM {$tbpref}textitems2
+		FROM textitems2
 		WHERE Ti2WordCount = 1 AND Ti2TxID IN($textID)
 		GROUP BY Ti2TxID"
     );
@@ -3229,7 +3229,7 @@ function textwordcount($textID): void
     $res = do_mysqli_query(
         'SELECT Ti2TxID as text, count(distinct Ti2WoID) as value, 
         count(Ti2WoID) as total
-		from ' . $tbpref . 'textitems2
+		from textitems2
 		where Ti2WordCount > 1 and Ti2TxID in(' . $textID . ')
 		group by Ti2TxID'
     );
@@ -3241,7 +3241,7 @@ function textwordcount($textID): void
     $res = do_mysqli_query(
         'SELECT Ti2TxID as text, count(distinct Ti2WoID) as value, 
         count(Ti2WoID) as total, WoStatus as status
-		from ' . $tbpref . 'textitems2, ' . $tbpref . 'words
+		from textitems2, words
 		where Ti2WoID!=0 and Ti2TxID in(' . $textID . ') and Ti2WoID=WoID
 		group by Ti2TxID, WoStatus'
     );
@@ -3265,7 +3265,7 @@ function texttodocount($text): string
     return '<span title="To Do" class="status0">&nbsp;' . 
     (get_first_value(
         'SELECT count(DISTINCT LOWER(Ti2Text)) as value 
-        FROM ' . $tbpref . 'textitems2 
+        FROM textitems2 
         WHERE Ti2WordCount=1 and Ti2WoID=0 and Ti2TxID=' . $text
     )
     ) . '&nbsp;</span>';
@@ -3288,7 +3288,7 @@ function texttodocount2($textid): string
     }
     $c = get_first_value(
         "SELECT COUNT(DISTINCT LOWER(Ti2Text)) AS value 
-        FROM {$tbpref}textitems2 
+        FROM textitems2 
         WHERE Ti2WordCount=1 AND Ti2WoID=0 AND Ti2TxID=$textid"
     );
     if ($c <= 0) {
@@ -3298,7 +3298,7 @@ function texttodocount2($textid): string
     
     $dict = get_first_value(
         "SELECT LgGoogleTranslateURI AS value 
-        FROM {$tbpref}languages, {$tbpref}texts 
+        FROM languages, texts 
         WHERE LgID = TxLgID and TxID = $textid"
     );
     if ($dict) {
@@ -3345,7 +3345,7 @@ function getSentence($seid, $wordlc, $mode): array
             '​', group_concat(Ti2Text ORDER BY Ti2Order asc SEPARATOR '​'),'​'
         ) AS SeText, 
         Ti2TxID AS SeTxID, LgRegexpWordCharacters, LgRemoveSpaces,  LgSplitEachChar 
-        FROM {$tbpref}textitems2, {$tbpref}languages 
+        FROM textitems2, languages 
         WHERE Ti2LgID = LgID AND Ti2WordCount < 2 AND Ti2SeID = $seid" 
     );
     $record = mysqli_fetch_assoc($res);
@@ -3376,7 +3376,7 @@ function getSentence($seid, $wordlc, $mode): array
                 'select concat(
                     \'​\',group_concat(Ti2Text order by Ti2Order asc SEPARATOR \'​\'),\'​\'
                 ) as value 
-                from ' . $tbpref . 'sentences, ' . $tbpref . 'textitems2 
+                from sentences, textitems2 
                 where Ti2SeID = SeID and SeID < ' . $seid . ' and SeTxID = ' . $txtid . " 
                 and trim(SeText) not in ('¶','') 
                 group by SeID 
@@ -3384,7 +3384,7 @@ function getSentence($seid, $wordlc, $mode): array
             );
         } else {
             $prevseSent = get_first_value(
-                'select SeText as value from ' . $tbpref . 'sentences 
+                'select SeText as value from sentences 
                 where SeID < ' . $seid . ' and SeTxID = ' . $txtid . "
                  and trim(SeText) not in ('¶','') order by SeID desc"
             );
@@ -3400,7 +3400,7 @@ function getSentence($seid, $wordlc, $mode): array
                         \'​\',group_concat(Ti2Text order by Ti2Order asc SEPARATOR \'​\'),
                         \'​\'
                     ) as  value 
-                    from ' . $tbpref . 'sentences, ' . $tbpref . 'textitems2 
+                    from sentences, textitems2 
                     where Ti2SeID = SeID and SeID > ' . $seid . ' 
                     and SeTxID = ' . $txtid . " 
                     and trim(SeText) not in ('¶','') 
@@ -3410,7 +3410,7 @@ function getSentence($seid, $wordlc, $mode): array
             } else {
                 $nextSent = get_first_value(
                     'SELECT SeText as value 
-                    from ' . $tbpref . 'sentences 
+                    from sentences 
                     where SeID > ' . $seid . ' and SeTxID = ' . $txtid . " 
                     and trim(SeText) not in ('¶','') order by SeID asc"
                 );
@@ -3427,7 +3427,7 @@ function getSentence($seid, $wordlc, $mode): array
         $sejs = str_replace('​', '', $sejs);
     }
     /* Not merged from official. Works better?
-    $nextseid = get_first_value('select SeID as value from ' . $tbpref . 'sentences where SeID > ' . $seid . ' and SeTxID = ' . $txtid . " and trim(SeText) not in ('¶','') order by SeID asc");
+    $nextseid = get_first_value('select SeID as value from sentences where SeID > ' . $seid . ' and SeTxID = ' . $txtid . " and trim(SeText) not in ('¶','') order by SeID asc");
     if (isset($nextseid)) $seidlist .= ',' . $nextseid;
     }
     }
@@ -3503,7 +3503,7 @@ function get20Sentences($lang, $wordlc, $wid, $jsctlname, $mode): string
     to copy sentence into above term)</p>';
     if (empty($wid)) {
         $sql = "SELECT DISTINCT SeID, SeText 
-        FROM {$tbpref}sentences, {$tbpref}textitems2 
+        FROM sentences, textitems2 
         WHERE LOWER(Ti2Text) = " . convert_string_to_sqlsyntax($wordlc) . " 
         AND Ti2WoID = 0 AND SeID = Ti2SeID AND SeLgID = $lang 
         ORDER BY CHAR_LENGTH(SeText), SeText 
@@ -3511,7 +3511,7 @@ function get20Sentences($lang, $wordlc, $wid, $jsctlname, $mode): string
     } else if ($wid==-1) {
         $res = do_mysqli_query(
             'SELECT LgRegexpWordCharacters, LgRemoveSpaces 
-            FROM ' . $tbpref . 'languages 
+            FROM languages 
             WHERE LgID = ' . $lang
         );
         $record = mysqli_fetch_assoc($res);
@@ -3551,7 +3551,7 @@ function get20Sentences($lang, $wordlc, $wid, $jsctlname, $mode): string
                 group_concat(Ti2Text ORDER BY Ti2Order asc SEPARATOR "\\t"),
                 "\\t"
             ) val
-             FROM ' . $tbpref . 'sentences, ' . $tbpref . 'textitems2
+             FROM sentences, textitems2
              WHERE lower(SeText)
              LIKE ' . convert_string_to_sqlsyntax("%$wordlc%") . '
              AND SeID = Ti2SeID AND SeLgID = ' . $lang . ' AND Ti2WordCount<2
@@ -3571,7 +3571,7 @@ function get20Sentences($lang, $wordlc, $wid, $jsctlname, $mode): string
             }
             $sql 
             = "SELECT DISTINCT SeID, SeText
-             FROM {$tbpref}sentences
+             FROM sentences
              WHERE SeText RLIKE $pattern AND SeLgID = $lang
              ORDER BY CHAR_LENGTH(SeText), SeText 
              LIMIT 0,20";
@@ -3579,7 +3579,7 @@ function get20Sentences($lang, $wordlc, $wid, $jsctlname, $mode): string
     } else {
         $sql 
         = "SELECT DISTINCT SeID, SeText
-         FROM {$tbpref}sentences, {$tbpref}textitems2
+         FROM sentences, textitems2
          WHERE Ti2WoID = $wid AND SeID = Ti2SeID AND SeLgID = $lang
          ORDER BY CHAR_LENGTH(SeText), SeText
          LIMIT 0,20";
@@ -3614,7 +3614,7 @@ function get_languages(): array
 {
     global $tbpref;
     $langs = array();
-    $sql = "SELECT LgID, LgName FROM " . $tbpref . "languages WHERE LgName<>''";
+    $sql = "SELECT LgID, LgName FROM languages WHERE LgName<>''";
     $res = do_mysqli_query($sql);
     while ($record = mysqli_fetch_assoc($res)) {
         $langs[$record['LgName']] = $record['LgID'];
@@ -3639,7 +3639,7 @@ function getLanguage($lid)
     }
     $r = get_first_value(
         "SELECT LgName AS value 
-        FROM " . $tbpref . "languages 
+        FROM languages 
         WHERE LgID='" . $lid . "'"
     );
     if (isset($r)) { 
@@ -3664,7 +3664,7 @@ function getScriptDirectionTag($lid): string
     }
     $r = get_first_value(
         "select LgRightToLeft as value 
-        from " . $tbpref . "languages 
+        from languages 
         where LgID='" . $lid . "'"
     );
     if (isset($r) ) {
@@ -3697,7 +3697,7 @@ function insert_expression_from_mecab($text, $lid, $wid, $len)
     $mecab_args = " -F %m\\t%t\\t%h\\n -U %m\\t%t\\t%h\\n -E EOS\\t3\\t7\\n ";
 
     $mecab = get_mecab_path($mecab_args);
-    $sql = "SELECT SeID, SeTxID, SeFirstPos, SeText FROM {$tbpref}sentences 
+    $sql = "SELECT SeID, SeTxID, SeFirstPos, SeText FROM sentences 
     WHERE SeText LIKE " . convert_string_to_sqlsyntax_notrim_nonull("%$text%");
     $res = do_mysqli_query($sql);
 
@@ -3801,7 +3801,7 @@ function insert_standard_expression($textlc, $lid, $wid, $len, $mode)
     global $tbpref;
     $appendtext = array();
     $sqlarr = array();
-    $res = do_mysqli_query("SELECT * FROM {$tbpref}languages WHERE LgID=$lid");
+    $res = do_mysqli_query("SELECT * FROM languages WHERE LgID=$lid");
     $record = mysqli_fetch_assoc($res);
     $removeSpaces = $record["LgRemoveSpaces"];
     $splitEachChar = $record['LgSplitEachChar'];
@@ -3812,13 +3812,13 @@ function insert_standard_expression($textlc, $lid, $wid, $len, $mode)
         $sql = "SELECT 
         group_concat(Ti2Text ORDER BY Ti2Order SEPARATOR ' ') AS SeText, SeID, 
         SeTxID, SeFirstPos 
-        FROM {$tbpref}textitems2, {$tbpref}sentences 
+        FROM textitems2, sentences 
         WHERE SeID=Ti2SeID AND SeLgID = $lid AND Ti2LgID = $lid 
         AND SeText LIKE " . convert_string_to_sqlsyntax_notrim_nonull("%$textlc%") . " 
         AND Ti2WordCount < 2 
         GROUP BY SeID";
     } else {
-        $sql = "SELECT * FROM {$tbpref}sentences 
+        $sql = "SELECT * FROM sentences 
         WHERE SeLgID = $lid AND SeText LIKE " . 
         convert_string_to_sqlsyntax_notrim_nonull("%$textlc%");
     }
@@ -3926,7 +3926,7 @@ function new_expression_interactable2($hex, $appendtext, $wid, $len): void
     global $tbpref;
     $showAll = (bool)getSettingZeroOrOne('showallwords', 1) ? "m" : "";
     
-    $sql = "SELECT * FROM {$tbpref}words WHERE WoID=$wid";
+    $sql = "SELECT * FROM words WHERE WoID=$wid";
     $res = do_mysqli_query($sql);
 
     $record = mysqli_fetch_assoc($res);
@@ -3988,7 +3988,7 @@ function new_expression_interactable2($hex, $appendtext, $wid, $len): void
 function insertExpressions($textlc, $lid, $wid, $len, $mode) 
 {
     global $tbpref;
-    $sql = "SELECT * FROM {$tbpref}languages WHERE LgID=$lid";
+    $sql = "SELECT * FROM languages WHERE LgID=$lid";
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $mecab = 'MECAB' == strtoupper(trim($record['LgRegexpWordCharacters']));
@@ -4013,7 +4013,7 @@ function insertExpressions($textlc, $lid, $wid, $len, $mode)
         $sqltext = '';
         if ($mode != 2) {
             $sqltext .= 
-            "INSERT INTO {$tbpref}textitems2
+            "INSERT INTO textitems2
              (Ti2WoID,Ti2LgID,Ti2TxID,Ti2SeID,Ti2Order,Ti2WordCount,Ti2Text)
              VALUES ";
         }
@@ -4167,14 +4167,14 @@ function recreate_save_ann($textid, $oldann): ?string
         $ann .= $item . "\n";
     }
     runsql(
-        'update ' . $tbpref . 'texts set ' .
+        'update texts set ' .
         'TxAnnotatedText = ' . convert_string_to_sqlsyntax($ann) . ' 
         where TxID = ' . $textid, 
         ""
     );
     return get_first_value(
         "select TxAnnotatedText as value 
-        from " . $tbpref . "texts 
+        from texts 
         where TxID = " . $textid
     );
 }
@@ -4193,8 +4193,8 @@ function create_ann($textid): string
     CASE WHEN Ti2WordCount > 0 THEN 0 ELSE 1 END AS TiIsNotWord, 
     WoID, WoTranslation 
     FROM (
-        ' . $tbpref . 'textitems2 
-        LEFT JOIN ' . $tbpref . 'words ON (Ti2WoID = WoID) AND (Ti2LgID = WoLgID)
+        textitems2 
+        LEFT JOIN words ON (Ti2WoID = WoID) AND (Ti2LgID = WoLgID)
     ) 
     WHERE Ti2TxID = ' . $textid . ' 
     ORDER BY Ti2Order asc, Ti2WordCount desc';
@@ -4266,13 +4266,13 @@ function create_save_ann($textid): ?string
     global $tbpref;
     $ann = create_ann($textid);
     runsql(
-        'update ' . $tbpref . 'texts set ' .
+        'update texts set ' .
         'TxAnnotatedText = ' . convert_string_to_sqlsyntax($ann) . ' 
         where TxID = ' . $textid, ""
     );
     return get_first_value(
         "select TxAnnotatedText as value 
-        from " . $tbpref . "texts 
+        from texts 
         where TxID = " . $textid
     );
 }
@@ -4310,7 +4310,7 @@ function get_first_translation($trans): string
 function get_annotation_link($textid): string 
 {
     global $tbpref;
-    if (get_first_value('select length(TxAnnotatedText) as value from ' . $tbpref . 'texts where TxID=' . $textid) > 0) { 
+    if (get_first_value('select length(TxAnnotatedText) as value from texts where TxID=' . $textid) > 0) { 
         return ' &nbsp;<a href="print_impr_text.php?text=' . $textid . 
         '" target="_top"><img src="icn/tick.png" title="Annotated Text" alt="Annotated Text" /></a>'; 
     }
@@ -4414,7 +4414,7 @@ function refreshText($word,$tid): string
     $sql = 
     'SELECT TiWordCount AS Code, TiOrder, TiIsNotWord, WoID 
     FROM (' . $tbpref . 'textitems 
-        LEFT JOIN ' . $tbpref . 'words ON (TiTextLC = WoTextLC) AND (TiLgID = WoLgID)
+        LEFT JOIN words ON (TiTextLC = WoTextLC) AND (TiLgID = WoLgID)
     ) ' . $inlist . ' 
     ORDER BY TiOrder asc, TiWordCount desc';
 

--- a/inc/session_utility.php
+++ b/inc/session_utility.php
@@ -224,14 +224,14 @@ function get_archivedtexttag_selectoptions($v,$l): string
     if ($l == '') {
         $sql = "select T2ID, T2Text 
         from archivedtexts, " . 
-        $tbpref . "tags2, archtexttags 
+        tags2, archtexttags 
         where T2ID = AgT2ID and AgAtID = AtID 
         group by T2ID 
         order by UPPER(T2Text)"; 
     } else {
         $sql = "select T2ID, T2Text 
         from archivedtexts, tags2, " . 
-        $tbpref . "archtexttags 
+        archtexttags 
         where T2ID = AgT2ID and AgAtID = AtID and AtLgID = " . $l . " 
         group by T2ID 
         order by UPPER(T2Text)"; 
@@ -841,7 +841,7 @@ function write_rss_to_db($texts): string
                 runsql(
                     "DELETE texttags 
                     FROM (" 
-                        . $tbpref . "texttags 
+                        . texttags 
                         LEFT JOIN texts on TtTxID = TxID
                     ) 
                     WHERE TxID IS NULL", 
@@ -3518,7 +3518,7 @@ function get20Sentences($lang, $wordlc, $wid, $jsctlname, $mode): string
         mysqli_free_result($res);
         $removeSpaces = $record["LgRemoveSpaces"];
         if ('MECAB'== strtoupper(trim($record["LgRegexpWordCharacters"]))) {
-            $mecab_file = sys_get_temp_dir() . "/" . $tbpref . "mecab_to_db.txt";
+            $mecab_file = sys_get_temp_dir() . "/mecab_to_db.txt";
             //$mecab_args = ' -F {%m%t\\t -U {%m%t\\t -E \\n ';
             // For instance, "このラーメン" becomes "この    6    68\nラーメン    7    38"
             $mecab_args = ' -F %m\\t%t\\t%h\\n -U %m\\t%t\\t%h\\n -E EOS\\t3\\t7\\n ';
@@ -3693,7 +3693,7 @@ function insert_expression_from_mecab($text, $lid, $wid, $len)
 {
     global $tbpref;
 
-    $db_to_mecab = tempnam(sys_get_temp_dir(), "{$tbpref}db_to_mecab");
+    $db_to_mecab = tempnam(sys_get_temp_dir(), "db_to_mecab");
     $mecab_args = " -F %m\\t%t\\t%h\\n -U %m\\t%t\\t%h\\n -E EOS\\t3\\t7\\n ";
 
     $mecab = get_mecab_path($mecab_args);
@@ -4348,7 +4348,7 @@ function phonetic_reading($text, $lang)
     }
 
     // Japanese is an exception
-    $mecab_file = sys_get_temp_dir() . "/" . $tbpref . "mecab_to_db.txt";
+    $mecab_file = sys_get_temp_dir() . "/mecab_to_db.txt";
     $mecab_args = ' -O yomi ';
     if (file_exists($mecab_file)) { 
         unlink($mecab_file); 

--- a/inc/session_utility.php
+++ b/inc/session_utility.php
@@ -3431,7 +3431,7 @@ function getSentence($seid, $wordlc, $mode): array
     if (isset($nextseid)) $seidlist .= ',' . $nextseid;
     }
     }
-    $sql2 = 'SELECT TiText, TiTextLC, TiWordCount, TiIsNotWord FROM ' . $tbpref . 'textitems WHERE TiSeID in (' . $seidlist . ') and TiTxID=' . $txtid . ' order by TiOrder asc, TiWordCount desc';
+    $sql2 = 'SELECT TiText, TiTextLC, TiWordCount, TiIsNotWord FROM textitems WHERE TiSeID in (' . $seidlist . ') and TiTxID=' . $txtid . ' order by TiOrder asc, TiWordCount desc';
     $res2 = do_mysqli_query($sql2);
     $sejs=''; 
     $se='';
@@ -4109,7 +4109,7 @@ function restore_file($handle, $title): string
     } // while (! feof($handle))
     gzclose($handle);
     if ($errors == 0) {
-        runsql("DROP TABLE IF EXISTS {$tbpref}textitems", '');
+        runsql("DROP TABLE IF EXISTS textitems", '');
         check_update_db($debug, $tbpref, $dbname);
         reparse_all_texts();
         optimizedb();
@@ -4392,7 +4392,7 @@ function refreshText($word,$tid): string
         return ''; 
     }
     $sql = 
-    'SELECT distinct TiSeID FROM ' . $tbpref . 'textitems 
+    'SELECT distinct TiSeID FROM textitems 
     WHERE TiIsNotWord = 0 AND TiTextLC = ' . convert_string_to_sqlsyntax($wordlc) . ' 
     AND TiTxID = ' . $tid . ' 
     ORDER BY TiSeID';
@@ -4413,7 +4413,7 @@ function refreshText($word,$tid): string
     }
     $sql = 
     'SELECT TiWordCount AS Code, TiOrder, TiIsNotWord, WoID 
-    FROM (' . $tbpref . 'textitems 
+    FROM (textitems 
         LEFT JOIN words ON (TiTextLC = WoTextLC) AND (TiLgID = WoLgID)
     ) ' . $inlist . ' 
     ORDER BY TiOrder asc, TiWordCount desc';

--- a/inc/simterms.php
+++ b/inc/simterms.php
@@ -75,7 +75,7 @@ function get_similar_terms(
     $lang_id, $compared_term, $max_count, $min_ranking
 ): array { 
 
-    global $tbpref;
+
     $compared_term_lc = mb_strtolower($compared_term, 'UTF-8');
     $sql = "select WoID, WoTextLC from words where WoLgID = " . $lang_id . " AND WoTextLC <> " . convert_string_to_sqlsyntax($compared_term_lc);
     $res = do_mysqli_query($sql);
@@ -103,7 +103,7 @@ function get_similar_terms(
  */
 function print_similar_terms($lang_id, $compared_term): string 
 {
-    global $tbpref;
+
     $max_count = (int)getSettingWithDefault("set-similar-terms-count");
     if ($max_count <= 0) { 
         return ''; 

--- a/inc/simterms.php
+++ b/inc/simterms.php
@@ -77,7 +77,7 @@ function get_similar_terms(
 
     global $tbpref;
     $compared_term_lc = mb_strtolower($compared_term, 'UTF-8');
-    $sql = "select WoID, WoTextLC from " . $tbpref . "words where WoLgID = " . $lang_id . " AND WoTextLC <> " . convert_string_to_sqlsyntax($compared_term_lc);
+    $sql = "select WoID, WoTextLC from words where WoLgID = " . $lang_id . " AND WoTextLC <> " . convert_string_to_sqlsyntax($compared_term_lc);
     $res = do_mysqli_query($sql);
     $termlsd = array();
     while ($record = mysqli_fetch_assoc($res)) {
@@ -115,7 +115,7 @@ function print_similar_terms($lang_id, $compared_term): string
     $termarr = get_similar_terms($lang_id, $compared_term, $max_count, 0.33);
     $rarr = array();
     foreach ($termarr as $termid) {
-        $sql = "select WoText, WoTranslation, WoRomanization from " . $tbpref . "words where WoID = " . $termid;
+        $sql = "select WoText, WoTranslation, WoRomanization from words where WoID = " . $termid;
         $res = do_mysqli_query($sql);
         if ($record = mysqli_fetch_assoc($res)) {
             $term = tohtml($record["WoText"]);

--- a/index.php
+++ b/index.php
@@ -115,19 +115,19 @@ function do_current_text_info($textid)
     global $tbpref;
     $txttit = get_first_value(
         'SELECT TxTitle AS value 
-        FROM ' . $tbpref . 'texts 
+        FROM texts 
         WHERE TxID=' . $textid
     );
     if (!isset($txttit)) {
         return;
     } 
     $txtlng = get_first_value(
-        'SELECT TxLgID AS value FROM ' . $tbpref . 'texts WHERE TxID=' . $textid
+        'SELECT TxLgID AS value FROM texts WHERE TxID=' . $textid
     );
     $lngname = getLanguage($txtlng);
     $annotated = (int)get_first_value(
         "SELECT LENGTH(TxAnnotatedText) AS value 
-        FROM " . $tbpref . "texts 
+        FROM texts 
         WHERE TxID = " . $textid
     ) > 0;
     ?>
@@ -259,7 +259,7 @@ if (is_numeric(getSetting('currenttext'))) {
     $currenttext = (int) getSetting('currenttext');
 }
 
-$langcnt = (int) get_first_value('SELECT COUNT(*) AS value FROM ' . $tbpref . 'languages');
+$langcnt = (int) get_first_value('SELECT COUNT(*) AS value FROM languages');
 
 list($p, $mb, $serversoft, $apache, $php, $mysql) = get_server_data();
 

--- a/inline_edit.php
+++ b/inline_edit.php
@@ -16,11 +16,11 @@ if (substr($id, 0, 5) == "trans") {
     if($value == '') { $value='*'; 
     }
     runsql(
-        'update ' . $tbpref . 'words set WoTranslation = ' . 
+        'update words set WoTranslation = ' . 
         convert_string_to_sqlsyntax(repl_tab_nl($value)) . ' where WoID = ' . $id,
         ""
     );
-    echo get_first_value("select WoTranslation as value from " . $tbpref . "words where WoID = " . $id);
+    echo get_first_value("select WoTranslation as value from words where WoID = " . $id);
     exit;
 }
 
@@ -29,11 +29,11 @@ if (substr($id, 0, 5) == "roman") {
     }
     $id = substr($id, 5);
     runsql(
-        'update ' . $tbpref . 'words set WoRomanization = ' . 
+        'update words set WoRomanization = ' . 
         convert_string_to_sqlsyntax(repl_tab_nl($value)) . ' where WoID = ' . $id,
         ""
     );
-    $value = get_first_value("select WoRomanization as value from " . $tbpref . "words where WoID = " . $id);
+    $value = get_first_value("select WoRomanization as value from words where WoID = " . $id);
     if ($value == '') { 
         echo '*'; 
     }

--- a/insert_word_ignore.php
+++ b/insert_word_ignore.php
@@ -22,11 +22,11 @@ require_once 'inc/session_utility.php';
  * 
  * @return string|null A word
  * 
- * @global string $tbpref 
+ *
  */
 function get_word($textid, $textpos) 
 {
-    global $tbpref;
+
     $word = get_first_value(
         "SELECT Ti2Text AS value 
         FROM textitems2 
@@ -45,11 +45,11 @@ function get_word($textid, $textpos)
  * 
  * @return string|null Word ID 
  * 
- * @global string $tbpref 
+ *
  */
 function insert_word_ignore_to_database($textid, $word)
 {
-    global $tbpref;
+
     
     $wordlc = mb_strtolower($word, 'UTF-8');
     
@@ -87,7 +87,7 @@ function insert_word_ignore_to_database($textid, $word)
  * @param string $hex    Hexadecimal version of the lowercase word.
  * @param string $textid ID of the text.
  * 
- * @global string $tbpref 
+ *
  * 
  * @return void
  */

--- a/insert_word_ignore.php
+++ b/insert_word_ignore.php
@@ -29,7 +29,7 @@ function get_word($textid, $textpos)
     global $tbpref;
     $word = get_first_value(
         "SELECT Ti2Text AS value 
-        FROM " . $tbpref . "textitems2 
+        FROM textitems2 
         WHERE Ti2WordCount = 1 AND Ti2TxID = " . $textid . " AND Ti2Order = " . $textpos
     );
     return $word;
@@ -55,11 +55,11 @@ function insert_word_ignore_to_database($textid, $word)
     
     $langid = get_first_value(
         "SELECT TxLgID AS value 
-        FROM " . $tbpref . "texts 
+        FROM texts 
         WHERE TxID = " . $textid
     );
     runsql(
-        'INSERT INTO ' . $tbpref . 'words (
+        'INSERT INTO words (
             WoLgID, WoText, WoTextLC, WoStatus, WoWordCount, WoStatusChanged,' .  make_score_random_insert_update('iv') . '
         ) values( ' . 
             $langid . ', ' . 
@@ -72,7 +72,7 @@ function insert_word_ignore_to_database($textid, $word)
     $wid = get_last_key();
     
     do_mysqli_query(
-        "UPDATE  " . $tbpref . "textitems2
+        "UPDATE  textitems2
         SET Ti2WoID  = " . $wid . " 
         WHERE Ti2LgID = " . $langid . " AND lower(Ti2Text) = " . convert_string_to_sqlsyntax($wordlc)
     );

--- a/insert_word_wellknown.php
+++ b/insert_word_wellknown.php
@@ -27,7 +27,7 @@ function get_word($textid, $textpos)
     global $tbpref;
     $word = get_first_value(
         "SELECT Ti2Text AS value 
-        FROM " . $tbpref . "textitems2 
+        FROM textitems2 
         WHERE Ti2WordCount = 1 AND Ti2TxID = " . $textid . " AND Ti2Order = " . $textpos
     );
     return $word;
@@ -51,11 +51,11 @@ function insert_word_wellknown_to_database($textid, $word)
     
     $langid = get_first_value(
         "SELECT TxLgID AS value 
-        FROM " . $tbpref . "texts 
+        FROM texts 
         WHERE TxID = " . $textid
     );
     runsql(
-        'INSERT INTO ' . $tbpref . 'words (
+        'INSERT INTO words (
             WoLgID, WoText, WoTextLC, WoStatus, WoWordCount, WoStatusChanged,' .  make_score_random_insert_update('iv') . '
         ) values( ' . 
             $langid . ', ' . 
@@ -67,7 +67,7 @@ function insert_word_wellknown_to_database($textid, $word)
     );
     $wid = get_last_key();
     do_mysqli_query(
-        "UPDATE  " . $tbpref . "textitems2
+        "UPDATE  textitems2
         SET Ti2WoID  = " . $wid . " 
         WHERE Ti2LgID = " . $langid . " AND lower(Ti2Text) = " . convert_string_to_sqlsyntax($wordlc)
     );

--- a/insert_word_wellknown.php
+++ b/insert_word_wellknown.php
@@ -20,11 +20,11 @@ require_once 'inc/session_utility.php';
  * 
  * @return string|null A word
  * 
- * @global string $tbpref 
+ *
  */
 function get_word($textid, $textpos) 
 {
-    global $tbpref;
+
     $word = get_first_value(
         "SELECT Ti2Text AS value 
         FROM textitems2 
@@ -41,11 +41,11 @@ function get_word($textid, $textpos)
  * 
  * @return string|null Word ID 
  * 
- * @global string $tbpref 
+ *
  */
 function insert_word_wellknown_to_database($textid, $word)
 {
-    global $tbpref;
+
     
     $wordlc = mb_strtolower($word, 'UTF-8');
     
@@ -82,7 +82,7 @@ function insert_word_wellknown_to_database($textid, $word)
  * @param string $hex    Hexadecimal version of the lowercase word.
  * @param string $textid ID of the text.
  * 
- * @global string $tbpref 
+ *
  * 
  * @return void
  */

--- a/install_demo.php
+++ b/install_demo.php
@@ -31,7 +31,7 @@ pagestart('Install LWT Demo Database', true);
 
 echo error_message_with_hide($message, 1);
 
-$langcnt = get_first_value('select count(*) as value from ' . $tbpref . 'languages');
+$langcnt = get_first_value('select count(*) as value from languages');
 
 if ($tbpref == '') { 
     $prefinfo = "(Default Table Set)"; 

--- a/long_text_import.php
+++ b/long_text_import.php
@@ -164,7 +164,7 @@ function long_text_check($max_input_vars)
  */
 function long_text_save()
 {
-    global $tbpref;
+
     $langid = (int) $_REQUEST["LgID"];
     $title = $_REQUEST["TxTitle"];
     $source_uri = $_REQUEST["TxSourceURI"];

--- a/long_text_import.php
+++ b/long_text_import.php
@@ -184,7 +184,7 @@ function long_text_save()
             $counter = makeCounterWithTotal($textcount, $i+1);
             $thistitle = $title . ($counter == '' ? '' : (' (' . $counter . ')')); 
             $imported += (int) runsql(
-                'insert into ' . $tbpref . 'texts (
+                'insert into texts (
                     TxLgID, TxTitle, TxText, TxAnnotatedText, TxAudioURI, 
                     TxSourceURI
                 ) values( ' . 

--- a/mobile.php
+++ b/mobile.php
@@ -55,7 +55,7 @@ if (isset($_REQUEST["action"])) {  // Action
     
         $lang = $_REQUEST["lang"];
         $langname = getLanguage($lang);
-        $sql = 'select TxID, TxTitle from ' . $tbpref . 'texts where TxLgID = ' . $lang . 
+        $sql = 'select TxID, TxTitle from texts where TxLgID = ' . $lang . 
         ' order by TxTitle';
         $res = do_mysqli_query($sql);
 
@@ -85,9 +85,9 @@ if (isset($_REQUEST["action"])) {  // Action
     
         $lang = $_REQUEST["lang"];
         $text = $_REQUEST["text"];
-        $texttitle = get_first_value('select TxTitle as value from ' . $tbpref . 'texts where TxID = ' . $text);
-        $textaudio = get_first_value('select TxAudioURI as value from ' . $tbpref . 'texts where TxID = ' . $text);
-        $sql = 'select SeID, SeText from ' . $tbpref . 'sentences where SeTxID = ' . $text . ' order by SeOrder';
+        $texttitle = get_first_value('select TxTitle as value from texts where TxID = ' . $text);
+        $textaudio = get_first_value('select TxAudioURI as value from texts where TxID = ' . $text);
+        $sql = 'select SeID, SeText from sentences where SeTxID = ' . $text . ' order by SeOrder';
         $res = do_mysqli_query($sql);
 
         ?>
@@ -142,11 +142,11 @@ if (isset($_REQUEST["action"])) {  // Action
         $text = $_REQUEST["text"];
         $sent = $_REQUEST["sent"];
         $senttext = get_first_value(
-            'SELECT SeText AS value FROM ' . $tbpref . 'sentences WHERE SeID = ' . $sent
+            'SELECT SeText AS value FROM sentences WHERE SeID = ' . $sent
         );
         $nextsent = get_first_value(
             'SELECT SeID AS value 
-            FROM ' . $tbpref . 'sentences 
+            FROM sentences 
             WHERE SeTxID = ' . $text . ' AND trim(SeText) != \'¶\' AND SeID > ' . $sent . ' 
             ORDER BY SeID 
             LIMIT 1'
@@ -160,7 +160,7 @@ if (isset($_REQUEST["action"])) {  // Action
             WoID, WoTranslation, WoRomanization, WoStatus 
             FROM (' . 
                 $tbpref . 'textitems2 
-                LEFT JOIN ' . $tbpref . 'words 
+                LEFT JOIN words 
                 ON (Ti2WoID = WoID) AND (Ti2LgID = WoLgID)
             ) 
             WHERE Ti2SeID = ' . $sent . ' 
@@ -305,7 +305,7 @@ span.status5 {
 <ul id="home" title="Mobile LWT" selected="true">
     <li class="group">Languages</li>
     <?php
-    $sql = 'select LgID, LgName from ' . $tbpref . 'languages where LgName<>"" order by LgName';
+    $sql = 'select LgID, LgName from languages where LgName<>"" order by LgName';
     $res = do_mysqli_query($sql);
     while ($record = mysqli_fetch_assoc($res)) {
         echo '<li><a href="mobile.php?action=2&amp;lang=' . $record["LgID"] . '">' .

--- a/mobile.php
+++ b/mobile.php
@@ -159,7 +159,7 @@ if (isset($_REQUEST["action"])) {  // Action
             CASE WHEN Ti2WordCount > 0 THEN 0 ELSE 1 END AS TiIsNotWord, 
             WoID, WoTranslation, WoRomanization, WoStatus 
             FROM (' . 
-                $tbpref . 'textitems2 
+                textitems2 
                 LEFT JOIN words 
                 ON (Ti2WoID = WoID) AND (Ti2LgID = WoLgID)
             ) 

--- a/new_word.php
+++ b/new_word.php
@@ -31,7 +31,7 @@ if (isset($_REQUEST['op'])) {
         echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
     
         $message = runsql(
-            'insert into ' . $tbpref . 'words (WoLgID, WoTextLC, WoText, ' .
+            'insert into words (WoLgID, WoTextLC, WoText, ' .
             'WoStatus, WoTranslation, WoSentence, WoRomanization, WoStatusChanged,' .  make_score_random_insert_update('iv') . ') values( ' . 
             $_REQUEST["WoLgID"] . ', ' .
             convert_string_to_sqlsyntax($textlc) . ', ' .
@@ -69,13 +69,13 @@ if (isset($_REQUEST['op'])) {
     //]]>
 </script>
             <?php
-            $len = get_first_value('select WoWordCount as value from ' . $tbpref . 'words where WoID = ' . $wid);
+            $len = get_first_value('select WoWordCount as value from words where WoID = ' . $wid);
             if ($len > 1) {
                 insertExpressions($textlc, $_REQUEST["WoLgID"], $wid, $len, 0);
             } else if ($len == 1) {
                 $hex = strToClassName(prepare_textdata($textlc));
                 do_mysqli_query(
-                    'UPDATE ' . $tbpref . 'textitems2 SET Ti2WoID = ' . $wid . ' 
+                    'UPDATE textitems2 SET Ti2WoID = ' . $wid . ' 
                     WHERE Ti2LgID = ' . $_REQUEST["WoLgID"] . ' AND LOWER(Ti2Text) = ' . convert_string_to_sqlsyntax_notrim_nonull($textlc)
                 );
                 ?>

--- a/print_impr_text.php
+++ b/print_impr_text.php
@@ -23,7 +23,7 @@ $editmode = getreq('edit');
 $editmode = ($editmode == '' ? 0 : (int)$editmode);
 $delmode = getreq('del');
 $delmode = ($delmode == '' ? 0 : (int)$delmode);
-$ann = get_first_value("select TxAnnotatedText as value from " . $tbpref . "texts where TxID = " . $textid);
+$ann = get_first_value("select TxAnnotatedText as value from texts where TxID = " . $textid);
 $ann_exists = (strlen($ann) > 0);
 if ($ann_exists) {
     $ann = recreate_save_ann($textid, $ann);
@@ -38,7 +38,7 @@ if($textid==0) {
 if ($delmode ) {  // Delete
     if ($ann_exists ) { 
         runsql(
-            'update ' . $tbpref . 'texts set ' .
+            'update texts set ' .
             'TxAnnotatedText = ' . convert_string_to_sqlsyntax("") . 
             ' where TxID = ' . $textid, 
             ""
@@ -46,7 +46,7 @@ if ($delmode ) {  // Delete
     }
     $ann_exists = (int)get_first_value(
         "SELECT length(TxAnnotatedText) AS value 
-        FROM " . $tbpref . "texts where TxID = " . $textid
+        FROM texts where TxID = " . $textid
     ) > 0;
     if (!$ann_exists ) {
         header("Location: print_text.php?text=" . $textid);
@@ -54,7 +54,7 @@ if ($delmode ) {  // Delete
     }
 }
 
-$sql = 'select TxLgID, TxTitle, TxAudioURI, TxSourceURI from ' . $tbpref . 'texts where TxID = ' . $textid;
+$sql = 'select TxLgID, TxTitle, TxAudioURI, TxSourceURI from texts where TxID = ' . $textid;
 $res = do_mysqli_query($sql);
 $record = mysqli_fetch_assoc($res);
 $title = $record['TxTitle'];
@@ -67,7 +67,7 @@ if (!isset($audio)) {
 $audio = trim($audio);
 mysqli_free_result($res);
 
-$sql = 'select LgTextSize, LgRemoveSpaces, LgRightToLeft, LgGoogleTranslateURI from ' . $tbpref . 'languages where LgID = ' . $langid;
+$sql = 'select LgTextSize, LgRemoveSpaces, LgRightToLeft, LgGoogleTranslateURI from languages where LgID = ' . $langid;
 $res = do_mysqli_query($sql);
 $record = mysqli_fetch_assoc($res);
 $textsize = $record['LgTextSize'];

--- a/print_text.php
+++ b/print_text.php
@@ -112,7 +112,7 @@ if($annplcmnt == '') {
     $annplcmnt = 0; 
 }
 
-$sql = 'select TxLgID, TxTitle, TxSourceURI from ' . $tbpref . 'texts where TxID = ' . $textid;
+$sql = 'select TxLgID, TxTitle, TxSourceURI from texts where TxID = ' . $textid;
 $res = do_mysqli_query($sql);
 $record = mysqli_fetch_assoc($res);
 $title = $record['TxTitle'];
@@ -120,7 +120,7 @@ $sourceURI = $record['TxSourceURI'];
 $langid = $record['TxLgID'];
 mysqli_free_result($res);
 
-$sql = 'select LgTextSize, LgRemoveSpaces, LgRightToLeft from ' . $tbpref . 'languages where LgID = ' . $langid;
+$sql = 'select LgTextSize, LgRemoveSpaces, LgRightToLeft from languages where LgID = ' . $langid;
 $res = do_mysqli_query($sql);
 $record = mysqli_fetch_assoc($res);
 $textsize = $record['LgTextSize'];
@@ -162,7 +162,7 @@ echo "<option value=\"1\"" . get_selected(1, $annplcmnt) . ">in front of</option
 echo "<option value=\"2\"" . get_selected(2, $annplcmnt) . ">above (ruby)</option>";
 echo "</select> the term.<br />";
 echo "<input type=\"button\" value=\"Print it!\" onclick=\"window.print();\" />  (only the text below the line)";
-if (((int)get_first_value("select length(TxAnnotatedText) as value from " . $tbpref . "texts where TxID = " . $textid)) > 0) {
+if (((int)get_first_value("select length(TxAnnotatedText) as value from texts where TxID = " . $textid)) > 0) {
     echo " &nbsp; | &nbsp; Or <input type=\"button\" value=\"Print/Edit/Delete\" onclick=\"location.href='print_impr_text.php?text=" . $textid . "';\" /> your <b>Improved Annotated Text</b>" . get_annotation_link($textid) . ".";
 } else {
     echo " &nbsp; | &nbsp; <input type=\"button\" value=\"Create\" onclick=\"location.href='print_impr_text.php?edit=1&amp;text=" . $textid . "';\" /> an <b>Improved Annotated Text</b> [<img src=\"icn/tick.png\" title=\"Annotated Text\" alt=\"Annotated Text\" />].";
@@ -179,8 +179,8 @@ Ti2Order,
 CASE WHEN Ti2WordCount > 0 THEN 0 ELSE 1 END as TiIsNotWord, 
 WoID, WoTranslation, WoRomanization, WoStatus 
 FROM (
-    ' . $tbpref . 'textitems2 
-    LEFT JOIN ' . $tbpref . 'words ON (Ti2WoID = WoID) AND (Ti2LgID = WoLgID)
+    textitems2 
+    LEFT JOIN words ON (Ti2WoID = WoID) AND (Ti2LgID = WoLgID)
 ) 
 WHERE Ti2TxID = ' . $textid . ' 
 ORDER BY Ti2Order asc, Ti2WordCount desc';

--- a/set_test_status.php
+++ b/set_test_status.php
@@ -115,18 +115,18 @@ function do_set_test_status_content($wid, $status, $oldstatus, $stchange)
 {
     global $tbpref;
     $word = get_first_value(
-        "SELECT WoText AS value FROM " . $tbpref . "words 
+        "SELECT WoText AS value FROM words 
         WHERE WoID = " . $wid
     );
 
     $oldscore = (int)get_first_value(
-        'SELECT greatest(0,round(WoTodayScore,0)) AS value FROM ' . $tbpref . 'words 
+        'SELECT greatest(0,round(WoTodayScore,0)) AS value FROM words 
         WHERE WoID = ' . $wid
     );
 
 
     runsql(
-        'UPDATE ' . $tbpref . 'words SET WoStatus = ' . 
+        'UPDATE words SET WoStatus = ' . 
         $status . ', WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' 
         WHERE WoID = ' . $wid, 
         'Status changed'
@@ -134,7 +134,7 @@ function do_set_test_status_content($wid, $status, $oldstatus, $stchange)
         
     $newscore = (int)get_first_value(
         'SELECT greatest(0,round(WoTodayScore,0)) AS value 
-        FROM ' . $tbpref . 'words where WoID = ' . $wid
+        FROM words where WoID = ' . $wid
     );
     pagestart("Term: " . $word, false);
     do_set_test_status_html($status, $oldstatus, $newscore, $oldscore);
@@ -160,7 +160,7 @@ function start_set_text_status()
 
     $wid = (int)getreq('wid');
     $oldstatus = (int)get_first_value(
-        "SELECT WoStatus AS value FROM " . $tbpref . "words 
+        "SELECT WoStatus AS value FROM words 
         WHERE WoID = " . $wid
     );
 

--- a/set_test_status.php
+++ b/set_test_status.php
@@ -109,11 +109,11 @@ function do_set_test_status_javascript($wid, $status, $stchange)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix 
+ *
  */
 function do_set_test_status_content($wid, $status, $oldstatus, $stchange) 
 {
-    global $tbpref;
+
     $word = get_first_value(
         "SELECT WoText AS value FROM words 
         WHERE WoID = " . $wid
@@ -148,11 +148,11 @@ function do_set_test_status_content($wid, $status, $oldstatus, $stchange)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function start_set_text_status()
 {
-    global $tbpref;
+
 
     if (!is_numeric(getreq('status')) && !is_numeric(getreq('stchange'))) {
         my_die('status or stchange should be specified!');

--- a/set_word_on_hover.php
+++ b/set_word_on_hover.php
@@ -24,10 +24,10 @@ if($_REQUEST['status']==1) {
 $word = convert_string_to_sqlsyntax($_REQUEST['text']);
 $wordlc = convert_string_to_sqlsyntax(mb_strtolower($_REQUEST['text'], 'UTF-8'));
 
-$langid = get_first_value("select TxLgID as value from " . $tbpref . "texts where TxID = " . $_REQUEST['tid']);
+$langid = get_first_value("select TxLgID as value from texts where TxID = " . $_REQUEST['tid']);
 
             runsql(
-                'insert into ' . $tbpref . 'words (WoLgID, WoTextLC, WoText, ' .
+                'insert into words (WoLgID, WoTextLC, WoText, ' .
                 'WoStatus, WoTranslation, WoSentence, WoRomanization, WoStatusChanged,' .  make_score_random_insert_update('iv') . ') values( ' . 
                 $langid . ', ' .
                 $wordlc . ', ' .
@@ -37,7 +37,7 @@ $langid = get_first_value("select TxLgID as value from " . $tbpref . "texts wher
                 make_score_random_insert_update('id') . ')', "Term saved"
             );
             $wid = get_last_key();
-            do_mysqli_query('UPDATE ' . $tbpref . 'textitems2 SET Ti2WoID = ' . $wid . ' WHERE Ti2LgID = ' . $langid . ' AND LOWER(Ti2Text) =' . $wordlc);
+            do_mysqli_query('UPDATE textitems2 SET Ti2WoID = ' . $wid . ' WHERE Ti2LgID = ' . $langid . ' AND LOWER(Ti2Text) =' . $wordlc);
             $hex = strToClassName(prepare_textdata(mb_strtolower($_REQUEST['text'], 'UTF-8')));
 
 

--- a/set_word_status.php
+++ b/set_word_status.php
@@ -23,11 +23,11 @@ require_once 'inc/session_utility.php';
  * @return array{0: string, 1: string, 2: string} The word in plain text, 
  * his translation and his romanization
  * 
- * @global string $tbpref 
+ *
  */
 function get_word_data($wid)
 {
-    global $tbpref;
+
     $sql = 'SELECT WoText, WoTranslation, WoRomanization 
     FROM words WHERE WoID = ' . $wid;
     $res = do_mysqli_query($sql);
@@ -50,11 +50,11 @@ function get_word_data($wid)
  * 
  * @return string Some edit message, number of affected rows or error message
  * 
- * @global string $tbpref 
+ *
  */
 function set_word_status_database($wid, $status)
 {
-    global $tbpref;
+
     $m1 = runsql(
         'UPDATE words 
         SET WoStatus = ' . $status . ', WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' 

--- a/set_word_status.php
+++ b/set_word_status.php
@@ -29,7 +29,7 @@ function get_word_data($wid)
 {
     global $tbpref;
     $sql = 'SELECT WoText, WoTranslation, WoRomanization 
-    FROM ' . $tbpref . 'words WHERE WoID = ' . $wid;
+    FROM words WHERE WoID = ' . $wid;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     if (!$record) {
@@ -56,7 +56,7 @@ function set_word_status_database($wid, $status)
 {
     global $tbpref;
     $m1 = runsql(
-        'UPDATE ' . $tbpref . 'words 
+        'UPDATE words 
         SET WoStatus = ' . $status . ', WoStatusChanged = NOW(),' . make_score_random_insert_update('u') . ' 
         WHERE WoID = ' . $wid, 
         'Status changed'

--- a/settings.php
+++ b/settings.php
@@ -18,7 +18,7 @@ if (isset($_REQUEST['op'])) {
         );
     }
     else {    
-        runsql("delete from " . $tbpref . "settings where StKey like 'set-%'", '');
+        runsql("delete from settings where StKey like 'set-%'", '');
     }
 }
 pagestart('Settings/Preferences', true);

--- a/show_word.php
+++ b/show_word.php
@@ -16,7 +16,7 @@ if ($wid == '') {
     my_die('Word not found in show_word.php'); 
 }
 
-$sql = 'select WoLgID, WoText, WoTranslation, WoSentence, WoRomanization, WoStatus from ' . $tbpref . 'words where WoID = ' . $wid;
+$sql = 'select WoLgID, WoText, WoTranslation, WoSentence, WoRomanization, WoStatus from words where WoID = ' . $wid;
 $res = do_mysqli_query($sql);
 if ($record = mysqli_fetch_assoc($res)) {
 

--- a/statistics.php
+++ b/statistics.php
@@ -40,13 +40,13 @@ $sum15 = 0;
 $sum599 = 0;
 $sumall = 0;
 
-$sql = 'SELECT WoLgID,WoStatus,count(*) AS value FROM ' . $tbpref . 'words GROUP BY WoLgID,WoStatus';
+$sql = 'SELECT WoLgID,WoStatus,count(*) AS value FROM words GROUP BY WoLgID,WoStatus';
 $res = do_mysqli_query($sql);
 $term_stat = null;
 while ($record = mysqli_fetch_assoc($res)) {
     $term_stat[$record['WoLgID']][$record['WoStatus']]=$record['value'];
 }
-$sql = 'SELECT LgID, LgName FROM ' . $tbpref . 'languages where LgName<>"" ORDER BY LgName';
+$sql = 'SELECT LgID, LgName FROM languages where LgName<>"" ORDER BY LgName';
 $res = do_mysqli_query($sql);
 while ($record = mysqli_fetch_assoc($res)) {
     $lang = $record['LgID'];
@@ -165,14 +165,14 @@ $sumkall = 0;
 </tr>
 <?php
 
-$sql = 'select WoLgID,TO_DAYS(curdate())-TO_DAYS(cast(WoCreated as date)) Created,count(WoID) as value from ' . $tbpref . 'words where WoStatus in (1,2,3,4,5,99) GROUP BY WoLgID,Created';
+$sql = 'select WoLgID,TO_DAYS(curdate())-TO_DAYS(cast(WoCreated as date)) Created,count(WoID) as value from words where WoStatus in (1,2,3,4,5,99) GROUP BY WoLgID,Created';
 $res = do_mysqli_query($sql);
 $term_created = null;
 while ($record = mysqli_fetch_assoc($res)) {
     $term_created[$record['WoLgID']][$record['Created']]=$record['value'];
 }
 
-$sql = 'select WoLgID,WoStatus,TO_DAYS(curdate())-TO_DAYS(cast(WoStatusChanged as date)) Changed,count(WoID) as value from ' . $tbpref . 'words GROUP BY WoLgID,WoStatus,WoStatusChanged';
+$sql = 'select WoLgID,WoStatus,TO_DAYS(curdate())-TO_DAYS(cast(WoStatusChanged as date)) Changed,count(WoID) as value from words GROUP BY WoLgID,WoStatus,WoStatusChanged';
 $res = do_mysqli_query($sql);
 $term_active = null;
 $term_known = null;
@@ -201,7 +201,7 @@ while ($record = mysqli_fetch_assoc($res)) {
     }
 }
 
-$sql = 'SELECT LgID, LgName FROM ' . $tbpref . 'languages where LgName<>"" ORDER BY LgName';
+$sql = 'SELECT LgID, LgName FROM languages where LgName<>"" ORDER BY LgName';
 $res = do_mysqli_query($sql);
 while ($record = mysqli_fetch_assoc($res)) {
 

--- a/trans.php
+++ b/trans.php
@@ -25,7 +25,7 @@ $t = $_REQUEST["t"];
 $satz = null;
 $trans = null;
 if ($x == 1 ) {
-    $sql = 'select SeText, LgGoogleTranslateURI from ' . $tbpref . 'languages, ' . $tbpref . 'sentences, ' . $tbpref . 'textitems2 where Ti2SeID = SeID and Ti2LgID = LgID and Ti2TxID = ' . $t . ' and Ti2Order = ' . $i;
+    $sql = 'select SeText, LgGoogleTranslateURI from languages, sentences, textitems2 where Ti2SeID = SeID and Ti2LgID = LgID and Ti2TxID = ' . $t . ' and Ti2Order = ' . $i;
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     if ($record) {

--- a/upload_words.php
+++ b/upload_words.php
@@ -40,11 +40,11 @@ function my_str_getcsv($input)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
 {
-    global $tbpref;
+
     $sql = "SELECT * FROM languages WHERE LgID=$lang";
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
@@ -551,11 +551,11 @@ function showImportedTerms(last_update, rtl, count, page) {
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function upload_words_import_tags($fields, $tabs, $file_upl)
 {
-    global $tbpref;
+
     $columns = '';
     for ($j=1; $j<=$fields["tl"]; $j++) {
         $columns .= ($j==1?'(':',') . ($j==$fields["tl"]?'@taglist':'@dummy');
@@ -643,11 +643,11 @@ function upload_words_import_tags($fields, $tabs, $file_upl)
  * 
  * @return void
  * 
- * @global string $tbpref Database table prefix
+ *
  */
 function upload_words_import()
 {
-    global $tbpref;
+
     $tabs = $_REQUEST["Tab"];
     $lang = $_REQUEST["LgID"];
     $sql = "SELECT * FROM languages WHERE LgID=$lang";

--- a/upload_words.php
+++ b/upload_words.php
@@ -45,13 +45,13 @@ function my_str_getcsv($input)
 function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
 {
     global $tbpref;
-    $sql = "SELECT * FROM {$tbpref}languages WHERE LgID=$lang";
+    $sql = "SELECT * FROM languages WHERE LgID=$lang";
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $removeSpaces = $record["LgRemoveSpaces"];
     $rtl = $record['LgRightToLeft'];
     $last_update = get_first_value(
-        "SELECT max(WoStatusChanged) AS value FROM {$tbpref}words"
+        "SELECT max(WoStatusChanged) AS value FROM words"
     );
     $overwrite = $_REQUEST["Over"];
     $status = $_REQUEST["WoStatus"];
@@ -78,7 +78,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
     if ($fields["tl"]==0 and $overwrite==0) {
 
         if (get_first_value("SELECT @@GLOBAL.local_infile as value")) {
-            $sql .= " IGNORE INTO TABLE {$tbpref}words 
+            $sql .= " IGNORE INTO TABLE words 
             FIELDS TERMINATED BY '$tabs' ENCLOSED BY '\"' LINES TERMINATED BY '\\n' 
             " . ($_REQUEST["IgnFirstLine"] == '1' ? "IGNORE 1 LINES" : "") . "
             $columns 
@@ -137,7 +137,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
                 $values[] = "(" . implode(",", $row) . ")";
             }
             do_mysqli_query(
-                "INSERT INTO {$tbpref}words(
+                "INSERT INTO words(
                     WoText, WoTextLC, " . 
                     ($fields["tr"] != 0 ? 'WoTranslation, ' : '') . 
                     ($fields["ro"] != 0 ? 'WoRomanization, ' : '') . 
@@ -162,7 +162,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
             ''
         );
         if (get_first_value("SELECT @@GLOBAL.local_infile as value")) {
-            $sql .= " INTO TABLE {$tbpref}tempwords 
+            $sql .= " INTO TABLE tempwords 
             FIELDS TERMINATED BY '$tabs' ENCLOSED BY '\"' LINES TERMINATED BY '\\n' 
             " . ($_REQUEST["IgnFirstLine"] == '1' ? "IGNORE 1 LINES" : "") . 
             "$columns SET " . (
@@ -216,7 +216,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
                 ) . ")";
             }
             do_mysqli_query(
-                "INSERT INTO {$tbpref}tempwords(
+                "INSERT INTO tempwords(
                     WoText, WoTextLC" . 
                     ($fields["tr"] != 0 ? ', WoTranslation' : '') . 
                     ($fields["ro"] != 0 ? ', WoRomanization' : '') . 
@@ -275,10 +275,10 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
                 ) name 
                 FROM {$tbpref}numbers 
                 INNER JOIN (
-                    SELECT {$tbpref}words.WoTextLC as WoTextLC, $WoTrRepl as WoTranslation 
-                    FROM {$tbpref}tempwords 
-                    LEFT JOIN {$tbpref}words 
-                    ON {$tbpref}words.WoTextLC = {$tbpref}tempwords.WoTextLC AND {$tbpref}words.WoTranslation != '*' AND {$tbpref}words.WoLgID = $lang
+                    SELECT words.WoTextLC as WoTextLC, $WoTrRepl as WoTranslation 
+                    FROM tempwords 
+                    LEFT JOIN words 
+                    ON words.WoTextLC = tempwords.WoTextLC AND words.WoTranslation != '*' AND words.WoLgID = $lang
                 ) b 
                 ON CHAR_LENGTH(b.WoTranslation)-CHAR_LENGTH(REPLACE(b.WoTranslation, " . convert_string_to_sqlsyntax($wosep[0]) . ", ''))>= {$tbpref}numbers.n-1 
                 ORDER BY b.WoTextLC, n", 
@@ -308,7 +308,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
 
             runsql(
                 "INSERT IGNORE INTO {$tbpref}merge_words(MText,MTranslation) 
-                SELECT {$tbpref}tempwords.WoTextLC, 
+                SELECT tempwords.WoTextLC, 
                 trim(
                     SUBSTRING_INDEX(
                         SUBSTRING_INDEX(
@@ -321,9 +321,9 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
                     )
                 ) name 
                 FROM {$tbpref}numbers 
-                INNER JOIN {$tbpref}tempwords 
-                ON CHAR_LENGTH({$tbpref}tempwords.WoTranslation)-CHAR_LENGTH(REPLACE($WoTrRepl, " . convert_string_to_sqlsyntax($tesep[0]) . ", ''))>= {$tbpref}numbers.n-1 
-                ORDER BY {$tbpref}tempwords.WoTextLC, n", 
+                INNER JOIN tempwords 
+                ON CHAR_LENGTH(tempwords.WoTranslation)-CHAR_LENGTH(REPLACE($WoTrRepl, " . convert_string_to_sqlsyntax($tesep[0]) . ", ''))>= {$tbpref}numbers.n-1 
+                ORDER BY tempwords.WoTextLC, n", 
                 ''
             );
             if ($wosep[0]==',' or $wosep[0]==';') { 
@@ -332,7 +332,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
                 $wosep = ' ' . $wosep[0] . ' '; 
             }
             runsql(
-                "UPDATE {$tbpref}tempwords 
+                "UPDATE tempwords 
                 LEFT JOIN (
                     SELECT MText, GROUP_CONCAT(trim(MTranslation) 
                         ORDER BY MID 
@@ -350,7 +350,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
         // */
         if ($overwrite!=3 and $overwrite!=5) {
             $sql = "INSERT " . ($overwrite != 0 ? '' : 'IGNORE ') .
-            " INTO {$tbpref}words (
+            " INTO words (
                 WoTextLC , WoText, WoTranslation, WoRomanization, WoSentence,
                 WoStatus, WoStatusChanged, WoLgID, 
                 " .  make_score_random_insert_update('iv')  . "
@@ -360,37 +360,37 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
                 SELECT WoTextLC , WoText, WoTranslation, WoRomanization, 
                 WoSentence, $status AS WoStatus, 
                 NOW() AS WoStatusChanged 
-                FROM {$tbpref}tempwords
+                FROM tempwords
             ) AS tw";
             if ($overwrite==1 or $overwrite==4) { 
                 $sql .= " ON DUPLICATE KEY UPDATE " . 
-                ($fields["tr"] ? "{$tbpref}words.WoTranslation = tw.WoTranslation, ":"") . 
-                ($fields["ro"]?"{$tbpref}words.WoRomanization = tw.WoRomanization, ":'') . 
-                ($fields["se"]?"{$tbpref}words.WoSentence = tw.WoSentence, ":'') . 
-                "{$tbpref}words.WoStatus = tw.WoStatus, 
-                {$tbpref}words.WoStatusChanged = tw.WoStatusChanged"; 
+                ($fields["tr"] ? "words.WoTranslation = tw.WoTranslation, ":"") . 
+                ($fields["ro"]?"words.WoRomanization = tw.WoRomanization, ":'') . 
+                ($fields["se"]?"words.WoSentence = tw.WoSentence, ":'') . 
+                "words.WoStatus = tw.WoStatus, 
+                words.WoStatusChanged = tw.WoStatusChanged"; 
             }
             if ($overwrite==2) { 
-                $sql .= " ON DUPLICATE KEY UPDATE {$tbpref}words.WoTranslation = case 
-                    when {$tbpref}words.WoTranslation = "*" then tw.WoTranslation 
-                    else {$tbpref}words.WoTranslation 
+                $sql .= " ON DUPLICATE KEY UPDATE words.WoTranslation = case 
+                    when words.WoTranslation = "*" then tw.WoTranslation 
+                    else words.WoTranslation 
                 end, 
-                {$tbpref}words.WoRomanization = case 
-                    when {$tbpref}words.WoRomanization IS NULL then tw.WoRomanization 
-                    else {$tbpref}words.WoRomanization 
+                words.WoRomanization = case 
+                    when words.WoRomanization IS NULL then tw.WoRomanization 
+                    else words.WoRomanization 
                 end, 
-                {$tbpref}words.WoSentence = case 
-                    when {$tbpref}words.WoSentence IS NULL then tw.WoSentence 
-                    else {$tbpref}words.WoSentence 
+                words.WoSentence = case 
+                    when words.WoSentence IS NULL then tw.WoSentence 
+                    else words.WoSentence 
                 end, 
-                {$tbpref}words.WoStatusChanged = case 
-                    when {$tbpref}words.WoSentence IS NULL or {$tbpref}words.WoRomanization IS NULL or {$tbpref}words.WoTranslation = "*" then tw.WoStatusChanged 
-                    else {$tbpref}words.WoStatusChanged 
+                words.WoStatusChanged = case 
+                    when words.WoSentence IS NULL or words.WoRomanization IS NULL or words.WoTranslation = "*" then tw.WoStatusChanged 
+                    else words.WoStatusChanged 
                 end";
             }
         } else {
-            $sql = "UPDATE {$tbpref}words AS a 
-            JOIN {$tbpref}tempwords AS b 
+            $sql = "UPDATE words AS a 
+            JOIN tempwords AS b 
             ON a.WoTextLC = b.WoTextLC SET a.WoTranslation = CASE 
                 WHEN b.WoTranslation = '' or b.WoTranslation = '*' THEN a.WoTranslation 
                 ELSE b.WoTranslation 
@@ -411,38 +411,38 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
         runsql($sql, '');
         if ($fields["tl"]!=0) {
             runsql(
-                "INSERT IGNORE INTO {$tbpref}tags (TgText) 
+                "INSERT IGNORE INTO tags (TgText) 
                 SELECT name FROM (
-                    SELECT {$tbpref}tempwords.WoTextLC, 
+                    SELECT tempwords.WoTextLC, 
                     SUBSTRING_INDEX(
                         SUBSTRING_INDEX(
-                            {$tbpref}tempwords.WoTaglist, ',', 
+                            tempwords.WoTaglist, ',', 
                             {$tbpref}numbers.n
                         ), ',', -1) name 
                     FROM {$tbpref}numbers 
-                    INNER JOIN {$tbpref}tempwords 
-                    ON CHAR_LENGTH({$tbpref}tempwords.WoTaglist)-CHAR_LENGTH(REPLACE({$tbpref}tempwords.WoTaglist, ',', ''))>={$tbpref}numbers.n-1 
+                    INNER JOIN tempwords 
+                    ON CHAR_LENGTH(tempwords.WoTaglist)-CHAR_LENGTH(REPLACE(tempwords.WoTaglist, ',', ''))>={$tbpref}numbers.n-1 
                     ORDER BY WoTextLC, n) A",
                 ''
             );
             runsql(
-                "INSERT IGNORE INTO {$tbpref}wordtags 
+                "INSERT IGNORE INTO wordtags 
                 select WoID,TgID 
                 FROM (
-                    SELECT {$tbpref}tempwords.WoTextLC, SUBSTRING_INDEX(
+                    SELECT tempwords.WoTextLC, SUBSTRING_INDEX(
                         SUBSTRING_INDEX(
-                            {$tbpref}tempwords.WoTaglist, ',', {$tbpref}numbers.n
+                            tempwords.WoTaglist, ',', {$tbpref}numbers.n
                         ), ',', -1) name 
                     FROM {$tbpref}numbers 
-                    INNER JOIN {$tbpref}tempwords ON CHAR_LENGTH({$tbpref}tempwords.WoTaglist)-CHAR_LENGTH(REPLACE({$tbpref}tempwords.WoTaglist, ',', ''))>={$tbpref}numbers.n-1 
+                    INNER JOIN tempwords ON CHAR_LENGTH(tempwords.WoTaglist)-CHAR_LENGTH(REPLACE(tempwords.WoTaglist, ',', ''))>={$tbpref}numbers.n-1 
                     ORDER BY WoTextLC, n
-                ) A, {$tbpref}tags, {$tbpref}words 
-                WHERE name=TgText AND A.WoTextLC={$tbpref}words.WoTextLC AND WoLgID=$lang", 
+                ) A, tags, words 
+                WHERE name=TgText AND A.WoTextLC=words.WoTextLC AND WoLgID=$lang", 
                 ''
             );
         }
         runsql("DROP TABLE {$tbpref}numbers", '');
-        runsql("TRUNCATE {$tbpref}tempwords", '');
+        runsql("TRUNCATE tempwords", '');
         if ($fields["tl"]!=0) { 
             get_tags(1); 
         }
@@ -452,28 +452,28 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
     }
     init_word_count();
     runsql(
-        "UPDATE {$tbpref}words 
-        JOIN {$tbpref}textitems2 
+        "UPDATE words 
+        JOIN textitems2 
         ON WoWordCount=1 AND Ti2WoID=0 AND lower(Ti2Text)=WoTextLC AND Ti2LgID = WoLgID 
         SET Ti2WoID=WoID", 
         ''
     );
     $mwords = get_first_value(
-        "SELECT count(*) AS value from {$tbpref}words 
+        "SELECT count(*) AS value from words 
         WHERE WoWordCount>1 AND WoCreated > " . 
         convert_string_to_sqlsyntax($last_update)
     );
     if ($mwords > 40) {
         runsql(
-            "DELETE FROM  {$tbpref}sentences WHERE SeLgID = $lang", 
+            "DELETE FROM  sentences WHERE SeLgID = $lang", 
             "Sentences deleted"
         );
         runsql(
-            "DELETE FROM {$tbpref}textitems2 WHERE Ti2LgID = $lang", 
+            "DELETE FROM textitems2 WHERE Ti2LgID = $lang", 
             "Text items deleted"
         );
         adjust_autoincr('sentences', 'SeID');
-        $sql = "SELECT TxID, TxText FROM {$tbpref}texts 
+        $sql = "SELECT TxID, TxText FROM texts 
         WHERE TxLgID = $lang ORDER BY TxID";
         $res = do_mysqli_query($sql);
         $cntrp = 0;
@@ -489,7 +489,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
         $sqlarr = array();
         $res = do_mysqli_query(
             "SELECT WoID, WoTextLC, WoWordCount 
-            FROM {$tbpref}words 
+            FROM words 
             WHERE WoWordCount>1 AND WoCreated > " . 
             convert_string_to_sqlsyntax($last_update)
         );
@@ -502,7 +502,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
         mysqli_free_result($res);
         $sqlarr = array_filter($sqlarr);
         if (!empty($sqlarr)) {
-            $sqltext = "INSERT INTO {$tbpref}textitems2 (
+            $sqltext = "INSERT INTO textitems2 (
                 Ti2WoID, Ti2LgID, Ti2TxID, Ti2SeID, Ti2Order, Ti2WordCount,
                 Ti2Text
             ) VALUES " . rtrim(implode(',', $sqlarr), ',');
@@ -510,7 +510,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
         }
     }
     $recno = get_first_value(
-        "SELECT count(*) AS value FROM {$tbpref}words 
+        "SELECT count(*) AS value FROM words 
         where WoStatusChanged > " . convert_string_to_sqlsyntax($last_update)
     );
     ?>
@@ -581,7 +581,7 @@ function upload_words_import_tags($fields, $tabs, $file_upl)
     }
     if (get_first_value("SELECT @@GLOBAL.local_infile as value")) {
         $sql = "LOAD DATA LOCAL INFILE " . convert_string_to_sqlsyntax($file_name) . 
-        " IGNORE INTO TABLE {$tbpref}tempwords 
+        " IGNORE INTO TABLE tempwords 
         FIELDS TERMINATED BY '$tabs' ENCLOSED BY '\"' LINES TERMINATED BY '\\n'
         " . ($_REQUEST["IgnFirstLine"] == '1' ? "IGNORE 1 LINES" : "") . "
         $columns 
@@ -602,7 +602,7 @@ function upload_words_import_tags($fields, $tabs, $file_upl)
             $texts[] = convert_string_to_sqlsyntax($tags);
         }
         do_mysqli_query(
-            "INSERT INTO {$tbpref}tempwords(WoTextLC) 
+            "INSERT INTO tempwords(WoTextLC) 
             VALUES " . implode(',', $texts)
         );
     }
@@ -618,20 +618,20 @@ function upload_words_import_tags($fields, $tabs, $file_upl)
         ''
     );
     runsql(
-        "INSERT IGNORE INTO {$tbpref}tags (TgText) 
+        "INSERT IGNORE INTO tags (TgText) 
         SELECT NAME FROM (
             SELECT SUBSTRING_INDEX(
                 SUBSTRING_INDEX(
-                    {$tbpref}tempwords.WoTextLC, ',',  {$tbpref}numbers.n
+                    tempwords.WoTextLC, ',',  {$tbpref}numbers.n
                 ), ',', -1) name 
             FROM {$tbpref}numbers 
-            INNER JOIN {$tbpref}tempwords 
-            ON CHAR_LENGTH({$tbpref}tempwords.WoTextLC)-CHAR_LENGTH(REPLACE({$tbpref}tempwords.WoTextLC, ',', ''))>= {$tbpref}numbers.n-1 
+            INNER JOIN tempwords 
+            ON CHAR_LENGTH(tempwords.WoTextLC)-CHAR_LENGTH(REPLACE(tempwords.WoTextLC, ',', ''))>= {$tbpref}numbers.n-1 
             ORDER BY WoTextLC, n) A", 
         ''
     );
     runsql("DROP TABLE {$tbpref}numbers", '');
-    runsql("TRUNCATE {$tbpref}tempwords", '');
+    runsql("TRUNCATE tempwords", '');
     get_tags(1);
     if (!$file_upl) {
         unlink($file_name);
@@ -650,7 +650,7 @@ function upload_words_import()
     global $tbpref;
     $tabs = $_REQUEST["Tab"];
     $lang = $_REQUEST["LgID"];
-    $sql = "SELECT * FROM {$tbpref}languages WHERE LgID=$lang";
+    $sql = "SELECT * FROM languages WHERE LgID=$lang";
     $res = do_mysqli_query($sql);
     $record = mysqli_fetch_assoc($res);
     $removeSpaces = $record["LgRemoveSpaces"];

--- a/upload_words.php
+++ b/upload_words.php
@@ -250,7 +250,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
                 }
             }
             $seplen = mb_strlen($wosep, 'UTF-8');
-            $WoTrRepl = $tbpref . 'words.WoTranslation';
+            $WoTrRepl = words.WoTranslation';
             for ($i=1; $i < $seplen; $i++) {
                 $WoTrRepl = 'REPLACE(
                     ' . $WoTrRepl . ', ' . 
@@ -297,7 +297,7 @@ function upload_words_import_terms($fields, $tabs, $file_upl, $col, $lang)
             }
 
             $seplen = mb_strlen($tesep, 'UTF-8');
-            $WoTrRepl = $tbpref . 'tempwords.WoTranslation';
+            $WoTrRepl = tempwords.WoTranslation';
             for ($i=1; $i<$seplen; $i++) {
                 $WoTrRepl = 'REPLACE(
                     ' . $WoTrRepl . ', ' . 


### PR DESCRIPTION
Work-in-progress only.

The code currently suffers from `$tbpref` which makes querying, dev, and life in general, difficult.  This is proof-of-concept work only at the moment to try removing it.

I'll be pushing to this branch regularly, and will edit the description as I go.

**Current state of cleanup:**

As at `commit 1b1dc74eac4d5a36a`, only the following files still have `$tbpref` references:

```
./inc/database_connect.php
./inc/session_utility.php
./inc/wp_logincheck.php
./index.php
./table_set_management.php
./install_demo.php
./backup_restore.php
./start.php
```

**Summary of work done:**

* Create some `devscripts` to cycle through the php files and update them.
* Changes to the php files done via the dev scripts.

**1. Remove any inline sql `$tbpref` from the php files, as at commit `commit 1e41a1d38e921`.**

Uses script `run_seds.sh`

Many files still declare the `global $tbpref` and have them in comments, but it's not used in the sql statements.

**2. Remove declaration of global $tbpref in functions if it's not used anywhere in the file.**

Uses script `only_global_or_comment.sh`

Some files still have tbpref in them, because it's used in a way that can't be easily removed:

```
Skipping ./backup_restore.php, has line if ($tbpref == '') {
Skipping ./inc/database_connect.php, has line substr($tbpref, $i, 1)
Skipping ./inc/session_utility.php, has line return substr($sql_line, 0, 21) . $tbpref . substr($sql_line, 21);
Skipping ./inc/wp_logincheck.php, has line $tbpref = $_SESSION['LWT-WP-User'];
Skipping ./index.php, has line if ($tbpref == '') {
Skipping ./install_demo.php, has line if ($tbpref == '') {
Skipping ./start.php, has line LWTTableSet('current_table_prefix', $tbpref);
Skipping ./table_set_management.php, has line if ($_REQUEST['delpref'] == substr($tbpref, 0, -1)) {
```

