### PR TITLE
Misc test fixes

### DIFF
--- a/do_test_test.php
+++ b/do_test_test.php
@@ -92,7 +92,6 @@ function do_test_test_css()
         display:table;
     } 
     body { 
-        display:table-cell; 
         vertical-align:middle; 
     } 
     #body { 

--- a/js/pgm.js
+++ b/js/pgm.js
@@ -84,8 +84,10 @@ $('input:submit').last().trigger('click');return!1}else{return!0}}
 function noShowAfter3Secs(){$('#hide3').slideUp()}
 function setTheFocus(){$('.setfocus').trigger('focus').trigger('select')}
 function word_click_event_do_test_test(){run_overlib_test(WBLINK1,WBLINK2,WBLINK3,$(this).attr('data_wid'),$(this).attr('data_text'),$(this).attr('data_trans'),$(this).attr('data_rom'),$(this).attr('data_status'),$(this).attr('data_sent'),$(this).attr('data_todo'));$('.todo').text(SOLUTION);return!1}
-function keydown_event_do_test_test(e){if(e.which==32&&OPENED==0){$('.word').trigger('click');cClick();showRightFrames('show_word.php?wid='+$('.word').attr('data_wid')+'&ann=');OPENED=1;return!1}
-if(OPENED==0)return!0;if(e.which==38){showRightFrames('set_test_status.php?wid='+WID+'&stchange=1');return!1}
+function keydown_event_do_test_test(e){let solution_shown=($('.todo').text()==SOLUTION);const RETURN=13;if(e.which==RETURN&&!solution_shown){$('.word').trigger('click');cClick();return!1}
+if(e.which==RETURN&&solution_shown){showRightFrames('set_test_status.php?wid='+WID+'&stchange=1');return!1}
+if(e.which==32&&OPENED==0){$('.word').trigger('click');cClick();showRightFrames('show_word.php?wid='+$('.word').attr('data_wid')+'&ann=');OPENED=1;return!1}
+if(e.which==38){showRightFrames('set_test_status.php?wid='+WID+'&stchange=1');return!1}
 if(e.which==40){showRightFrames('set_test_status.php?wid='+WID+'&stchange=-1');return!1}
 if(e.which==27){showRightFrames('set_test_status.php?wid='+WID+'&status='+$('.word').attr('data_status'));return!1}
 for(let i=1;i<=5;i++){if(e.which==(48+i)||e.which==(96+i)){showRightFrames('set_test_status.php?wid='+WID+'&status='+i);return!1}}
@@ -165,9 +167,9 @@ SUW=(parseInt($('#chart').attr('data_wo_cnt'))<<4)+(parseInt($('#unknownpercent'
 function do_ajax_edit_impr_text(pagepos,word){if(word=='')$('#editimprtextdata').html('<img src="icn/waiting2.gif" />');const textid=$('#editimprtextdata').attr('data_id');$.post('inc/ajax_edit_impr_text.php',{id:textid,word:word},function(data){eval(data);$.scrollTo(pagepos);$('input.impr-ann-text').on('change',changeImprAnnText);$('input.impr-ann-radio').on('change',changeImprAnnRadio)})}
 function showRightFrames(roUrl,ruUrl){if(roUrl!==undefined){top.frames.ro.location.href=roUrl}
 if(ruUrl!==undefined){top.frames.ru.location.href=ruUrl}
-if($('#frames-r').length){$('#frames-r').animate({right:'5px'});return!0}
+if($('#frames-r').length){$('#frames-r').animate({right:'5px'},100);return!0}
 return!1}
-function hideRightFrames(){if($('#frames-r').length){$('#frames-r').animate({right:'-100%'});return!0}
+function hideRightFrames(){if($('#frames-r').length){$('#frames-r').animate({right:'-100%'},100);return!0}
 return!1}
 function successSound(){document.getElementById('success_sound').pause();document.getElementById('failure_sound').pause();return document.getElementById('success_sound').play()}
 function failureSound(){document.getElementById('success_sound').pause();document.getElementById('failure_sound').pause();return document.getElementById('failure_sound').play()}

--- a/set_test_status.php
+++ b/set_test_status.php
@@ -86,7 +86,7 @@ function do_set_test_status_javascript($wid, $status, $stchange)
     // Waittime <= 0 causes the page to loop-reloading
     const waittime = <?php 
     echo json_encode((int)getSettingWithDefault('set-test-main-frame-waiting-time')); 
-    ?> + 500;
+    ?> + 50;
     if (waittime <= 0) {
         console.log("aaa");
         window.parent.location.reload();

--- a/src/js/jq_pgm.js
+++ b/src/js/jq_pgm.js
@@ -330,6 +330,18 @@ function word_click_event_do_test_test () {
  * @returns {bool} true if nothing was done, false otherwise
  */
 function keydown_event_do_test_test (e) {
+  let solution_shown = ($('.todo').text() == SOLUTION);
+  const RETURN = 13;
+  if (e.which == RETURN && !solution_shown) {
+    $('.word').trigger('click');
+    cClick();
+    return false;
+  }
+  if (e.which == RETURN && solution_shown) {
+    // Passed.
+    showRightFrames('set_test_status.php?wid=' + WID + '&stchange=1');
+    return false;
+  }
   if (e.which == 32 && OPENED == 0) { // space : show sol.
     $('.word').trigger('click');
     cClick();

--- a/src/js/jq_pgm.js
+++ b/src/js/jq_pgm.js
@@ -337,7 +337,6 @@ function keydown_event_do_test_test (e) {
     OPENED = 1;
     return false;
   }
-  if (OPENED == 0) return true;
   if (e.which == 38) { // up : status+1
 		showRightFrames('set_test_status.php?wid=' + WID + '&stchange=1');
     return false;

--- a/src/js/jq_pgm.js
+++ b/src/js/jq_pgm.js
@@ -1091,7 +1091,7 @@ function showRightFrames(roUrl, ruUrl) {
     top.frames.ru.location.href = ruUrl;
   }
   if ($('#frames-r').length) {
-    $('#frames-r').animate({right: '5px'});
+    $('#frames-r').animate({right: '5px'}, 100);
     return true;
   }
   return false;
@@ -1104,7 +1104,7 @@ function showRightFrames(roUrl, ruUrl) {
  */
 function hideRightFrames() {
   if ($('#frames-r').length) {
-    $('#frames-r').animate({right: '-100%'});
+    $('#frames-r').animate({right: '-100%'}, 100);
     return true;
   }
   return false;


### PR DESCRIPTION
A few misc fixes to make the testing more enjoyable (for me, anyway, and hopefully for others as well):

**Fix test headers.**

Currently, the tests are shown right at the top of the screen, eg:

![current_tests_no_header](https://user-images.githubusercontent.com/1637133/200721129-8c954c89-b4ae-4b5d-9822-76b5e9aafff0.png)

The first commit restores the header:

![image](https://user-images.githubusercontent.com/1637133/200721197-29fbf670-8f05-4153-a268-968cff872030.png)

**Speed things up**

During heavy usage, the right frame slide-ins-and-outs become distracting and annoying.

**Faster test actions**

The last two commits let me see and set the answers and statuses more quickly.  I can just "enter-enter-enter-enter" to rapidly go through all tests, without having to mouse everywhere, and I don't have to see any pop-ups to say whether I passed or failed ... I know if I passed or failed. :-)