### PR TITLE
Refactor edit_word.php

### DIFF
--- a/edit_word.php
+++ b/edit_word.php
@@ -93,9 +93,6 @@ function edit_term($translation)
  */
 function lowercase_term_not_equal($textlc): void
 {
-    $titletext = "New/Edit Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
-    pagestart_nobody($titletext);
-    echo '<h4><span class="bigger">' . $titletext . '</span></h4>';        
     $message = 
     'Error: Term in lowercase must be exactly = "' . 
     $textlc . '", please go back and correct this!'; 
@@ -176,22 +173,24 @@ if (isset($_REQUEST['op'])) {
     
     $textlc = trim(prepare_textdata($_REQUEST["WoTextLC"]));
     $text = trim(prepare_textdata($_REQUEST["WoText"]));
-    
+
+    $titlestart = "Edit Term: ";
+    if ($_REQUEST['op'] == 'Save') {
+      $titlestart = "New Term: ";
+    }
+    $titletext = $titlestart . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
+    pagestart_nobody($titletext);
+    echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
+
     if (mb_strtolower($text, 'UTF-8') == $textlc) {
     
         if ($_REQUEST['op'] == 'Save') {
-            $titletext = "New Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
-            pagestart_nobody($titletext);
-            echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
             $output = insert_new_word($textlc, $translation);
             $wid = $output[0];
             $message = $output[1];
             $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
         }
         else {
-            $titletext = "Edit Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
-            pagestart_nobody($titletext);
-            echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
             $output = edit_term($translation);
             $wid = $output[0];
             $message = $output[1];

--- a/edit_word.php
+++ b/edit_word.php
@@ -203,39 +203,26 @@ function handle_save_or_update(): void
 
 function get_term_and_lang($wid)
 {
-    if ($wid == '') {    
-        $sql = 
-        'SELECT Ti2Text, Ti2LgID FROM ' . $tbpref . 'textitems2 
-        WHERE Ti2TxID = ' . $_REQUEST['tid'] . ' AND Ti2WordCount = 1 AND Ti2Order = ' . $_REQUEST['ord'];
-        $res = do_mysqli_query($sql);
-        $record = mysqli_fetch_assoc($res);
-        if ($record) {
-            $term = $record['Ti2Text'];
-            $lang = $record['Ti2LgID'];
-        } else {
-            my_die("Cannot access Term and Language in edit_word.php");
-        }
-        mysqli_free_result($res);
-        
-        $termlc = mb_strtolower($term, 'UTF-8');
-    } else {
-
-        $sql = 'SELECT WoText, WoLgID FROM ' . $tbpref . 'words WHERE WoID = ' . $wid;
-        $res = do_mysqli_query($sql);
-        $record = mysqli_fetch_assoc($res);
-        if ($record ) {
-            $term = $record['WoText'];
-            $lang = $record['WoLgID'];
-        } else {
-            my_die("Cannot access Term and Language in edit_word.php");
-        }
-        mysqli_free_result($res);
-        $termlc =    mb_strtolower($term, 'UTF-8');
-        
+  $sql = "SELECT WoText AS t, WoLgID AS lid FROM {$tbpref}words WHERE WoID = {$wid}";
+    if ($wid == '') {
+        $tid = $_REQUEST["tid"];
+        $ord = $_REQUEST["ord"];
+        $sql =  "SELECT Ti2Text AS t, Ti2LgID AS lid
+        FROM {$tbpref}textitems2 
+        WHERE Ti2TxID = {$tid} AND Ti2WordCount = 1 AND Ti2Order = {$ord};";
     }
-
+    $res = do_mysqli_query($sql);
+    $record = mysqli_fetch_assoc($res);
+    mysqli_free_result($res);
+    if ($record) {
+      $term = $record['t'];
+      $lang = $record['lid'];
+    } else {
+      my_die("Cannot access Term and Language in edit_word.php");
+    }
     return [ $term, $lang ];
 }
+
 
 $fromAnn = getreq("fromAnn"); // from-recno or empty
 $lang = null;

--- a/edit_word.php
+++ b/edit_word.php
@@ -237,6 +237,23 @@ function get_sentence_for_termlc($termlc) {
 }
 
 
+class FormData
+{
+  public $fromAnn = '';
+  public $lang;
+  public $term;
+  public $termlc;
+  public $srcdir;
+  public $transl = '';
+  public $tags;
+  public $romanization = '';
+  public $sentence = '';
+  public $status = 1;
+  public $status_old = 1;
+  public $status_radiooptions;
+}
+
+
 $fromAnn = getreq("fromAnn"); // from-recno or empty
 $lang = null;
 $term = null;
@@ -276,20 +293,28 @@ if (isset($_REQUEST['op'])) {
     // NEW
     
     if ($new) {
-        $sentence = get_sentence_for_termlc($termlc);
-            
-        ?>
-    
+        $formdata = new FormData();
+        $formdata->fromAnn = $fromAnn;
+        $formdata->lang = $lang;
+        $formdata->term = $term;
+        $formdata->termlc = $termlc;
+        $formdata->scrdir = $scrdir;
+        $formdata->tags = getWordTags(0);
+        $formdata->sentence = get_sentence_for_termlc($termlc);
+        $formdata->status = 1;
+        $formdata->status_old = 1;
+
+?>
  <form name="newword" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
- <input type="hidden" name="fromAnn" value="<?php echo $fromAnn; ?>" />
- <input type="hidden" name="WoLgID" id="langfield" value="<?php echo $lang; ?>" />
- <input type="hidden" name="WoTextLC" value="<?php echo tohtml($termlc); ?>" />
+ <input type="hidden" name="fromAnn" value="<?php echo $formdata->fromAnn; ?>" />
+ <input type="hidden" name="WoLgID" id="langfield" value="<?php echo $formdata->lang; ?>" />
+ <input type="hidden" name="WoTextLC" value="<?php echo tohtml($formdata->termlc); ?>" />
  <input type="hidden" name="tid" value="<?php echo $_REQUEST['tid']; ?>" />
  <input type="hidden" name="ord" value="<?php echo $_REQUEST['ord']; ?>" />
  <table class="tab2" cellspacing="0" cellpadding="5">
  <tr title="Only change uppercase/lowercase!">
  <td class="td1 right"><b>New Term:</b></td>
- <td class="td1"><input <?php echo $scrdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($term); ?>" maxlength="250" size="35" /> <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
+ <td class="td1"><input <?php echo $formdata->scrdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($formdata->term); ?>" maxlength="250" size="35" /> <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
  </td></tr>
         <?php print_similar_terms_tabrow(); ?>
  <tr>
@@ -308,24 +333,24 @@ if (isset($_REQUEST['op'])) {
  </tr>
  <tr>
  <td class="td1 right">Sentence<br />Term in {...}:</td>
- <td class="td1"><textarea <?php echo $scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($sentence); ?></textarea></td>
+ <td class="td1"><textarea <?php echo $scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea></td>
  </tr>
         <?php print_similar_terms_tabrow(); ?>
  <tr>
  <td class="td1 right">Status:</td>
  <td class="td1">
-        <?php echo get_wordstatus_radiooptions(1); ?>
+        <?php echo get_wordstatus_radiooptions($formdata->status); ?>
  </td>
  </tr>
  <tr>
  <td class="td1 right" colspan="2">
-        <?php echo createDictLinksInEditWin($lang, $term, 'document.forms[0].WoSentence', isset($_GET['nodict'])?0:1); ?>
- &nbsp; &nbsp; &nbsp; 
- <input type="submit" name="op" value="Save" /></td>
+        <?php echo createDictLinksInEditWin($formdata->lang, $formdata->term, 'document.forms[0].WoSentence', isset($_GET['nodict'])?0:1); ?>
+ &nbsp; &nbsp; &nbsp; <input type="submit" name="op" value="Save" /></td>
  </tr>
  </table>
  </form>
- <div id="exsent"><span class="click" onclick="do_ajax_show_sentences(<?php echo $lang; ?>, <?php echo prepare_textdata_js($termlc) . ', ' . prepare_textdata_js("document.forms['newword'].WoSentence") . ', 0'; ?>);"><img src="icn/sticky-notes-stack.png" title="Show Sentences" alt="Show Sentences" /> Show Sentences</span></div>    
+ <div id="exsent"><span class="click" onclick="do_ajax_show_sentences(<?php echo $formdata->lang; ?>, <?php echo prepare_textdata_js($formdata->termlc) . ', ' . prepare_textdata_js("document.forms['newword'].WoSentence") . ', 0'; ?>);"><img src="icn/sticky-notes-stack.png" title="Show Sentences" alt="Show Sentences" /> Show Sentences</span></div>    
+
         <?php
         
     } else {

--- a/edit_word.php
+++ b/edit_word.php
@@ -344,15 +344,14 @@ if (isset($_REQUEST['op'])) {
     <?php
     $scrdir = getScriptDirectionTag($lang);
 
-    // NEW
-    
+    $formdata = new FormData();
+    $formdata->fromAnn = $fromAnn;
+    $formdata->lang = $lang;
+    $formdata->term = $term;
+    $formdata->termlc = $termlc;
+    $formdata->scrdir = $scrdir;
+
     if ($new) {
-        $formdata = new FormData();
-        $formdata->fromAnn = $fromAnn;
-        $formdata->lang = $lang;
-        $formdata->term = $term;
-        $formdata->termlc = $termlc;
-        $formdata->scrdir = $scrdir;
         $formdata->tags = getWordTags(0);
         $formdata->sentence = get_sentence_for_termlc($termlc);
         $formdata->status = 1;
@@ -361,15 +360,6 @@ if (isset($_REQUEST['op'])) {
         show_form($formdata, "New Term", "Save");
         
     } else {
-        // CHG
-
-        $formdata = new FormData();
-        $formdata->fromAnn = $fromAnn;
-        $formdata->lang = $lang;
-        $formdata->term = $term;
-        $formdata->termlc = $termlc;
-        $formdata->scrdir = $scrdir;
-
         $sql = 'select WoTranslation, WoSentence, WoRomanization, WoStatus from ' . $tbpref . 'words where WoID = ' . $wid;
         $res = do_mysqli_query($sql);
         if ($record = mysqli_fetch_assoc($res)) {

--- a/edit_word.php
+++ b/edit_word.php
@@ -197,6 +197,8 @@ function handle_save_or_update(): void
     } else {
         change_term_display($wid, $translation, $hex);
     }
+
+    pageend();
 }
 
 
@@ -391,8 +393,8 @@ if (isset($_REQUEST['op'])) {
         mysqli_free_result($res);
     }
 
+    pageend();
 }
 
-pageend();
 
 ?>

--- a/edit_word.php
+++ b/edit_word.php
@@ -254,6 +254,59 @@ class FormData
 }
 
 
+function show_form($formdata)
+{
+?>
+ <form name="newword" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
+ <input type="hidden" name="fromAnn" value="<?php echo $formdata->fromAnn; ?>" />
+ <input type="hidden" name="WoLgID" id="langfield" value="<?php echo $formdata->lang; ?>" />
+ <input type="hidden" name="WoTextLC" value="<?php echo tohtml($formdata->termlc); ?>" />
+ <input type="hidden" name="tid" value="<?php echo $_REQUEST['tid']; ?>" />
+ <input type="hidden" name="ord" value="<?php echo $_REQUEST['ord']; ?>" />
+ <table class="tab2" cellspacing="0" cellpadding="5">
+ <tr title="Only change uppercase/lowercase!">
+ <td class="td1 right"><b>New Term:</b></td>
+ <td class="td1"><input <?php echo $formdata->srcdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($formdata->term); ?>" maxlength="250" size="35" /> <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
+ </td></tr>
+        <?php print_similar_terms_tabrow(); ?>
+ <tr>
+ <td class="td1 right">Translation:</td>
+ <td class="td1"><textarea name="WoTranslation" class="setfocus textarea-noreturn checklength checkoutsidebmp" data_maxlength="500" data_info="Translation" cols="35" rows="3"></textarea></td>
+ </tr>
+ <tr>
+ <td class="td1 right">Tags:</td>
+ <td class="td1">
+        <?php echo getWordTags(0); ?>
+ </td>
+ </tr>
+ <tr>
+ <td class="td1 right">Romaniz.:</td>
+ <td class="td1"><input type="text" class="checkoutsidebmp" data_info="Romanization" name="WoRomanization" value="" maxlength="100" size="35" /></td>
+ </tr>
+ <tr>
+ <td class="td1 right">Sentence<br />Term in {...}:</td>
+ <td class="td1"><textarea <?php echo $scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea></td>
+ </tr>
+        <?php print_similar_terms_tabrow(); ?>
+ <tr>
+ <td class="td1 right">Status:</td>
+ <td class="td1">
+        <?php echo get_wordstatus_radiooptions($formdata->status); ?>
+ </td>
+ </tr>
+ <tr>
+ <td class="td1 right" colspan="2">
+        <?php echo createDictLinksInEditWin($formdata->lang, $formdata->term, 'document.forms[0].WoSentence', isset($_GET['nodict'])?0:1); ?>
+ &nbsp; &nbsp; &nbsp; <input type="submit" name="op" value="Save" /></td>
+ </tr>
+ </table>
+ </form>
+ <div id="exsent"><span class="click" onclick="do_ajax_show_sentences(<?php echo $formdata->lang; ?>, <?php echo prepare_textdata_js($formdata->termlc) . ', ' . prepare_textdata_js("document.forms['newword'].WoSentence") . ', 0'; ?>);"><img src="icn/sticky-notes-stack.png" title="Show Sentences" alt="Show Sentences" /> Show Sentences</span></div>    
+
+        <?php
+}
+
+
 $fromAnn = getreq("fromAnn"); // from-recno or empty
 $lang = null;
 $term = null;
@@ -304,54 +357,7 @@ if (isset($_REQUEST['op'])) {
         $formdata->status = 1;
         $formdata->status_old = 1;
 
-?>
- <form name="newword" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
- <input type="hidden" name="fromAnn" value="<?php echo $formdata->fromAnn; ?>" />
- <input type="hidden" name="WoLgID" id="langfield" value="<?php echo $formdata->lang; ?>" />
- <input type="hidden" name="WoTextLC" value="<?php echo tohtml($formdata->termlc); ?>" />
- <input type="hidden" name="tid" value="<?php echo $_REQUEST['tid']; ?>" />
- <input type="hidden" name="ord" value="<?php echo $_REQUEST['ord']; ?>" />
- <table class="tab2" cellspacing="0" cellpadding="5">
- <tr title="Only change uppercase/lowercase!">
- <td class="td1 right"><b>New Term:</b></td>
- <td class="td1"><input <?php echo $formdata->scrdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($formdata->term); ?>" maxlength="250" size="35" /> <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
- </td></tr>
-        <?php print_similar_terms_tabrow(); ?>
- <tr>
- <td class="td1 right">Translation:</td>
- <td class="td1"><textarea name="WoTranslation" class="setfocus textarea-noreturn checklength checkoutsidebmp" data_maxlength="500" data_info="Translation" cols="35" rows="3"></textarea></td>
- </tr>
- <tr>
- <td class="td1 right">Tags:</td>
- <td class="td1">
-        <?php echo getWordTags(0); ?>
- </td>
- </tr>
- <tr>
- <td class="td1 right">Romaniz.:</td>
- <td class="td1"><input type="text" class="checkoutsidebmp" data_info="Romanization" name="WoRomanization" value="" maxlength="100" size="35" /></td>
- </tr>
- <tr>
- <td class="td1 right">Sentence<br />Term in {...}:</td>
- <td class="td1"><textarea <?php echo $scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea></td>
- </tr>
-        <?php print_similar_terms_tabrow(); ?>
- <tr>
- <td class="td1 right">Status:</td>
- <td class="td1">
-        <?php echo get_wordstatus_radiooptions($formdata->status); ?>
- </td>
- </tr>
- <tr>
- <td class="td1 right" colspan="2">
-        <?php echo createDictLinksInEditWin($formdata->lang, $formdata->term, 'document.forms[0].WoSentence', isset($_GET['nodict'])?0:1); ?>
- &nbsp; &nbsp; &nbsp; <input type="submit" name="op" value="Save" /></td>
- </tr>
- </table>
- </form>
- <div id="exsent"><span class="click" onclick="do_ajax_show_sentences(<?php echo $formdata->lang; ?>, <?php echo prepare_textdata_js($formdata->termlc) . ', ' . prepare_textdata_js("document.forms['newword'].WoSentence") . ', 0'; ?>);"><img src="icn/sticky-notes-stack.png" title="Show Sentences" alt="Show Sentences" /> Show Sentences</span></div>    
-
-        <?php
+        show_form($formdata);
         
     } else {
         // CHG

--- a/edit_word.php
+++ b/edit_word.php
@@ -255,7 +255,7 @@ class FormData
 }
 
 
-function show_form($formdata, $title = "New Term:")
+function show_form($formdata, $title = "New Term:", $operation = "Save")
 {
 ?>
  <form name="newword" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
@@ -288,6 +288,8 @@ function show_form($formdata, $title = "New Term:")
  <tr>
  <td class="td1 right">Sentence<br />Term in {...}:</td>
  <td class="td1"><textarea <?php echo $scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea></td>
+ </tr>
+ <tr>
  <td class="td1 right">Status:</td>
  <td class="td1">
         <?php echo get_wordstatus_radiooptions($formdata->status); ?>
@@ -296,7 +298,7 @@ function show_form($formdata, $title = "New Term:")
  <tr>
  <td class="td1 right" colspan="2">
         <?php echo createDictLinksInEditWin($formdata->lang, $formdata->term, 'document.forms[0].WoSentence', isset($_GET['nodict'])?0:1); ?>
- &nbsp; &nbsp; &nbsp; <input type="submit" name="op" value="Save" /></td>
+ &nbsp; &nbsp; &nbsp; <input type="submit" name="op" value="<?php echo $operation; ?>" /></td>
  </tr>
  </table>
  </form>
@@ -356,7 +358,7 @@ if (isset($_REQUEST['op'])) {
         $formdata->status = 1;
         $formdata->status_old = 1;
 
-        show_form($formdata);
+        show_form($formdata, "New Term", "Save");
         
     } else {
         // CHG

--- a/edit_word.php
+++ b/edit_word.php
@@ -258,7 +258,7 @@ class FormData
 function show_form($formdata, $title = "New Term:", $operation = "Save")
 {
 ?>
- <form name="newword" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
+ <form name="wordform" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
  <input type="hidden" name="WoLgID" id="langfield" value="<?php echo $formdata->lang; ?>" />
  <input type="hidden" name="fromAnn" value="<?php echo $formdata->fromAnn; ?>" />
  <input type="hidden" name="WoOldStatus" value="<?php echo $formdata->status_old; ?>" />
@@ -302,7 +302,7 @@ function show_form($formdata, $title = "New Term:", $operation = "Save")
  </tr>
  </table>
  </form>
- <div id="exsent"><span class="click" onclick="do_ajax_show_sentences(<?php echo $formdata->lang; ?>, <?php echo prepare_textdata_js($formdata->termlc) . ', ' . prepare_textdata_js("document.forms['newword'].WoSentence") . ', 0'; ?>);"><img src="icn/sticky-notes-stack.png" title="Show Sentences" alt="Show Sentences" /> Show Sentences</span></div>    
+ <div id="exsent"><span class="click" onclick="do_ajax_show_sentences(<?php echo $formdata->lang; ?>, <?php echo prepare_textdata_js($formdata->termlc) . ', ' . prepare_textdata_js("document.forms['wordform'].WoSentence") . ', 0'; ?>);"><img src="icn/sticky-notes-stack.png" title="Show Sentences" alt="Show Sentences" /> Show Sentences</span></div>    
 
         <?php
 }

--- a/edit_word.php
+++ b/edit_word.php
@@ -241,10 +241,11 @@ class FormData
 {
   public $fromAnn = '';
   public $lang;
+  public $wid = 0;
   public $term;
   public $termlc;
   public $srcdir;
-  public $transl = '';
+  public $translation = '';
   public $tags;
   public $romanization = '';
   public $sentence = '';
@@ -254,34 +255,35 @@ class FormData
 }
 
 
-function show_form($formdata)
+function show_form($formdata, $title = "New Term:")
 {
 ?>
  <form name="newword" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
- <input type="hidden" name="fromAnn" value="<?php echo $formdata->fromAnn; ?>" />
  <input type="hidden" name="WoLgID" id="langfield" value="<?php echo $formdata->lang; ?>" />
+ <input type="hidden" name="fromAnn" value="<?php echo $formdata->fromAnn; ?>" />
+ <input type="hidden" name="WoOldStatus" value="<?php echo $formdata->status_old; ?>" />
  <input type="hidden" name="WoTextLC" value="<?php echo tohtml($formdata->termlc); ?>" />
- <input type="hidden" name="tid" value="<?php echo $_REQUEST['tid']; ?>" />
- <input type="hidden" name="ord" value="<?php echo $_REQUEST['ord']; ?>" />
+ <input type="hidden" name="tid" value="<?php echo getreq('tid'); ?>" />
+ <input type="hidden" name="ord" value="<?php echo getreq('ord'); ?>" />
  <table class="tab2" cellspacing="0" cellpadding="5">
  <tr title="Only change uppercase/lowercase!">
- <td class="td1 right"><b>New Term:</b></td>
+ <td class="td1 right"><b><?php echo $title; ?></b></td>
  <td class="td1"><input <?php echo $formdata->srcdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($formdata->term); ?>" maxlength="250" size="35" /> <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
  </td></tr>
         <?php print_similar_terms_tabrow(); ?>
  <tr>
  <td class="td1 right">Translation:</td>
- <td class="td1"><textarea name="WoTranslation" class="setfocus textarea-noreturn checklength checkoutsidebmp" data_maxlength="500" data_info="Translation" cols="35" rows="3"></textarea></td>
+ <td class="td1"><textarea name="WoTranslation" class="setfocus textarea-noreturn checklength checkoutsidebmp" data_maxlength="500" data_info="Translation" cols="35" rows="3"><?php echo tohtml($formdata->translation); ?></textarea></td>
  </tr>
  <tr>
  <td class="td1 right">Tags:</td>
  <td class="td1">
-        <?php echo getWordTags(0); ?>
+        <?php echo getWordTags($formdata->wid); ?>
  </td>
  </tr>
  <tr>
  <td class="td1 right">Romaniz.:</td>
- <td class="td1"><input type="text" class="checkoutsidebmp" data_info="Romanization" name="WoRomanization" value="" maxlength="100" size="35" /></td>
+ <td class="td1"><input type="text" class="checkoutsidebmp" data_info="Romanization" name="WoRomanization" value="" maxlength="100" size="35" value="<?php echo tohtml($formdata->romanization); ?>" /></td>
  </tr>
  <tr>
  <td class="td1 right">Sentence<br />Term in {...}:</td>

--- a/edit_word.php
+++ b/edit_word.php
@@ -154,14 +154,11 @@ function change_term_display($wid, $translation, $hex): void
 }
 
 
-$fromAnn = getreq("fromAnn"); // from-recno or empty
-
-// INS/UPD
-
-$lang = null;
-$term = null;
-if (isset($_REQUEST['op'])) {
-    
+/**
+ * Add new term or edit existing one, display result.
+ */
+function handle_save_or_update(): void
+{
     $textlc = trim(prepare_textdata($_REQUEST["WoTextLC"]));
     $text = trim(prepare_textdata($_REQUEST["WoText"]));
     $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
@@ -201,11 +198,17 @@ if (isset($_REQUEST['op'])) {
     } else {
         change_term_display($wid, $translation, $hex);
     }
-    // if (isset($_REQUEST['op']))
-} else {  
-    // FORM
-    // if (! isset($_REQUEST['op']))
+}
 
+
+$fromAnn = getreq("fromAnn"); // from-recno or empty
+$lang = null;
+$term = null;
+
+if (isset($_REQUEST['op'])) {
+  handle_save_or_update();
+} else {
+    // FORM
     // edit_word.php?tid=..&ord=..&wid=..
     
     $wid = getreq('wid');

--- a/edit_word.php
+++ b/edit_word.php
@@ -189,15 +189,11 @@ if (isset($_REQUEST['op'])) {
     }
     
     if ($_REQUEST['op'] == 'Save') {
-        $output = insert_new_word($textlc, $translation);
-        $wid = $output[0];
-        $message = $output[1];
+        [ $wid, $message ] = insert_new_word($textlc, $translation);
         $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
     }
     else {
-        $output = edit_term($translation);
-        $wid = $output[0];
-        $message = $output[1];
+        [ $wid, $message ] = edit_term($translation);
     }
     saveWordTags($wid);
 

--- a/edit_word.php
+++ b/edit_word.php
@@ -257,6 +257,13 @@ class FormData
 function show_form($formdata, $title = "New Term:", $operation = "Save")
 {
 ?>
+<script type="text/javascript">
+    $(document).ready(ask_before_exiting);
+    $(window).on('beforeunload',function() {
+        setTimeout(function() {window.parent.frames['ru'].location.href = 'empty.html';}, 0);
+    });
+</script>
+
  <form name="wordform" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
  <input type="hidden" name="WoID" id="langfield" value="<?php echo $formdata->wid; ?>" />
  <input type="hidden" name="WoLgID" id="langfield" value="<?php echo $formdata->lang; ?>" />
@@ -334,14 +341,6 @@ if (isset($_REQUEST['op'])) {
 
     $titletext = ($new ? "New Term" : "Edit Term") . ": " . tohtml($term);
     pagestart_nobody($titletext);
-    ?>
-<script type="text/javascript">
-    $(document).ready(ask_before_exiting);
-    $(window).on('beforeunload',function() {
-        setTimeout(function() {window.parent.frames['ru'].location.href = 'empty.html';}, 0);
-    });
-</script>
-    <?php
     $scrdir = getScriptDirectionTag($lang);
 
     $formdata = new FormData();

--- a/edit_word.php
+++ b/edit_word.php
@@ -244,7 +244,7 @@ class FormData
   public $wid = 0;
   public $term;
   public $termlc;
-  public $srcdir;
+  public $scrdir;
   public $translation = '';
   public $tags;
   public $romanization = '';
@@ -268,7 +268,7 @@ function show_form($formdata, $title = "New Term:")
  <table class="tab2" cellspacing="0" cellpadding="5">
  <tr title="Only change uppercase/lowercase!">
  <td class="td1 right"><b><?php echo $title; ?></b></td>
- <td class="td1"><input <?php echo $formdata->srcdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($formdata->term); ?>" maxlength="250" size="35" /> <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
+ <td class="td1"><input <?php echo $formdata->scrdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($formdata->term); ?>" maxlength="250" size="35" /> <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
  </td></tr>
         <?php print_similar_terms_tabrow(); ?>
  <tr>

--- a/edit_word.php
+++ b/edit_word.php
@@ -193,10 +193,11 @@ if (isset($_REQUEST['op'])) {
     saveWordTags($wid);
 
     echo '<p>OK: ' . tohtml($message) . '</p>';
-    
-    if ($fromAnn !== '') {
+
+    $fa = getreq("fromAnn"); // from-recno or empty
+    if ($fa !== '') {
         $textlc_js = prepare_textdata_js($textlc);
-        echo "<script>window.opener.do_ajax_edit_impr_text({$fromAnn}, {$textlc_js});</script>";
+        echo "<script>window.opener.do_ajax_edit_impr_text({$fa}, {$textlc_js});</script>";
     } else {
         change_term_display($wid, $translation, $hex);
     }

--- a/edit_word.php
+++ b/edit_word.php
@@ -29,11 +29,6 @@ require_once 'inc/simterms.php';
 function insert_new_word($textlc, $translation)
 {
     global $tbpref;
-
-    $titletext = "New Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
-    pagestart_nobody($titletext);
-    echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
-
     $message = runsql(
         'INSERT INTO ' . $tbpref . 'words 
         (
@@ -71,11 +66,6 @@ function insert_new_word($textlc, $translation)
 function edit_term($translation)
 {
     global $tbpref;
-
-    $titletext = "Edit Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
-    pagestart_nobody($titletext);
-    echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
-    
     $oldstatus = $_REQUEST["WoOldStatus"];
     $newstatus = $_REQUEST["WoStatus"];
     $xx = '';
@@ -189,24 +179,23 @@ if (isset($_REQUEST['op'])) {
     
     if (mb_strtolower($text, 'UTF-8') == $textlc) {
     
-        // INSERT
-        
         if ($_REQUEST['op'] == 'Save') {
+            $titletext = "New Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
+            pagestart_nobody($titletext);
+            echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
             $output = insert_new_word($textlc, $translation);
             $wid = $output[0];
             $message = $output[1];
             $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
-            
-        } // $_REQUEST['op'] == 'Save'
-        
-        // UPDATE
-        
-        else {  // $_REQUEST['op'] != 'Save'
+        }
+        else {
+            $titletext = "Edit Term: " . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
+            pagestart_nobody($titletext);
+            echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
             $output = edit_term($translation);
             $wid = $output[0];
             $message = $output[1];
-            
-        }  // $_REQUEST['op'] != 'Save'
+        }
         
         saveWordTags($wid);
 

--- a/edit_word.php
+++ b/edit_word.php
@@ -199,15 +199,8 @@ if (isset($_REQUEST['op'])) {
     echo '<p>OK: ' . tohtml($message) . '</p>';
     
     if ($fromAnn !== '') {
-        ?>
-<script type="text/javascript">
-//<![CDATA[
-    window.opener.do_ajax_edit_impr_text(
-        <?php echo $fromAnn; ?>, <?php echo prepare_textdata_js($textlc); ?>
-        );
-//]]>
-</script>
-        <?php
+        $textlc_js = prepare_textdata_js($textlc);
+        echo "<script>window.opener.do_ajax_edit_impr_text({$fromAnn}, {$textlc_js});</script>";
     } else {
         change_term_display($wid, $translation, $hex);
     }

--- a/edit_word.php
+++ b/edit_word.php
@@ -201,18 +201,8 @@ function handle_save_or_update(): void
 }
 
 
-$fromAnn = getreq("fromAnn"); // from-recno or empty
-$lang = null;
-$term = null;
-
-if (isset($_REQUEST['op'])) {
-  handle_save_or_update();
-} else {
-    // FORM
-    // edit_word.php?tid=..&ord=..&wid=..
-    
-    $wid = getreq('wid');
-    
+function get_term_and_lang($wid)
+{
     if ($wid == '') {    
         $sql = 
         'SELECT Ti2Text, Ti2LgID FROM ' . $tbpref . 'textitems2 
@@ -228,13 +218,6 @@ if (isset($_REQUEST['op'])) {
         mysqli_free_result($res);
         
         $termlc = mb_strtolower($term, 'UTF-8');
-        
-        $wid = get_first_value(
-            "SELECT WoID AS value 
-            FROM " . $tbpref . "words 
-            WHERE WoLgID = " . $lang . " AND WoTextLC = " . convert_string_to_sqlsyntax($termlc)
-        ); 
-        
     } else {
 
         $sql = 'SELECT WoText, WoLgID FROM ' . $tbpref . 'words WHERE WoID = ' . $wid;
@@ -249,6 +232,31 @@ if (isset($_REQUEST['op'])) {
         mysqli_free_result($res);
         $termlc =    mb_strtolower($term, 'UTF-8');
         
+    }
+
+    return [ $term, $lang ];
+}
+
+$fromAnn = getreq("fromAnn"); // from-recno or empty
+$lang = null;
+$term = null;
+
+if (isset($_REQUEST['op'])) {
+  handle_save_or_update();
+} else {
+    // FORM
+    // edit_word.php?tid=..&ord=..&wid=..
+
+    $wid = getreq('wid');
+    [ $term, $lang ] = get_term_and_lang($wid);
+    $termlc = mb_strtolower($term, 'UTF-8');
+
+    if ($wid == '') {
+        $wid = get_first_value(
+            "SELECT WoID AS value 
+            FROM " . $tbpref . "words 
+            WHERE WoLgID = " . $lang . " AND WoTextLC = " . convert_string_to_sqlsyntax($termlc)
+        );
     }
     
     $new = (isset($wid) == false);

--- a/edit_word.php
+++ b/edit_word.php
@@ -178,7 +178,7 @@ if (isset($_REQUEST['op'])) {
     if ($_REQUEST['op'] == 'Save') {
       $titlestart = "New Term: ";
     }
-    $titletext = $titlestart . tohtml(prepare_textdata($_REQUEST["WoTextLC"]));
+    $titletext = $titlestart . tohtml($textlc);
     pagestart_nobody($titletext);
     echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
 

--- a/edit_word.php
+++ b/edit_word.php
@@ -328,14 +328,12 @@ function augment_formdata_for_updates($wid, &$formdata)
     }
 
     $status = $record['WoStatus'];
-    if ($fromAnn == '' ) {
-        if ($status >= 98) {
-            $status = 1;
-        }
+    if ($formdata->romAnn == '' && $status >= 98) {
+        $status = 1;
     }
     $sentence = repl_tab_nl($record['WoSentence']);
     if ($sentence == '' && isset($_REQUEST['tid']) && isset($_REQUEST['ord'])) {
-        $sentence = get_sentence_for_termlc($termlc);
+        $sentence = get_sentence_for_termlc($formdata->termlc);
     }
     $transl = repl_tab_nl($record['WoTranslation']);
     if($transl == '*') {
@@ -351,10 +349,6 @@ function augment_formdata_for_updates($wid, &$formdata)
     $formdata->status_old = $record['WoStatus'];
 }
 
-
-$fromAnn = getreq("fromAnn"); // from-recno or empty
-$lang = null;
-$term = null;
 
 if (isset($_REQUEST['op'])) {
   handle_save_or_update();
@@ -376,7 +370,7 @@ if (isset($_REQUEST['op'])) {
     }
 
     $formdata = new FormData();
-    $formdata->fromAnn = $fromAnn;
+    $formdata->fromAnn = getreq("fromAnn");
     $formdata->lang = $lang;
     $formdata->term = $term;
     $formdata->termlc = $termlc;

--- a/edit_word.php
+++ b/edit_word.php
@@ -260,60 +260,76 @@ function show_form($formdata, $title = "New Term:", $operation = "Save")
 {
 ?>
 <script type="text/javascript">
-    $(document).ready(ask_before_exiting);
-    $(window).on('beforeunload',function() {
-        setTimeout(function() {window.parent.frames['ru'].location.href = 'empty.html';}, 0);
-    });
+$(document).ready(ask_before_exiting);
+$(window).on('beforeunload',function() {
+  setTimeout(function() {window.parent.frames['ru'].location.href = 'empty.html';}, 0);
+});
 </script>
 
- <form name="wordform" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
- <input type="hidden" name="WoID" id="langfield" value="<?php echo $formdata->wid; ?>" />
- <input type="hidden" name="WoLgID" id="langfield" value="<?php echo $formdata->lang; ?>" />
- <input type="hidden" name="fromAnn" value="<?php echo $formdata->fromAnn; ?>" />
- <input type="hidden" name="WoOldStatus" value="<?php echo $formdata->status_old; ?>" />
- <input type="hidden" name="WoTextLC" value="<?php echo tohtml($formdata->termlc); ?>" />
- <input type="hidden" name="tid" value="<?php echo getreq('tid'); ?>" />
- <input type="hidden" name="ord" value="<?php echo getreq('ord'); ?>" />
- <table class="tab2" cellspacing="0" cellpadding="5">
- <tr title="Only change uppercase/lowercase!">
- <td class="td1 right"><b><?php echo $title; ?></b></td>
- <td class="td1"><input <?php echo $formdata->scrdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($formdata->term); ?>" maxlength="250" size="35" /> <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
- </td></tr>
-        <?php print_similar_terms_tabrow(); ?>
- <tr>
- <td class="td1 right">Translation:</td>
- <td class="td1"><textarea name="WoTranslation" class="setfocus textarea-noreturn checklength checkoutsidebmp" data_maxlength="500" data_info="Translation" cols="35" rows="3"><?php echo tohtml($formdata->translation); ?></textarea></td>
- </tr>
- <tr>
- <td class="td1 right">Tags:</td>
- <td class="td1">
-        <?php echo getWordTags($formdata->wid); ?>
- </td>
- </tr>
- <tr>
- <td class="td1 right">Romaniz.:</td>
- <td class="td1"><input type="text" class="checkoutsidebmp" data_info="Romanization" name="WoRomanization" value="<?php echo tohtml($formdata->romanization); ?>" maxlength="100" size="35" /></td>
- </tr>
- <tr>
- <td class="td1 right">Sentence<br />Term in {...}:</td>
- <td class="td1"><textarea <?php echo $formdata->scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea></td>
- </tr>
- <tr>
- <td class="td1 right">Status:</td>
- <td class="td1">
-        <?php echo get_wordstatus_radiooptions($formdata->status); ?>
- </td>
- </tr>
- <tr>
- <td class="td1 right" colspan="2">
-        <?php echo createDictLinksInEditWin($formdata->lang, $formdata->term, 'document.forms[0].WoSentence', isset($_GET['nodict'])?0:1); ?>
- &nbsp; &nbsp; &nbsp; <input type="submit" name="op" value="<?php echo $operation; ?>" /></td>
- </tr>
- </table>
- </form>
- <div id="exsent"><span class="click" onclick="do_ajax_show_sentences(<?php echo $formdata->lang; ?>, <?php echo prepare_textdata_js($formdata->termlc) . ', ' . prepare_textdata_js("document.forms['wordform'].WoSentence") . ', 0'; ?>);"><img src="icn/sticky-notes-stack.png" title="Show Sentences" alt="Show Sentences" /> Show Sentences</span></div>    
+<form name="wordform" class="validate" action="<?php echo $_SERVER['PHP_SELF']; ?>" method="post">
+<input type="hidden" name="WoID" id="langfield" value="<?php echo $formdata->wid; ?>" />
+<input type="hidden" name="WoLgID" id="langfield" value="<?php echo $formdata->lang; ?>" />
+<input type="hidden" name="fromAnn" value="<?php echo $formdata->fromAnn; ?>" />
+<input type="hidden" name="WoOldStatus" value="<?php echo $formdata->status_old; ?>" />
+<input type="hidden" name="WoTextLC" value="<?php echo tohtml($formdata->termlc); ?>" />
+<input type="hidden" name="tid" value="<?php echo getreq('tid'); ?>" />
+<input type="hidden" name="ord" value="<?php echo getreq('ord'); ?>" />
 
-        <?php
+<table class="tab2" cellspacing="0" cellpadding="5">
+  <tr title="Only change uppercase/lowercase!">
+    <td class="td1 right"><b><?php echo $title; ?></b></td>
+    <td class="td1">
+      <input <?php echo $formdata->scrdir; ?> class="notempty checkoutsidebmp" data_info="New Term" type="text" name="WoText" id="wordfield" value="<?php echo tohtml($formdata->term); ?>" maxlength="250" size="35" />
+      <img src="icn/status-busy.png" title="Field must not be empty" alt="Field must not be empty" />
+    </td>
+  </tr>
+  <?php print_similar_terms_tabrow(); ?>
+  <tr>
+    <td class="td1 right">Translation:</td>
+    <td class="td1">
+      <textarea name="WoTranslation" class="setfocus textarea-noreturn checklength checkoutsidebmp" data_maxlength="500" data_info="Translation" cols="35" rows="3"><?php echo tohtml($formdata->translation); ?></textarea>
+    </td>
+  </tr>
+  <tr>
+    <td class="td1 right">Tags:</td>
+    <td class="td1">
+      <?php echo getWordTags($formdata->wid); ?>
+    </td>
+  </tr>
+  <tr>
+    <td class="td1 right">Romaniz.:</td>
+    <td class="td1">
+      <input type="text" class="checkoutsidebmp" data_info="Romanization" name="WoRomanization" value="<?php echo tohtml($formdata->romanization); ?>" maxlength="100" size="35" />
+    </td>
+  </tr>
+  <tr>
+    <td class="td1 right">Sentence<br />Term in {...}:</td>
+    <td class="td1">
+      <textarea <?php echo $formdata->scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea>
+    </td>
+  </tr>
+  <tr>
+    <td class="td1 right">Status:</td>
+    <td class="td1">
+       <?php echo get_wordstatus_radiooptions($formdata->status); ?>
+    </td>
+  </tr>
+  <tr>
+    <td class="td1 right" colspan="2">
+       <?php echo createDictLinksInEditWin($formdata->lang, $formdata->term, 'document.forms[0].WoSentence', isset($_GET['nodict'])?0:1); ?>
+ &nbsp; &nbsp; &nbsp; <input type="submit" name="op" value="<?php echo $operation; ?>" />
+    </td>
+  </tr>
+</table>
+
+</form>
+
+<div id="exsent">
+  <span class="click" onclick="do_ajax_show_sentences(<?php echo $formdata->lang; ?>, <?php echo prepare_textdata_js($formdata->termlc) . ', ' . prepare_textdata_js("document.forms['wordform'].WoSentence") . ', 0'; ?>);">
+  <img src="icn/sticky-notes-stack.png" title="Show Sentences" alt="Show Sentences" /> Show Sentences</span>
+</div>
+
+     <?php
 }
 
 

--- a/edit_word.php
+++ b/edit_word.php
@@ -286,9 +286,6 @@ function show_form($formdata)
  <tr>
  <td class="td1 right">Sentence<br />Term in {...}:</td>
  <td class="td1"><textarea <?php echo $scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea></td>
- </tr>
-        <?php print_similar_terms_tabrow(); ?>
- <tr>
  <td class="td1 right">Status:</td>
  <td class="td1">
         <?php echo get_wordstatus_radiooptions($formdata->status); ?>

--- a/edit_word.php
+++ b/edit_word.php
@@ -182,7 +182,11 @@ if (isset($_REQUEST['op'])) {
     pagestart_nobody($titletext);
     echo '<h4><span class="bigger">' . $titletext . '</span></h4>';
 
-    if (mb_strtolower($text, 'UTF-8') == $textlc) {
+    if (mb_strtolower($text, 'UTF-8') != $textlc) {
+        lowercase_term_not_equal($textlc);
+        pageend();
+        exit();
+    }
     
         if ($_REQUEST['op'] == 'Save') {
             $output = insert_new_word($textlc, $translation);
@@ -197,16 +201,6 @@ if (isset($_REQUEST['op'])) {
         }
         
         saveWordTags($wid);
-
-    } // (mb_strtolower($text, 'UTF-8') == $textlc)
-    
-    else { // (mb_strtolower($text, 'UTF-8') != $textlc)
-        lowercase_term_not_equal($textlc);
-        pageend();
-        exit();
-    
-    }
-    
 
     echo '<p>OK: ' . tohtml($message) . '</p>';
     

--- a/edit_word.php
+++ b/edit_word.php
@@ -287,7 +287,7 @@ function show_form($formdata, $title = "New Term:", $operation = "Save")
  </tr>
  <tr>
  <td class="td1 right">Sentence<br />Term in {...}:</td>
- <td class="td1"><textarea <?php echo $scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea></td>
+ <td class="td1"><textarea <?php echo $formdata->scrdir; ?> name="WoSentence" class="textarea-noreturn checklength checkoutsidebmp" data_maxlength="1000" data_info="Sentence" cols="35" rows="3"><?php echo tohtml($formdata->sentence); ?></textarea></td>
  </tr>
  <tr>
  <td class="td1 right">Status:</td>

--- a/edit_word.php
+++ b/edit_word.php
@@ -328,7 +328,7 @@ function augment_formdata_for_updates($wid, &$formdata)
     }
 
     $status = $record['WoStatus'];
-    if ($formdata->romAnn == '' && $status >= 98) {
+    if ($formdata->fromAnn == '' && $status >= 98) {
         $status = 1;
     }
     $sentence = repl_tab_nl($record['WoSentence']);
@@ -350,11 +350,10 @@ function augment_formdata_for_updates($wid, &$formdata)
 }
 
 
-if (isset($_REQUEST['op'])) {
-  handle_save_or_update();
-} else {
+function handle_display_form() {
     // FORM
     // edit_word.php?tid=..&ord=..&wid=..
+    global $tbpref;
 
     $wid = getreq('wid');
     [ $term, $lang ] = get_term_and_lang($wid);
@@ -395,6 +394,13 @@ if (isset($_REQUEST['op'])) {
     }
 
     pageend();
+}
+
+
+if (isset($_REQUEST['op'])) {
+  handle_save_or_update();
+} else {
+  handle_display_form();
 }
 
 

--- a/edit_word.php
+++ b/edit_word.php
@@ -328,6 +328,7 @@ if (isset($_REQUEST['op'])) {
     $wid = getreq('wid');
     [ $term, $lang ] = get_term_and_lang($wid);
     $termlc = mb_strtolower($term, 'UTF-8');
+    $scrdir = getScriptDirectionTag($lang);
 
     if ($wid == '') {
         $wid = get_first_value(
@@ -336,12 +337,6 @@ if (isset($_REQUEST['op'])) {
             WHERE WoLgID = " . $lang . " AND WoTextLC = " . convert_string_to_sqlsyntax($termlc)
         );
     }
-    
-    $new = (isset($wid) == false);
-
-    $titletext = ($new ? "New Term" : "Edit Term") . ": " . tohtml($term);
-    pagestart_nobody($titletext);
-    $scrdir = getScriptDirectionTag($lang);
 
     $formdata = new FormData();
     $formdata->fromAnn = $fromAnn;
@@ -349,6 +344,11 @@ if (isset($_REQUEST['op'])) {
     $formdata->term = $term;
     $formdata->termlc = $termlc;
     $formdata->scrdir = $scrdir;
+
+    $new = (isset($wid) == false);
+
+    $titletext = ($new ? "New Term" : "Edit Term") . ": " . tohtml($term);
+    pagestart_nobody($titletext);
 
     if ($new) {
         $formdata->tags = getWordTags(0);

--- a/edit_word.php
+++ b/edit_word.php
@@ -188,19 +188,18 @@ if (isset($_REQUEST['op'])) {
         exit();
     }
     
-        if ($_REQUEST['op'] == 'Save') {
-            $output = insert_new_word($textlc, $translation);
-            $wid = $output[0];
-            $message = $output[1];
-            $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
-        }
-        else {
-            $output = edit_term($translation);
-            $wid = $output[0];
-            $message = $output[1];
-        }
-        
-        saveWordTags($wid);
+    if ($_REQUEST['op'] == 'Save') {
+        $output = insert_new_word($textlc, $translation);
+        $wid = $output[0];
+        $message = $output[1];
+        $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
+    }
+    else {
+        $output = edit_term($translation);
+        $wid = $output[0];
+        $message = $output[1];
+    }
+    saveWordTags($wid);
 
     echo '<p>OK: ' . tohtml($message) . '</p>';
     

--- a/edit_word.php
+++ b/edit_word.php
@@ -166,13 +166,13 @@ $fromAnn = getreq("fromAnn"); // from-recno or empty
 
 // INS/UPD
 
-$hex = null;
 $lang = null;
 $term = null;
 if (isset($_REQUEST['op'])) {
     
     $textlc = trim(prepare_textdata($_REQUEST["WoTextLC"]));
     $text = trim(prepare_textdata($_REQUEST["WoText"]));
+    $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
 
     $titlestart = "Edit Term: ";
     if ($_REQUEST['op'] == 'Save') {
@@ -190,7 +190,6 @@ if (isset($_REQUEST['op'])) {
     
     if ($_REQUEST['op'] == 'Save') {
         [ $wid, $message ] = insert_new_word($textlc, $translation);
-        $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
     }
     else {
         [ $wid, $message ] = edit_term($translation);

--- a/edit_word.php
+++ b/edit_word.php
@@ -154,14 +154,6 @@ function change_term_display($wid, $translation, $hex): void
 }
 
 
-$translation_raw = repl_tab_nl(getreq("WoTranslation"));
-if ($translation_raw == '' ) { 
-    $translation = '*'; 
-}
-else { 
-    $translation = $translation_raw; 
-}
-
 $fromAnn = getreq("fromAnn"); // from-recno or empty
 
 // INS/UPD
@@ -173,6 +165,10 @@ if (isset($_REQUEST['op'])) {
     $textlc = trim(prepare_textdata($_REQUEST["WoTextLC"]));
     $text = trim(prepare_textdata($_REQUEST["WoText"]));
     $hex = strToClassName(prepare_textdata($_REQUEST["WoTextLC"]));
+    $translation = repl_tab_nl(getreq("WoTranslation"));
+    if ($translation == '' ) {
+      $translation = '*';
+    }
 
     $titlestart = "Edit Term: ";
     if ($_REQUEST['op'] == 'Save') {


### PR DESCRIPTION
This branch rewrites much of `edit_word.php`, and makes it much easier to follow what's going on.  (Unintentionally, it ends up looking fairly close to `edit_mword.php`.)

**Details**

See the commits for the work I did as I went along -- most are quite small: just moving code around, pulling out functions, removing common code, etc.

The biggest change is that now there is one function, `show_form()`, which is used for both the "insert new" and "update existing" code paths, and a class `FormData` holds the necessary data for the form.  (again practically the same as `edit_mword.php`).  I find it _much_ easier to grok.

**Future cleanup that can be done with this**

I believe that the `show_form()` function, the `FormData` structure, and the main idea of this file can be pulled out to a separate `inc/` file, and reused in the following, getting rid of a lot of duplication:

* edit_words.php
* edit_tword.php
* edit_mword.php

I have some more changes I wanted to make to simplify the overall code, but this cleanup was necessary first!

**Testing**

I've tried the code in a few different ways (adding new terms, editing existing, calling from the annotated printout), and it is working fine for me (Mac, Chrome, Spanish).