### PR TITLE
Give each wordpress user their own database instance.

### DIFF
--- a/connect_wordpress.inc.php
+++ b/connect_wordpress.inc.php
@@ -7,19 +7,22 @@
  * @author https://sourceforge.net/projects/lwt/ LWT Project
  * @since  1.5.5
  */
-  
+
 // database server
-// $server = "";
+$server = "localhost:8889";
 
 // database userid
-// $userid = "";
+$userid = "root";
 
 // database password
-// $passwd = "";
+$passwd = "root";
 
-// database name
-// $dbname = "";
+// database name "root"
+// (the wp user ID is appended to the end of the name
+// so each user gets their own database instance.)
+$rootdbname = "wordpress_lwt";
 
-require_once 'inc/wp_logincheck.php' ;   
+// DO NOT REMOVE THE NEXT LINE, it is required for the wordpress integration!
+require_once 'inc/wp_logincheck.php';
 
 ?>

--- a/docs/wordpress.md
+++ b/docs/wordpress.md
@@ -11,7 +11,7 @@ The following instructions are for users who have installed WordPress, and want 
 
 1.  [Download](http://wordpress.org/) and install WordPress.
 2.  [Download](http://sourceforge.net/projects/learning-with-texts/files/) and install LWT into a new subdirectory "lwt", located in the main directory of your WordPress installation.
-3.  In subdirectory "lwt", rename the file _connect\_wordpress.inc.php_ into _connect.inc.php_, and enter the database parameters $server (database server), $userid (database user id), $passwd (database password), and $dbname (database name, can be the same like your wordpress database, or a different one) by editing the file with a text editor.
+3.  In subdirectory "lwt", rename the file _connect\_wordpress.inc.php_ into _connect.inc.php_, and enter the database parameters $server (database server), $userid (database user id), $passwd (database password), and $rootdbname (database name "root") by editing the file with a text editor.
 4.  In the WordPress General Settings, decide whether anyone can register and use LWT (Membership = "Anyone can register"), or not (an administrator must create new users). The "New User Default Role" should be "Subscriber".
 5.  The link to start LWT with **complete** WordPress authentication is:  
     _http://...path-to-wp-blog.../lwt/wp\_lwt\_start.php_
@@ -21,4 +21,4 @@ The following instructions are for users who have installed WordPress, and want 
 7.  To properly log out from both WordPress and LWT, use the link:  
     _http://...path-to-wp-blog.../lwt/wp\_lwt\_stop.php_  
     The LWT home page has such a link. If you only log out via the links on the WordPress pages, you will still be able to use LWT until the browser is closed. If you want to log out from both WordPress and LWT, use the above link, or click on the link on the LWT home page!
-8.  If you delete a user, you must find out its user number (table "wp\_users"). After deleting the user in WordPress, you can delete all LWT tables with table names beginning with the user number plus an underscore "\_". You can do this in phpMyAdmin.
+8.  If you delete a user, you must find out its user number (table "wp\_users"). After deleting the user in WordPress, you can delete the database for that user ($rootdbname + the user number, e.g., "wordpress_lwt_42").  You can do this in phpMyAdmin.

--- a/inc/wp_logincheck.php
+++ b/inc/wp_logincheck.php
@@ -15,8 +15,14 @@
 
 require_once __DIR__ . '/start_session.php';
 
-if (isset($_SESSION['LWT-WP-User'])) {
-    $tbpref = $_SESSION['LWT-WP-User'];
+/** The ACTUAL database name that will be used for this wordpress user! */
+$dbname = null;
+
+$lwtwpuser = $_SESSION['LWT-WP-User'];
+if (isset($lwtwpuser)) {
+    global $dbname;
+    $dbname = "{$rootdbname}_{$lwtwpuser}";
+    $tbpref = '';
 } else {
     $url = '';
     if ($_SERVER['REQUEST_METHOD'] == 'GET') {


### PR DESCRIPTION
**Summary**

Instead of having table name prefixes, we can just have LWT auto-create completely separate databases for each WP user, so each WP user can manage their own database.  **With this, we can get rid of $tbpref everywhere, and fix all the DB migrations**.

This change is _much simpler_ than creating user tables, and modifying all data structures and queries to support a multi-tenant db architecture!!!

**Changes**

Pretty minimal, actually.  Essentially, every time a WP user tries to connect to the DB, the file `inc/wp_logincheck.php` just appends the user's WP ID to the `$rootdbname` specified in the connect file, and sets the new global `$dbname` which is used everywhere else.

**Demo**

I installed wordpress locally, and on the initial wp sample page I added a link to `[lwt/wp_lwt_start.php](http://localhost:8888/wordpress/lwt/wp_lwt_start.php)` as given in the docs.  In WP admin, I created a few users.  I then logged in to each user and clicked the link, and the databases were created.  Each user can then install their own demo, create their own texts etc, and the $dbname is set correctly.

e.g., I created a new WP user, "newguy", which had user_id=4:

```
mysql> select ID, user_login from wp_users where user_login = 'newguy';
+----+------------+
| ID | user_login |
+----+------------+
|  4 | newguy     |
+----+------------+
```

Prior to newguy's wordpress login:

```
mysql> show databases;
+-----------------------+
| Database              |
+-----------------------+
...
| wordpress_lwt_1       |
| wordpress_lwt_2       |
| wordpress_lwt_3       |
+-----------------------+
```

newguy logs in and clicks the LWT link, and new db is created

```
mysql> show databases;
+-----------------------+
| Database              |
+-----------------------+
...
| wordpress_lwt_1       |
| wordpress_lwt_2       |
| wordpress_lwt_3       |
| wordpress_lwt_4       |       <<<<<<< Welcome, newguy
+-----------------------+
```

and everything works as expected.  eg on the UI:

![image](https://user-images.githubusercontent.com/1637133/201503767-0b7c3399-fdce-4467-afad-c8a6761d0ac9.png)

**What this lets us do**

* Get rid of $tbpref everywhere, and a fair amount of trashy db update code.

** Docs needed for existing WP users to migrate**

For each WP user, the WP admin would need to do the following:

* create a copy of the WP database with the proper name ($rootdbname + user id)
* in that new db, drop all tables except those starting with the user id (and leave system table _lwt_general)
* rename all tables, removing the user id prefix

(We might be able to write some helper scripts for this, but I personally would rely on the community for input.  If they are savvy enough to set up the integrations etc for WP, then perhaps they can get into some other tasks too.  We do the best we can, but this is still an open source project, and not a paid product!)