### PR TITLE
Add initial database unit testing

### DIFF
--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -1950,6 +1950,7 @@ global $fixed_tbpref;
 $fixed_tbpref = get_database_prefixes($tbpref);
 
 // check/update db
+global $debug;
 check_update_db($debug, $tbpref, $dbname);
 
 ?>

--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -1934,15 +1934,21 @@ if (!empty($dspltime)) {
 /**
  * @var mysqli $DBCONNECTION Connection to the database
  */
+global $DBCONNECTION;
 $DBCONNECTION = connect_to_database($server, $userid, $passwd, $dbname);
+
 /** 
  * @var string $tbpref Database table prefix 
  */
+global $tbpref;
 $tbpref = null;
+
 /** 
  * @var int $fixed_tbpref Database prefix is fixed (1) or not (0)
  */
+global $fixed_tbpref;
 $fixed_tbpref = get_database_prefixes($tbpref);
+
 // check/update db
 check_update_db($debug, $tbpref, $dbname);
 

--- a/inc/settings.php
+++ b/inc/settings.php
@@ -16,16 +16,19 @@
  * @var int $debug 
  * 1 = debugging on, 0 = .. off 
  */
-$debug = 0;     
+global $debug;
+$debug = 0;
 /** 
  * @var int $dsplerrors 
  * 1 = display all errors on, 0 = .. off 
  */   
+global $dsplerrors;
 $dsplerrors = 0;
 /** 
  * @var int $dspltime 
  * 1 = display time on, 0 = .. off 
  */
+global $dspltime;
 $dspltime = 0;
 
 ?>

--- a/tests/db_helpers.php
+++ b/tests/db_helpers.php
@@ -1,0 +1,47 @@
+<?php
+
+/**
+ * IMPORTANT!
+ *
+ * This file should be included at the top of any files that hit the
+ * db.
+ */
+
+require_once __DIR__ . '/../inc/database_connect.php';
+
+class DbHelpers {
+
+    public static function ensure_using_test_db() {
+        global $dbname;
+        global $DBCONNECTION;
+        $conn_db_name = get_first_value("SELECT DATABASE() AS value");
+
+        $istestdbname = function($s) {
+            return (strtolowersubstr($s, 0, 5) == 'test_');
+        };
+        foreach([$dbname, $conn_db_name] as $s) {
+            $prefix = substr($s, 0, 5);
+            if (strtolower($prefix) != 'test_') {
+                $msg = "
+*************************************************************
+ERROR: Db name \"{$s}\" does not start with 'test_'
+
+(Stopping tests to prevent data loss.)
+
+Since database tests are destructive (delete/edit/change data),
+you must use a dedicated test database when running tests.
+
+1. Create a new database called 'test_<whatever_you_want>'
+2. Update your connect.inc.php to use this new db
+3. Run the tests.
+*************************************************************
+";
+                echo $msg;
+                die("Quitting");
+            }
+        }
+    }
+
+}
+
+?>

--- a/tests/db_helpers.php
+++ b/tests/db_helpers.php
@@ -42,6 +42,57 @@ you must use a dedicated test database when running tests.
         }
     }
 
+    public static function clean_db() {
+        $tables = [
+            "_lwtgeneral",
+            "archivedtexts",
+            "archtexttags",
+            "feedlinks",
+            "languages",
+            "newsfeeds",
+            "sentences",
+            // "settings",  // Keep these????
+            "tags",
+            "tags2",
+            "temptextitems",
+            "tempwords",
+            "textitems2",
+            "texts",
+            "texttags",
+            "tts",
+            "words",
+            "wordtags"
+        ];
+        foreach ($tables as $t) {
+            do_mysqli_query("truncate {$t}");
+        }
+    }
+
+    /**
+     * Data loaders.
+     *
+     * These might belong in an /api/db/ or similar.
+     *
+     * These are very hacky, not handling weird chars etc., and are
+     * also very inefficient!  Will fix if tests get stupid slow.
+     */
+
+    public static function add_tags($tags) {
+        foreach ($tags as $t) {
+            $sql = "insert into tags (TgText, TgComment)
+            values ('{$t}', '{$t} comment')";
+            do_mysqli_query($sql);
+        };
+    }
+
+    public static function add_texttags($tags) {
+        foreach ($tags as $t) {
+            $sql = "insert into tags2 (T2Text, T2Comment)
+            values ('{$t}', '{$t} comment')";
+            do_mysqli_query($sql);
+        };
+    }
+
 }
 
 ?>

--- a/tests/session_utility_Test.php
+++ b/tests/session_utility_Test.php
@@ -8,12 +8,13 @@ use PHPUnit\Framework\TestCase;
 final class session_utility_Test extends TestCase
 {
 
-    /**
-     * Hack/fake session and server information.
-     */
     public function setUp(): void
     {
+        // Set up db.
         DbHelpers::ensure_using_test_db();
+        DbHelpers::clean_db();
+
+        // Fake session and server info.
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REQUEST_URI'] = '/dummyuri';
         $this->clear_session();
@@ -76,32 +77,28 @@ final class session_utility_Test extends TestCase
     }
 
 
-    /**
-     * STUB TESTS ONLY.
-     *
-     * These don't really test functionality at the moment,
-     * they just ensure that the queries etc work.
-     * When the db setup/teardown is in place, and test data
-     * loaded, these tests can be replaced/updated to show
-     * actual data.
-     */
-
     /** TAGS **/
 
-    public function test_smoke_get_tags(): void
+    public function test_get_tags(): void
     {
+        $expected = ['a', 'b', 'c'];
+        DbHelpers::add_tags($expected);
         $t = get_tags();
-        $this->assertIsArray($t, 'returns tags');
-        $keys = [ 'TAGS', 'TBPREF_TAGS' ];
-        $this->assert_all_session_keys_set($keys);
+        $this->assertEquals($t, $expected);
+        $this->assertEquals($_SESSION['TAGS'], $expected);
+        $this->assertEquals($_SESSION['TBPREF_TAGS'], 'http://localhost/dummyuri/');
     }
 
-    public function test_smoke_get_texttags(): void
+    public function test_get_texttags(): void
     {
+        $expected = ['a2', 'b2', 'c2'];
+        DbHelpers::add_texttags($expected);
+
         $t = get_texttags();
-        $this->assertIsArray($t, 'returns tags');
-        $keys = [ 'TEXTTAGS', 'TBPREF_TEXTTAGS' ];
-        $this->assert_all_session_keys_set($keys);
+
+        $this->assertEquals($t, $expected);
+        $this->assertEquals($_SESSION['TEXTTAGS'], $expected);
+        $this->assertEquals($_SESSION['TBPREF_TEXTTAGS'], 'http://localhost/dummyuri/');
     }
 
 }

--- a/tests/session_utility_Test.php
+++ b/tests/session_utility_Test.php
@@ -1,6 +1,7 @@
 <?php declare(strict_types=1);
 
 require_once __DIR__ . '/../inc/session_utility.php';
+require_once __DIR__ . '/db_helpers.php';
 
 use PHPUnit\Framework\TestCase;
 
@@ -12,6 +13,7 @@ final class session_utility_Test extends TestCase
      */
     public function setUp(): void
     {
+        DbHelpers::ensure_using_test_db();
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REQUEST_URI'] = '/dummyuri';
         $this->clear_session();

--- a/tests/session_utility_Test.php
+++ b/tests/session_utility_Test.php
@@ -31,32 +31,35 @@ final class session_utility_Test extends TestCase
      * actual data.
      */
 
-    public function test_smoke_get_tags(): void
-    {
-        $session_keys = [ 'TAGS', 'TBPREF_TAGS' ];
-        foreach($session_keys as $k) {
+    private function unset_session_keys($keys) {
+        foreach($keys as $k) {
             unset($_SESSION[$k]);
             $this->assertFalse(isset($_SESSION[$k]), 'sanity check');
         };
-        $t = get_tags();
-        $this->assertIsArray($t, 'returns tags');
-        foreach($session_keys as $k) {
+    }
+
+    private function assert_all_session_keys_set($keys) {
+        foreach($keys as $k) {
             $this->assertTrue(isset($_SESSION[$k]), "Session {$k} set");
         };
+    }
+
+    public function test_smoke_get_tags(): void
+    {
+        $session_keys = [ 'TAGS', 'TBPREF_TAGS' ];
+        $this->unset_session_keys($session_keys);
+        $t = get_tags();
+        $this->assertIsArray($t, 'returns tags');
+        $this->assert_all_session_keys_set($session_keys);
     }
 
     public function test_smoke_get_texttags(): void
     {
         $session_keys = [ 'TEXTTAGS', 'TBPREF_TEXTTAGS' ];
-        foreach($session_keys as $k) {
-            unset($_SESSION[$k]);
-            $this->assertFalse(isset($_SESSION[$k]), 'sanity check');
-        };
+        $this->unset_session_keys($session_keys);
         $t = get_texttags();
         $this->assertIsArray($t, 'returns tags');
-        foreach($session_keys as $k) {
-            $this->assertTrue(isset($_SESSION[$k]), "Session {$k} set");
-        };
+        $this->assert_all_session_keys_set($session_keys);
     }
 
 }

--- a/tests/session_utility_Test.php
+++ b/tests/session_utility_Test.php
@@ -21,7 +21,17 @@ final class session_utility_Test extends TestCase
         // echo "tearing down ... \n";
     }
 
-    public function test_smoke_tests_tags(): void
+    /**
+     * SMOKE TESTS ONLY.
+     *
+     * These don't really test functionality at the moment,
+     * they just ensure that the queries etc work.
+     * When the db setup/teardown is in place, and test data
+     * loaded, these tests can be replaced/updated to show
+     * actual data.
+     */
+
+    public function test_smoke_get_tags(): void
     {
         $session_keys = [ 'TAGS', 'TBPREF_TAGS' ];
         foreach($session_keys as $k) {
@@ -29,6 +39,20 @@ final class session_utility_Test extends TestCase
             $this->assertFalse(isset($_SESSION[$k]), 'sanity check');
         };
         $t = get_tags();
+        $this->assertIsArray($t, 'returns tags');
+        foreach($session_keys as $k) {
+            $this->assertTrue(isset($_SESSION[$k]), "Session {$k} set");
+        };
+    }
+
+    public function test_smoke_get_texttags(): void
+    {
+        $session_keys = [ 'TEXTTAGS', 'TBPREF_TEXTTAGS' ];
+        foreach($session_keys as $k) {
+            unset($_SESSION[$k]);
+            $this->assertFalse(isset($_SESSION[$k]), 'sanity check');
+        };
+        $t = get_texttags();
         $this->assertIsArray($t, 'returns tags');
         foreach($session_keys as $k) {
             $this->assertTrue(isset($_SESSION[$k]), "Session {$k} set");

--- a/tests/session_utility_Test.php
+++ b/tests/session_utility_Test.php
@@ -1,0 +1,15 @@
+<?php declare(strict_types=1);
+
+require_once __DIR__ . '/../inc/session_utility.php';
+
+use PHPUnit\Framework\TestCase;
+
+final class session_utility_Test extends TestCase
+{
+    
+    public function test_dummy_test(): void
+    {
+        $this->assertSame(1, 1);
+    }
+
+}

--- a/tests/session_utility_Test.php
+++ b/tests/session_utility_Test.php
@@ -6,10 +6,33 @@ use PHPUnit\Framework\TestCase;
 
 final class session_utility_Test extends TestCase
 {
-    
-    public function test_dummy_test(): void
+
+    /**
+     * Hack/fake session and server information.
+     */
+    public function setUp(): void
     {
-        $this->assertSame(1, 1);
+        $_SERVER['HTTP_HOST'] = 'localhost';
+        $_SERVER['REQUEST_URI'] = '/dummyuri';
+    }
+
+    public function tearDown(): void
+    {
+        // echo "tearing down ... \n";
+    }
+
+    public function test_smoke_tests_tags(): void
+    {
+        $session_keys = [ 'TAGS', 'TBPREF_TAGS' ];
+        foreach($session_keys as $k) {
+            unset($_SESSION[$k]);
+            $this->assertFalse(isset($_SESSION[$k]), 'sanity check');
+        };
+        $t = get_tags();
+        $this->assertIsArray($t, 'returns tags');
+        foreach($session_keys as $k) {
+            $this->assertTrue(isset($_SESSION[$k]), "Session {$k} set");
+        };
     }
 
 }

--- a/tests/session_utility_Test.php
+++ b/tests/session_utility_Test.php
@@ -14,6 +14,7 @@ final class session_utility_Test extends TestCase
     {
         $_SERVER['HTTP_HOST'] = 'localhost';
         $_SERVER['REQUEST_URI'] = '/dummyuri';
+        $this->clear_session();
     }
 
     public function tearDown(): void
@@ -21,15 +22,10 @@ final class session_utility_Test extends TestCase
         // echo "tearing down ... \n";
     }
 
-    /**
-     * SMOKE TESTS ONLY.
-     *
-     * These don't really test functionality at the moment,
-     * they just ensure that the queries etc work.
-     * When the db setup/teardown is in place, and test data
-     * loaded, these tests can be replaced/updated to show
-     * actual data.
-     */
+    private function clear_session() {
+        $session_keys = [ 'TAGS', 'TBPREF_TAGS', 'TEXTTAGS', 'TBPREF_TEXTTAGS' ];
+        $this->unset_session_keys($session_keys);
+    }
 
     private function unset_session_keys($keys) {
         foreach($keys as $k) {
@@ -44,22 +40,66 @@ final class session_utility_Test extends TestCase
         };
     }
 
+    /**
+     * SMOKE TESTS ONLY.
+     *
+     * These don't test functionality,
+     * they just ensure that the queries etc work.
+     */
+    public function test_smoke_tests(): void
+    {
+        $this->clear_session();
+        get_tags();
+
+        $this->clear_session();
+        get_texttags();
+
+        getTextTitle(42);
+
+        get_tag_selectoptions('cat', '');
+        get_tag_selectoptions('cat', 42);
+
+        get_texttag_selectoptions('cat', '');
+        get_texttag_selectoptions('cat', 42);
+
+        get_txtag_selectoptions('', 'cat');
+        get_txtag_selectoptions(42, 'cat');
+
+        get_archivedtexttag_selectoptions('cat', '');
+        get_archivedtexttag_selectoptions('cat', 42);
+
+        // TODO - before adding new smoke tests, have to complete
+        // dbsetup ... in particular, need to ensure that the tests
+        // are only run with a db named TESTING_xxx.
+    }
+
+
+    /**
+     * STUB TESTS ONLY.
+     *
+     * These don't really test functionality at the moment,
+     * they just ensure that the queries etc work.
+     * When the db setup/teardown is in place, and test data
+     * loaded, these tests can be replaced/updated to show
+     * actual data.
+     */
+
+    /** TAGS **/
+
     public function test_smoke_get_tags(): void
     {
-        $session_keys = [ 'TAGS', 'TBPREF_TAGS' ];
-        $this->unset_session_keys($session_keys);
         $t = get_tags();
         $this->assertIsArray($t, 'returns tags');
-        $this->assert_all_session_keys_set($session_keys);
+        $keys = [ 'TAGS', 'TBPREF_TAGS' ];
+        $this->assert_all_session_keys_set($keys);
     }
 
     public function test_smoke_get_texttags(): void
     {
-        $session_keys = [ 'TEXTTAGS', 'TBPREF_TEXTTAGS' ];
-        $this->unset_session_keys($session_keys);
         $t = get_texttags();
         $this->assertIsArray($t, 'returns tags');
-        $this->assert_all_session_keys_set($session_keys);
+        $keys = [ 'TEXTTAGS', 'TBPREF_TEXTTAGS' ];
+        $this->assert_all_session_keys_set($keys);
     }
 
 }


### PR DESCRIPTION
This starts adding some basic code for database testing, and a couple of simple tests to start things off.

The basic idea is outlined well in http://www.phpunit.cn/manual/current/en/database.html, section "The four stages of a database test": the db has to be put into a known state, data added, and then data-accessing or -modifying routines are run, and the results checked.

I tried to install php's dbunit using composer but ran into problems (it couldn't get past the specifications).  Since the underlying idea of dbunit is very simple, I just started to write the pieces that I needed.  I've done this in prior projects (ruby, java, c#, etc) and it's worked fine.

For the LWT code to work in PHPUnit, I had to change some of the variables so that they are specifically defined as `global` ... otherwise, PHPUnit fails all the time.  That change is in c5bc178397b1bbc0b39e49471b72a10414df5c30, and the project still works.

Since the database tests are destructive, the DB name _must_ begin with `test_`.  If it doesn't the tests immediately stop running.  This prevents the tests from stomping on a real production/live database.

These tests are run just like any other tests: `php composer.phar test` or e.g. `phpunit tests/session_utility_Test.php`