### PR TITLE
add default values to docker installation - closes issue #37

### DIFF
--- a/.env
+++ b/.env
@@ -1,4 +1,4 @@
-DB_HOSTNAME=localhost
+DB_HOSTNAME=db
 DB_USER=root
-DB_PASSWORD=abcxyz
+DB_PASSWORD=root
 DB_DATABASE=learning-with-texts

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ RUN docker-php-ext-install pdo pdo_mysql mysqli
 COPY . /var/www/html/
 
 # creating connect.inc.php
-ARG DB_HOSTNAME
-ARG DB_USER
-ARG DB_PASSWORD
-ARG DB_DATABASE
+ARG DB_HOSTNAME=db
+ARG DB_USER=root
+ARG DB_PASSWORD=root
+ARG DB_DATABASE=learning-with-texts
 RUN printf '<?php\n$server = "%s";\n$userid = "%s";\n$passwd = "%s";\n$dbname = "%s";\n?>' "$DB_HOSTNAME" "$DB_USER" "$DB_PASSWORD" "$DB_DATABASE" > /var/www/html/connect.inc.php

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,12 +5,14 @@ services:
       context: .
       dockerfile: Dockerfile
       args:
-        - DB_HOSTNAME
-        - DB_USER
-        - DB_PASSWORD
-        - DB_DATABASE
+        - DB_HOSTNAME=db
+        - DB_USER=root
+        - DB_PASSWORD=root
+        - DB_DATABASE=learning-with-texts
     container_name: lwt
     depends_on:
+      - db
+    links:
       - db
     ports:
       - "8010:80"
@@ -26,4 +28,4 @@ services:
     volumes:
         - lwt_db_data:/var/lib/mysql
 volumes:
-  lwt_db_data:
+  lwt_db_data: {}


### PR DESCRIPTION
saw fix by @hakuro-jp in pull request
 - https://github.com/HugoFara/lwt/pull/79

adapted db linking example from rdearman/LWT_Docker as mentioned at:
 - https://github.com/HugoFara/lwt/issues/37#issuecomment-1186578342
 
my guess is that @hakuro-jp auto-sourced .env to load the environment variables and that is why it was working on their machine and not for @HugoFara - this pull request makes the default values explicit and incorporates @hakuro-jp's fix. it is nice to have the environment variables so people can override and make their installations more secure. there could possibly be some kind of security advisory in the docs, I imagine it isn't too big an issue for most users. 

cheers!