### PR TITLE
chars are not space separated in the SeText column

### DIFF
--- a/inc/session_utility.php
+++ b/inc/session_utility.php
@@ -4019,6 +4019,10 @@ function insert_standard_expression($textlc, $lid, $wid, $len, $mode): array
         WHERE SeLgID = $lid AND SeText LIKE " . 
         convert_string_to_sqlsyntax_notrim_nonull("%$textlc%");
     }
+
+    if ($splitEachChar) {
+        $textlc = preg_replace('/([^\s])/u', "$1 ", $textlc);
+    }
     $wis = $textlc;
     $res = do_mysqli_query($sql);
     $notermchar = "/[^$termchar]($textlc)[^$termchar]/ui";
@@ -4193,9 +4197,6 @@ function insertExpressions($textlc, $lid, $wid, $len, $mode): string|null
     $mecab = 'MECAB' == strtoupper(trim($record['LgRegexpWordCharacters']));
     $splitEachChar = !$mecab && $record['LgSplitEachChar'];
     mysqli_free_result($res);
-    if ($splitEachChar) {
-        $textlc = preg_replace('/([^\s])/u', "$1 ", $textlc);
-    }
 
     /*
     * TODO:


### PR DESCRIPTION
Adding a new mword with languages using "split each character as a words" required to reparse the text content to display these words.
The line referencing the new mword was not added in the text2items2, this commit fix this by passing the original (not space separated) mword to the sql query.