### PR TITLE
php-dom is not available in yum only in apt-get

### DIFF
--- a/INSTALL.sh
+++ b/INSTALL.sh
@@ -4,7 +4,7 @@
 apt_get_cmd=$(which apt-get)
 yum_cmd=$(which yum)
 
-packages="apache2 libapache2-mod-php php php-dom php-mbstring php-mysql mysql-server"
+packages="apache2 libapache2-mod-php php php-xml php-mbstring php-mysql mysql-server"
 
 echo "Installing dependencies"
 if [ ! -z $apt_get_cmd ]; then


### PR DESCRIPTION
https://access.redhat.com/documentation/en-us/red_hat_enterprise_linux/6/html-single/package_manifest/index
https://packages.debian.org/sid/php-dom
