### PR TITLE
Utterance checkbox not saved

### DIFF
--- a/do_test_test.php
+++ b/do_test_test.php
@@ -485,6 +485,15 @@ function do_test_prepare_ajax_test_area($selector, $selection, $count, $testtype
 
     ?>
     <script type="text/javascript">
+                window.onload = (event) => {
+            var utterancecheckbox = document.getElementById('utterance-allowed')
+
+            var utterancechecked = JSON.parse(localStorage.getItem('utterance-allowed'));
+            utterancecheckbox.checked = utterancechecked;
+            utterancecheckbox.addEventListener('change', function () {
+                localStorage.setItem('utterance-allowed', utterancecheckbox.checked);
+            });
+        };
         /**
          * Get a new word test.
          */


### PR DESCRIPTION
In test mode, the utterance-allowed selection is not saved when in test mode.