### PR TITLE
str_replace null case deprecated

### DIFF
--- a/inc/database_connect.php
+++ b/inc/database_connect.php
@@ -106,7 +106,10 @@ function get_first_value($sql)
  */
 function prepare_textdata($s): string 
 {
-    return str_replace("\r\n", "\n", $s);
+	if ($s == null)
+		return "";
+	else
+		return str_replace("\r\n", "\n", $s);
 }
 
 // -------------------------------------------------------------


### PR DESCRIPTION
Hi. i was trying to backup a database and i got a lot of deprecation warnings messing up the output:
` str_replace(): Passing null to parameter #3 ($subject)`
 apparently some null were being passed to the function prepare_textdata? the database i was using was quite small so idk what could be causing that, and im having trouble reproducing the error now!  the database was mostly empty (just one text and one term) so idk. 
after backing up with this patch, and then reverting the patch and restoring the database backup, the bug was gone and i could download the backup succesfully again, no mention of str_replace. 
maybe there's an easier way to avoid this by just telling php NOT to clutter the output with deprecation notices, maybe it's because i am running lwt with the "php -S" server locally isntead of with docker or a proper production server. anyway.
PHP 8.3.7
last lwt commit 8196ced74c61b14a1d8e666aba96e58f02bd9df4 (Sun Apr 21 18:08:59 2024 +0200)
cheers