### PR TITLE
fix(db): parse SQL schema files regardless of line endings (#241)

### DIFF
--- a/src/Shared/Infrastructure/Database/SqlFileParser.php
+++ b/src/Shared/Infrastructure/Database/SqlFileParser.php
@@ -36,35 +36,36 @@ class SqlFileParser
      */
     public static function parseFile(string $filename): array
     {
-        $handle = @fopen($filename, 'r');
-        if ($handle === false) {
+        $content = @file_get_contents($filename);
+        if ($content === false) {
             return array();
         }
+        // Normalize line endings up front so statement splitting does not depend
+        // on the file's origin OS. A CRLF/CR file (e.g. committed from Windows or
+        // baked into an image) must parse the same as an LF file on a Linux host,
+        // where PHP_EOL is "\n" and would never match a ";\r\n" boundary.
+        $content = str_replace(["\r\n", "\r"], "\n", $content);
+
         $queries_list = array();
         $curr_content = '';
-        while ($stream = fgets($handle)) {
+        foreach (explode("\n", $content) as $line) {
             // Skip comments
-            if (str_starts_with($stream, '-- ')) {
+            if (str_starts_with($line, '-- ')) {
                 continue;
             }
-            // Add stream to accumulator
-            $curr_content .= $stream;
-            // Get queries
-            $queries = explode(';' . PHP_EOL, $curr_content);
-            // Replace line by remainders of the last element (incomplete line)
+            // Add line (with its newline restored) to the accumulator
+            $curr_content .= $line . "\n";
+            // Pull out every complete statement, keep the trailing remainder
+            $queries = explode(";\n", $curr_content);
             $curr_content = array_pop($queries);
             foreach ($queries as $query) {
                 $queries_list[] = trim($query);
             }
         }
         // Add final query if there's any remaining content
-        if (!empty(trim($curr_content))) {
+        if (trim($curr_content) !== '') {
             $queries_list[] = trim($curr_content);
         }
-        if (!feof($handle)) {
-            // Throw error
-        }
-        fclose($handle);
         return $queries_list;
     }
 }

--- a/tests/backend/Core/Utils/SqlFileParserTest.php
+++ b/tests/backend/Core/Utils/SqlFileParserTest.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lwt\Tests\Core\Utils;
 
 use Lwt\Shared\Infrastructure\Database\SqlFileParser;
+use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
 /**
@@ -51,5 +52,44 @@ final class SqlFileParserTest extends TestCase
         // Should return empty array
         $this->assertIsArray($result);
         $this->assertEmpty($result);
+    }
+
+    /**
+     * Statements must be split regardless of the file's line endings.
+     *
+     * Regression test for a CRLF schema file producing a single un-split blob
+     * that mysqli rejects with error 1064 on a Linux host (issue #241).
+     */
+    #[DataProvider('lineEndingProvider')]
+    public function testParseFileSplitsStatementsForAnyLineEnding(string $eol): void
+    {
+        $sqlContent = "-- Test SQL file" . $eol .
+                      "CREATE TABLE a (id INT);" . $eol .
+                      "CREATE TABLE b (id INT);" . $eol .
+                      "INSERT INTO a VALUES (1);";
+
+        $tempFile = sys_get_temp_dir() . '/test_sql_' . uniqid() . '.sql';
+        file_put_contents($tempFile, $sqlContent);
+
+        $queries = SqlFileParser::parseFile($tempFile);
+        unlink($tempFile);
+
+        // Each statement must come back individually, not concatenated.
+        $this->assertSame(
+            ['CREATE TABLE a (id INT)', 'CREATE TABLE b (id INT)', 'INSERT INTO a VALUES (1)'],
+            $queries
+        );
+    }
+
+    /**
+     * @return array<string, array{string}>
+     */
+    public static function lineEndingProvider(): array
+    {
+        return [
+            'LF (Unix)' => ["\n"],
+            'CRLF (Windows)' => ["\r\n"],
+            'CR (classic Mac)' => ["\r"],
+        ];
     }
 }


### PR DESCRIPTION
## Summary

Fixes #241 — fresh installs fail to boot with **`Internal Server Error - A database error occurred.`** and MySQL **error 1064** while applying `db/schema/baseline.sql`.

## Root cause

`SqlFileParser::parseFile()` split statements on `';' . PHP_EOL`. `PHP_EOL` is `"\n"` on the (Linux) server, so the split looks for the literal `";\n"`. When `baseline.sql` has **CRLF** line endings (e.g. cloned on Windows with `core.autocrlf=true` and built locally), the real boundary is `";\r\n"` and never matches. The whole file then collapses into a **single multi-statement string**, which `mysqli_query()` rejects after the first statement with error 1064.

The issue's error context shows the tell-tale symptom: two `CREATE TABLE` statements (`_migrations` + `users`) concatenated into one query, every line ending in `\r\n`.

## Fix

`parseFile()` now reads the file whole, normalizes `CRLF`/`CR` → `LF` up front, then splits. Parsing is now independent of the file's origin OS, and CR-only files (which `fgets()` could not line-split at all) also work.

## Tests

Added a data-provider regression test (`testParseFileSplitsStatementsForAnyLineEnding`) covering **LF, CRLF, and CR**. Verified end-to-end that a CRLF copy of the real `baseline.sql` now parses into 18 individual statements (previously 1 blob), with zero multi-`CREATE TABLE` statements.

```
./vendor/bin/phpunit tests/backend/Core            # 1163 passed, 22 skipped
./vendor/bin/psalm --threads=1 SqlFileParser.php   # No errors
./vendor/bin/phpcs --standard=PSR12 ...            # clean
```

## Notes

- Likely warrants a **3.2.1** patch release since affected users can't self-heal a pre-built image.