### PR TITLE
chore(release): LWT 3.2.1-fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,18 @@ ones are marked like "v1.0.0-fork".
 
 ## [Unreleased]
 
+## [3.2.1-fork] - 2026-06-30
+
 ### Fixed
 
+* **Database error on first boot with CRLF schema files** (#241): a fresh
+  install could fail to start with "Internal Server Error - A database error
+  occurred." (MySQL error 1064) while applying `db/schema/baseline.sql`.
+  `SqlFileParser` split statements on `';' . PHP_EOL` — which is `";\n"` on a
+  Linux host — so a schema file with Windows (CRLF) line endings was never
+  split, and the whole file was sent to MySQL as a single multi-statement
+  query that it rejected. The parser now normalizes CRLF/CR to LF before
+  splitting, so parsing no longer depends on the file's origin OS.
 * **Mixed-content asset blocking behind a TLS-terminating reverse proxy**
   (#240): the Content-Security-Policy now emits `upgrade-insecure-requests` on
   HTTPS connections, so any stray `http://` subresource is transparently

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwt",
-  "version": "3.2.0",
+  "version": "3.2.1",
   "description": "Learning with Texts - A self-hosted language learning application for reading-based vocabulary acquisition",
   "type": "module",
   "main": "index.js",

--- a/src/Shared/Infrastructure/ApplicationInfo.php
+++ b/src/Shared/Infrastructure/ApplicationInfo.php
@@ -30,12 +30,12 @@ class ApplicationInfo
     /**
      * Version of this current LWT application.
      */
-    public const VERSION = '3.2.0-fork';
+    public const VERSION = '3.2.1-fork';
 
     /**
      * Date of the latest published release of LWT.
      */
-    public const RELEASE_DATE = '2026-06-23';
+    public const RELEASE_DATE = '2026-06-30';
 
     /**
      * Get the application version for display to humans.


### PR DESCRIPTION
Patch release prep for **LWT 3.2.1-fork**.

### Included since 3.2.0
- **#241 / #242** — `SqlFileParser` normalizes CRLF/CR → LF before splitting, fixing the *"Internal Server Error - A database error occurred."* (MySQL **1064**) crash on first boot when `baseline.sql` has Windows line endings.
- **#240** — CSP emits `upgrade-insecure-requests` on HTTPS, fixing mixed-content asset blocking behind a TLS-terminating reverse proxy.

### Version bumps (per CLAUDE.md)
| File | Change |
| --- | --- |
| `src/Shared/Infrastructure/ApplicationInfo.php` | `VERSION` → `3.2.1-fork`, `RELEASE_DATE` → `2026-06-30` |
| `package.json` | `version` → `3.2.1` |
| `CHANGELOG.md` | `[Unreleased]` items moved into dated `[3.2.1-fork] - 2026-06-30` |

### Checks
- `phpunit tests/backend/Core/VersionTest.php` — pass
- `psalm --threads=1` / `phpcs --standard=PSR12` on `ApplicationInfo.php` — clean

### Cutting the release (after merge)
Tag `3.2.1` (bare, matching existing tag convention) and publish a GitHub Release — this triggers `docker-to-release.yml` to build and push the versioned image to `ghcr.io/hugofara/lwt`, which is how affected users pull the fix.