### PR TITLE
test(api): fix stale ApiV1 version/release-date assertions

### DIFF
--- a/tests/backend/Api/V1/ApiV1Test.php
+++ b/tests/backend/Api/V1/ApiV1Test.php
@@ -5,6 +5,7 @@ declare(strict_types=1);
 namespace Lwt\Tests\Api\V1;
 
 use Lwt\Api\V1\ApiV1;
+use Lwt\Shared\Infrastructure\ApplicationInfo;
 use Lwt\Shared\Infrastructure\Globals;
 use Lwt\Shared\Infrastructure\Container\Container;
 use Lwt\Shared\Infrastructure\Container\CoreServiceProvider;
@@ -137,21 +138,44 @@ class ApiV1Test extends TestCase
     }
 
     /**
-     * Test VERSION constant exists.
+     * The `version` endpoint must source its version from ApplicationInfo
+     * (the single source of truth), not a local constant that drifts.
+     *
+     * Regression guard: ApiV1 used to carry a hardcoded `VERSION = "3.0.2"`
+     * that was never bumped, so the API misreported the version through 3.1.x
+     * and 3.2.0. It now reads from ApplicationInfo and strips the `-fork`
+     * suffix to serve bare semver to clients.
      */
-    public function testVersionConstantExists(): void
+    public function testVersionSourcedFromApplicationInfo(): void
     {
+        // ApiV1 must not reintroduce its own version constant.
         $reflection = new \ReflectionClass(ApiV1::class);
-        $this->assertTrue($reflection->hasConstant('VERSION'));
+        $this->assertFalse(
+            $reflection->hasConstant('VERSION'),
+            'ApiV1 should source its version from ApplicationInfo, not a local constant'
+        );
+
+        // The value the endpoint serves is bare semver (X.Y.Z, no "-fork").
+        $apiVersion = \explode('-', ApplicationInfo::getRawVersion())[0];
+        $this->assertMatchesRegularExpression('/^\d+\.\d+\.\d+$/', $apiVersion);
     }
 
     /**
-     * Test RELEASE_DATE constant exists.
+     * The `version` endpoint must source its release date from ApplicationInfo,
+     * not a local constant.
      */
-    public function testReleaseDateConstantExists(): void
+    public function testReleaseDateSourcedFromApplicationInfo(): void
     {
         $reflection = new \ReflectionClass(ApiV1::class);
-        $this->assertTrue($reflection->hasConstant('RELEASE_DATE'));
+        $this->assertFalse(
+            $reflection->hasConstant('RELEASE_DATE'),
+            'ApiV1 should source its release date from ApplicationInfo, not a local constant'
+        );
+
+        $this->assertMatchesRegularExpression(
+            '/^\d{4}-\d{2}-\d{2}$/',
+            ApplicationInfo::getReleaseDate()
+        );
     }
 
     /**


### PR DESCRIPTION
## Problem

`ApiV1Test::testVersionConstantExists` and `testReleaseDateConstantExists` assert that `ApiV1::VERSION` / `ApiV1::RELEASE_DATE` still exist:

```php
$this->assertTrue($reflection->hasConstant('VERSION'));
```

Those local constants were **removed** in `48d418dc1` ("fix(api): source /api/v1/version from ApplicationInfo"), which fixed the API silently reporting a stale `"3.0.2"` through 3.1.x/3.2.0 by reading from `ApplicationInfo` (the single source of truth) instead. The tests were never updated, so they assert a contract that no longer holds.

### Why it slipped through

`ApiV1Test::setUp()` constructs `new ApiV1()` and has a DB-skip guard, so the **entire class is skipped in unit CI** (which runs without MySQL). The two assertions therefore stayed green on CI and never blocked the 3.2.1 release — but they **fail in any run with a test database present** (local dev, `composer test:integration`). I hit them while running the full suite during #244.

## Fix

Rewrite the two tests to assert the *actual* post-`48d418dc1` contract:

- ApiV1 no longer carries a drift-prone local version constant (`hasConstant(...)` is now expected **false** — a regression guard against re-introducing a hardcoded version), and
- the values the `/version` endpoint serves come from `ApplicationInfo` in the API's promised shape — bare semver `X.Y.Z` (no `-fork`) and an ISO `YYYY-MM-DD` date.

Test-only change; no production code touched.

## Verification

- `./vendor/bin/phpcs --standard=PSR12` — 0
- `./vendor/bin/psalm --threads=1` — 0
- `composer test:no-coverage` **with a local test DB** — 0 failures (previously **2**); the two rewritten tests now actually execute and pass (`OK (9 tests, 41 assertions)` for `ApiV1Test`).