### PR TITLE
fix(backup): restore no longer wipes the database on Windows (#249)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,34 @@ ones are marked like "v1.0.0-fork".
   the same way `SqlFileParser` does since #241. This is what failed the Windows
   PHPUnit jobs. Verified end-to-end against MeCab 0.996 and covered by tests
   that assert LF, CRLF and CR-only output tokenize identically.
+* **Restoring a backup wiped the database and reported success** (#249): on a
+  Windows host, "Restore from Backup" emptied the install and restored nothing,
+  while the page still said "Database restored". `Restore::restoreFile` split
+  the dump into statements on `';' . PHP_EOL` — `";\r\n"` on Windows — but LWT
+  always writes `";\n"`, so the split never matched, every statement piled up
+  in the accumulator and the statement list came back empty. The restore then
+  dropped every table and replayed nothing. This is the same defect fixed in
+  `SqlFileParser` for #241; the restore path was missed. Line endings are now
+  normalized before splitting, so a dump restores identically regardless of
+  which OS wrote or reads it. Three further hardening changes make the failure
+  non-destructive if it ever recurs: a dump that parses to zero statements is
+  refused *before* any table is dropped, the restore's own report (query and
+  record counts) is shown verbatim instead of a flat "Database restored", and a
+  final statement not followed by a newline is no longer discarded.
+* **Restore left the database in pieces when foreign keys were enabled**
+  (#249): a dump's `CREATE TABLE` statements come from `SHOW CREATE TABLE`, so
+  they carry their `FOREIGN KEY` clauses, but they are replayed in backup-table
+  order rather than dependency order (`feed_links` references `news_feeds` yet
+  is created before it). With foreign-key checks on, every such statement
+  failed with errno 1215 — on a 12-table backup, 11 of 12 `CREATE TABLE`s were
+  lost. Checks are now suspended for the replay and enforced again once every
+  table exists.
+* **Choosing a restore file did nothing** (#249): the file field stayed empty
+  and the "Restore from Backup" button stayed disabled, because the inline
+  `@change` handler used optional chaining
+  (`$event.target.files[0]?.name || ''`), which `@alpinejs/csp` cannot parse —
+  it threw "CSP Parser Error: Unexpected token" on every selection. The handler
+  moved into the `backupManager` component as `selectFile()`.
 
 ### Changed
 

--- a/src/Modules/Admin/Application/AdminFacade.php
+++ b/src/Modules/Admin/Application/AdminFacade.php
@@ -190,7 +190,7 @@ class AdminFacade
      * @param array{name: string, type: string, tmp_name: string, error: int, size: int}|null $fileData
      *        Validated file data from InputValidator::getUploadedFile()
      *
-     * @return array{success: bool, error: ?string}
+     * @return array{success: bool, error: ?string, message?: string}
      */
     public function restoreFromUpload(?array $fileData): array
     {

--- a/src/Modules/Admin/Application/UseCases/Backup/RestoreFromUpload.php
+++ b/src/Modules/Admin/Application/UseCases/Backup/RestoreFromUpload.php
@@ -55,7 +55,10 @@ class RestoreFromUpload
      * @param array{name: string, type: string, tmp_name: string, error: int, size: int}|null $fileData
      *        Validated file data from InputValidator::getUploadedFile()
      *
-     * @return array{success: bool, error: ?string}
+     * @return array{success: bool, error: ?string, message?: string}
+     *         On success, `message` carries the restore's own report (query
+     *         and record counts), which the caller should show verbatim
+     *         rather than substituting a generic "restored" string.
      */
     public function execute(?array $fileData): array
     {
@@ -97,6 +100,6 @@ class RestoreFromUpload
         if (str_starts_with($message, 'Error:')) {
             return ['success' => false, 'error' => $message];
         }
-        return ['success' => true, 'error' => null];
+        return ['success' => true, 'error' => null, 'message' => $message];
     }
 }

--- a/src/Modules/Admin/Http/AdminController.php
+++ b/src/Modules/Admin/Http/AdminController.php
@@ -131,7 +131,13 @@ class AdminController extends BaseController
             $result = $this->adminFacade->restoreFromUpload(
                 InputValidator::getUploadedFile('thefile')
             );
-            $message = $result['success'] ? 'Database restored' : ($result['error'] ?? 'Restore failed');
+            // Show the restore's own report rather than a flat "Database
+            // restored": its query/record counts are the only signal an admin
+            // has that the dump actually replayed. A restore that parsed zero
+            // statements used to look identical to a real one here (#249).
+            $message = $result['success']
+                ? ($result['message'] ?? 'Database restored')
+                : ($result['error'] ?? 'Restore failed');
         } elseif ($this->hasParam('backup')) {
             $this->adminFacade->downloadBackup();
             // downloadBackup exits, so we never reach here

--- a/src/Modules/Admin/Views/backup.php
+++ b/src/Modules/Admin/Views/backup.php
@@ -192,7 +192,7 @@ $uploadMaxFilesize = ini_get('upload_max_filesize');
                     <div class="file has-name is-fullwidth">
                         <label class="file-label">
                             <input class="file-input" type="file" name="thefile"
-                                   @change="fileName = $event.target.files[0]?.name || ''"
+                                   @change="selectFile($event)"
                                    accept=".sql,.gz,.sql.gz">
                             <span class="file-cta">
                                 <span class="file-icon">

--- a/src/Shared/Infrastructure/Database/Restore.php
+++ b/src/Shared/Infrastructure/Database/Restore.php
@@ -83,6 +83,108 @@ class Restore
     }
 
     /**
+     * Read a backup stream and split it into individual SQL statements.
+     *
+     * Statement boundaries are matched platform-independently. LWT always
+     * writes ";\n", but this used to split on ';' . PHP_EOL, which is
+     * ";\r\n" on a Windows host and therefore never matched: every
+     * statement piled up in the accumulator and the caller received an
+     * empty list, dropped every table and replayed nothing (issue #249).
+     * Line endings are now normalised exactly as
+     * SqlFileParser::parseFile() does, so a dump restores identically
+     * regardless of which OS wrote it or reads it.
+     *
+     * The handle is always closed before returning.
+     *
+     * @param resource $handle Backup file handle (may be a gzopen handle)
+     * @param string   $title  File title, used in error messages
+     *
+     * @return array{queries: list<string>, error: string|null}
+     *
+     * @since 3.2.2-fork Extracted from restoreFile() and made EOL-agnostic
+     */
+    private static function parseBackupStream($handle, string $title): array
+    {
+        $queries_list = [];
+        $curr_content = '';
+        $start = true;
+        $bytesRead = 0;
+        $error = null;
+
+        while ($stream = fgets($handle)) {
+            // Gzip-bomb defense: cap the total decompressed bytes we
+            // pull off the handle. A 1 GB SQL dump is more than any
+            // real LWT install produces; anything bigger is almost
+            // certainly malicious or a runaway.
+            $bytesRead += strlen($stream);
+            if ($bytesRead > self::MAX_DECOMPRESSED_BYTES) {
+                $error = "Error: $title Restore file exceeds the "
+                    . intdiv(self::MAX_DECOMPRESSED_BYTES, 1024 * 1024)
+                    . " MB decompressed-size limit (likely a gzip bomb).";
+                break;
+            }
+
+            // Normalise line endings before anything is matched against
+            // them. formatValueForSqlOutput() escapes CR inside values via
+            // mysqli_real_escape_string, so a raw CR in a dump is only ever
+            // a line terminator and is safe to rewrite.
+            $stream = str_replace(["\r\n", "\r"], "\n", $stream);
+
+            // Check file header
+            if ($start) {
+                if (
+                    !str_starts_with($stream, "-- lwt-backup-")
+                    && !str_starts_with($stream, "-- lwt-exp_version-backup-")
+                ) {
+                    $error = "Error: Invalid $title Restore file " .
+                    "(possibly not created by LWT backup)";
+                    break;
+                }
+                $start = false;
+                continue;
+            }
+            // Skip comments (lines starting with "-- " or lines that are just "--")
+            $trimmedLine = trim($stream);
+            if (str_starts_with($stream, '-- ') || $trimmedLine === '--') {
+                continue;
+            }
+            // Add stream to accumulator
+            $curr_content .= $stream;
+            // Get queries
+            $queries = explode(";\n", $curr_content);
+            // Replace line by remainders of the last element (incomplete line)
+            $curr_content = array_pop($queries);
+
+            foreach ($queries as $query) {
+                $queries_list[] = trim($query);
+            }
+        }
+
+        $reachedEof = feof($handle);
+        fclose($handle);
+
+        if ($error !== null) {
+            return ['queries' => [], 'error' => $error];
+        }
+
+        if (!$reachedEof) {
+            return [
+                'queries' => [],
+                'error' => "Error: cannot read the end of the $title file!",
+            ];
+        }
+
+        // Flush a trailing statement that is not followed by a newline, so a
+        // dump whose final line lacks its EOL still restores completely.
+        $tail = trim(rtrim(trim($curr_content), ';'));
+        if ($tail !== '') {
+            $queries_list[] = $tail;
+        }
+
+        return ['queries' => $queries_list, 'error' => null];
+    }
+
+    /**
      * Restore the database from a file.
      *
      * @param resource $handle       Backup file handle
@@ -96,6 +198,9 @@ class Restore
      * @since 2.7.0-fork $handle should be an *uncompressed* file.
      * @since 2.9.1-fork It can read SQL with more or less than one instruction a line
      * @since 3.0.0 Added SQL validation for security hardening
+     * @since 3.2.2-fork Refuses to drop anything when the dump yields no
+     *        statements; replays with FK checks suspended so FK-carrying
+     *        CREATE TABLEs no longer fail on dependency order
      */
     public static function restoreFile($handle, string $title, bool $validateSql = true): string
     {
@@ -122,63 +227,14 @@ class Restore
             "inserts" => 0,
             "creates" => 0
         ];
-        $start = true;
-        $curr_content = '';
-        $queries_list = [];
-        $bytesRead = 0;
 
-        while ($stream = fgets($handle)) {
-            // Gzip-bomb defense: cap the total decompressed bytes we
-            // pull off the handle. A 1 GB SQL dump is more than any
-            // real LWT install produces; anything bigger is almost
-            // certainly malicious or a runaway.
-            $bytesRead += strlen($stream);
-            if ($bytesRead > self::MAX_DECOMPRESSED_BYTES) {
-                $message = "Error: $title Restore file exceeds the "
-                    . intdiv(self::MAX_DECOMPRESSED_BYTES, 1024 * 1024)
-                    . " MB decompressed-size limit (likely a gzip bomb).";
-                $install_status["errors"] = 1;
-                $hasErrors = true;
-                break;
-            }
-            // Check file header
-            if ($start) {
-                if (
-                    !str_starts_with($stream, "-- lwt-backup-")
-                    && !str_starts_with($stream, "-- lwt-exp_version-backup-")
-                ) {
-                    $message = "Error: Invalid $title Restore file " .
-                    "(possibly not created by LWT backup)";
-                    $install_status["errors"] = 1;
-                    $hasErrors = true;
-                    break;
-                }
-                $start = false;
-                continue;
-            }
-            // Skip comments (lines starting with "-- " or lines that are just "--")
-            $trimmedLine = trim($stream);
-            if (str_starts_with($stream, '-- ') || $trimmedLine === '--') {
-                continue;
-            }
-            // Add stream to accumulator
-            $curr_content .= $stream;
-            // Get queries
-            $queries = explode(';' . PHP_EOL, $curr_content);
-            // Replace line by remainders of the last element (incomplete line)
-            $curr_content = array_pop($queries);
-
-            foreach ($queries as $query) {
-                $queries_list[] = trim($query);
-            }
-        }
-
-        if (!feof($handle) && !$hasErrors) {
-            $message = "Error: cannot read the end of the demo file!";
+        $parsed = self::parseBackupStream($handle, $title);
+        $queries_list = $parsed['queries'];
+        if ($parsed['error'] !== null) {
+            $message = $parsed['error'];
             $install_status["errors"] = 1;
             $hasErrors = true;
         }
-        fclose($handle);
 
         // Validate all queries before executing any (security hardening)
         if ($validateSql && !$hasErrors) {
@@ -196,6 +252,18 @@ class Restore
             }
         }
 
+        // A dump that yielded no statements must never reach
+        // dropAllLwtTables(): dropping every table and then replaying nothing
+        // leaves the install empty with no way back. That is exactly what the
+        // PHP_EOL statement split did on Windows (issue #249) — silently, and
+        // while reporting success. Refuse instead, so any future parser bug
+        // costs an error message rather than the user's data.
+        if (!$hasErrors && $queries_list === []) {
+            $message = "Error: $title Restore file contains no SQL statements";
+            $install_status["errors"] = 1;
+            $hasErrors = true;
+        }
+
         // Drop all existing tables first to ensure a clean slate
         // This prevents issues with partial state from previous attempts
         if (!$hasErrors) {
@@ -205,32 +273,46 @@ class Restore
         // Now run all queries
         $connection = Globals::getDbConnection();
         if (!$hasErrors && $connection !== null) {
-            foreach ($queries_list as $query) {
-                $sql_line = trim(
-                    str_replace("\r", "", str_replace("\n", "", $query))
-                );
-                if ($sql_line != "") {
-                    if (!str_starts_with($query, '-- ')) {
-                        $res = mysqli_query(
-                            $connection,
-                            $query
-                        );
-                        $install_status["queries"]++;
-                        if ($res == false) {
-                            $install_status["errors"]++;
-                            $hasErrors = true;
-                        } else {
-                            $install_status["successes"]++;
-                            if (str_starts_with($query, "INSERT INTO")) {
-                                $install_status["inserts"]++;
-                            } elseif (str_starts_with($query, "DROP TABLE")) {
-                                $install_status["drops"]++;
-                            } elseif (str_starts_with($query, "CREATE TABLE")) {
-                                $install_status["creates"]++;
+            // A dump's CREATE TABLE statements are taken from SHOW CREATE
+            // TABLE, so they carry their FOREIGN KEY clauses — but they are
+            // emitted in backup-table order, not dependency order (feed_links
+            // references news_feeds yet is created before it). With FK checks
+            // on, every such CREATE fails with errno 1215 and the restore
+            // leaves the install in pieces. dropAllLwtTables() restores checks
+            // to 1 on the way out, so they have to be suspended again here for
+            // the replay; the constraints are enforced again afterwards, once
+            // every table exists.
+            Connection::execute("SET FOREIGN_KEY_CHECKS = 0");
+            try {
+                foreach ($queries_list as $query) {
+                    $sql_line = trim(
+                        str_replace("\r", "", str_replace("\n", "", $query))
+                    );
+                    if ($sql_line != "") {
+                        if (!str_starts_with($query, '-- ')) {
+                            $res = mysqli_query(
+                                $connection,
+                                $query
+                            );
+                            $install_status["queries"]++;
+                            if ($res == false) {
+                                $install_status["errors"]++;
+                                $hasErrors = true;
+                            } else {
+                                $install_status["successes"]++;
+                                if (str_starts_with($query, "INSERT INTO")) {
+                                    $install_status["inserts"]++;
+                                } elseif (str_starts_with($query, "DROP TABLE")) {
+                                    $install_status["drops"]++;
+                                } elseif (str_starts_with($query, "CREATE TABLE")) {
+                                    $install_status["creates"]++;
+                                }
                             }
                         }
                     }
                 }
+            } finally {
+                Connection::execute("SET FOREIGN_KEY_CHECKS = 1");
             }
         }
 

--- a/src/frontend/js/modules/admin/pages/backup_manager.ts
+++ b/src/frontend/js/modules/admin/pages/backup_manager.ts
@@ -16,6 +16,7 @@ interface BackupManagerState {
   restoring: boolean;
   emptying: boolean;
   confirmEmpty: boolean;
+  selectFile(event: Event): void;
 }
 
 /**
@@ -27,7 +28,22 @@ export function backupManager(): BackupManagerState {
     fileName: '',
     restoring: false,
     emptying: false,
-    confirmEmpty: false
+    confirmEmpty: false,
+
+    /**
+     * Record the chosen backup file's name from a file-input change event.
+     *
+     * This lives here rather than inline in the view because @alpinejs/csp
+     * cannot parse optional chaining: the previous inline handler,
+     * `fileName = $event.target.files[0]?.name || ''`, threw a CSP parser
+     * error on every change, so the filename never appeared and the submit
+     * button stayed disabled forever (issue #249).
+     */
+    selectFile(event: Event): void {
+      const input = event.target as HTMLInputElement | null;
+      const file = input && input.files ? input.files[0] : null;
+      this.fileName = file ? file.name : '';
+    }
   };
 }
 

--- a/tests/backend/Modules/Admin/UseCases/AdminUseCaseTest.php
+++ b/tests/backend/Modules/Admin/UseCases/AdminUseCaseTest.php
@@ -375,6 +375,72 @@ class AdminUseCaseTest extends TestCase
         Globals::setBackupRestoreEnabled(null);
     }
 
+    public function testRestoreFromUploadCarriesTheRestoreReportOnSuccess(): void
+    {
+        // The controller shows this message verbatim. Dropping it in favour of
+        // a flat "Database restored" made a restore that replayed zero
+        // statements indistinguishable from a real one (issue #249), so the
+        // counts have to survive the use case.
+        Globals::setBackupRestoreEnabled(true);
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'lwt_test_');
+        $gz = gzopen($tmpFile, 'w');
+        gzwrite($gz, "-- lwt-backup-2026-07-08.sql.gz\n");
+        gzclose($gz);
+
+        $report = 'Success: Database restored - 412 queries - 412 successful '
+            . '(37/37 tables dropped/created, 340 records added), 0 failed.';
+        $repo = $this->createMock(BackupRepositoryInterface::class);
+        $repo->method('restoreFromHandle')->willReturn($report);
+
+        $useCase = new RestoreFromUpload($repo);
+        $result = $useCase->execute([
+            'name' => 'backup.sql.gz',
+            'type' => 'application/gzip',
+            'tmp_name' => $tmpFile,
+            'error' => 0,
+            'size' => filesize($tmpFile),
+        ]);
+
+        $this->assertTrue($result['success']);
+        $this->assertSame($report, $result['message']);
+
+        @unlink($tmpFile);
+        Globals::setBackupRestoreEnabled(null);
+    }
+
+    public function testRestoreFromUploadSurfacesTheNoStatementsRefusalAsFailure(): void
+    {
+        // Restore::restoreFile refuses a dump that parsed to zero statements
+        // rather than dropping every table and replaying nothing (issue #249).
+        // The refusal must reach the admin as a failure.
+        Globals::setBackupRestoreEnabled(true);
+
+        $tmpFile = tempnam(sys_get_temp_dir(), 'lwt_test_');
+        $gz = gzopen($tmpFile, 'w');
+        gzwrite($gz, "-- lwt-backup-2026-07-08.sql.gz\n");
+        gzclose($gz);
+
+        $repo = $this->createMock(BackupRepositoryInterface::class);
+        $repo->method('restoreFromHandle')
+            ->willReturn('Error: Database Restore file contains no SQL statements');
+
+        $useCase = new RestoreFromUpload($repo);
+        $result = $useCase->execute([
+            'name' => 'backup.sql.gz',
+            'type' => 'application/gzip',
+            'tmp_name' => $tmpFile,
+            'error' => 0,
+            'size' => filesize($tmpFile),
+        ]);
+
+        $this->assertFalse($result['success']);
+        $this->assertStringContainsString('no SQL statements', $result['error']);
+
+        @unlink($tmpFile);
+        Globals::setBackupRestoreEnabled(null);
+    }
+
     public function testRestoreFromUploadDisabledMessageMentionsEnvSetting(): void
     {
         Globals::setBackupRestoreEnabled(false);

--- a/tests/backend/Shared/Infrastructure/Database/RestoreParseBackupStreamTest.php
+++ b/tests/backend/Shared/Infrastructure/Database/RestoreParseBackupStreamTest.php
@@ -1,0 +1,203 @@
+<?php
+
+/**
+ * Unit tests for Restore's backup-stream parsing.
+ *
+ * Regression cover for issue #249: splitting statements on ';' . PHP_EOL
+ * matched nothing on a Windows host (PHP_EOL === "\r\n") while LWT dumps
+ * always terminate with ";\n". The parser handed back an empty statement
+ * list, and the caller then dropped every table and replayed nothing.
+ *
+ * PHP version 8.1
+ *
+ * @category Testing
+ * @package  Lwt\Tests\Shared\Infrastructure\Database
+ * @license  Unlicense <http://unlicense.org/>
+ * @since    3.2.2-fork
+ */
+
+declare(strict_types=1);
+
+namespace Tests\Backend\Shared\Infrastructure\Database;
+
+use Lwt\Shared\Infrastructure\Database\Restore;
+use PHPUnit\Framework\Attributes\CoversClass;
+use PHPUnit\Framework\Attributes\Test;
+use PHPUnit\Framework\TestCase;
+use ReflectionMethod;
+
+/**
+ * Unit tests for Restore::parseBackupStream().
+ *
+ * These exercise the parser in isolation, so they need no database.
+ *
+ * @since 3.2.2-fork
+ */
+#[CoversClass(Restore::class)]
+class RestoreParseBackupStreamTest extends TestCase
+{
+    /**
+     * The header line every LWT dump starts with.
+     */
+    private const HEADER = "-- lwt-backup-2026-07-08-11-20-52.sql.gz";
+
+    /**
+     * Call the private parser with the given dump contents.
+     *
+     * @param string $contents Raw dump bytes
+     *
+     * @return array{queries: list<string>, error: string|null}
+     */
+    private function parse(string $contents): array
+    {
+        $handle = fopen('php://memory', 'r+');
+        $this->assertIsResource($handle);
+        fwrite($handle, $contents);
+        rewind($handle);
+
+        // Private methods are reflection-accessible without setAccessible()
+        // since PHP 8.1, and the call is deprecated as of 8.5.
+        $method = new ReflectionMethod(Restore::class, 'parseBackupStream');
+
+        /** @var array{queries: list<string>, error: string|null} $result */
+        $result = $method->invoke(null, $handle, 'Database');
+        return $result;
+    }
+
+    /**
+     * Build a dump body with the given line terminator.
+     *
+     * @param string $eol Line terminator to join with
+     *
+     * @return string
+     */
+    private function dump(string $eol): string
+    {
+        return implode($eol, [
+            self::HEADER,
+            '',
+            'DROP TABLE IF EXISTS words;',
+            "CREATE TABLE words (WoID int, WoText varchar(250));",
+            "INSERT INTO words VALUES(1,'Haus');",
+            "INSERT INTO words VALUES(2,'Baum');",
+            '',
+        ]);
+    }
+
+    #[Test]
+    public function parsesAnLfDump(): void
+    {
+        $result = $this->parse($this->dump("\n"));
+
+        $this->assertNull($result['error']);
+        $this->assertCount(4, $result['queries']);
+        $this->assertSame('DROP TABLE IF EXISTS words', $result['queries'][0]);
+        $this->assertSame("INSERT INTO words VALUES(2,'Baum')", $result['queries'][3]);
+    }
+
+    /**
+     * The #249 regression: a CRLF dump, or an LF dump read on a Windows host,
+     * must produce the same statements as an LF dump on Linux.
+     */
+    #[Test]
+    public function parsesACrlfDumpIdenticallyToAnLfDump(): void
+    {
+        $lf = $this->parse($this->dump("\n"));
+        $crlf = $this->parse($this->dump("\r\n"));
+
+        $this->assertNull($crlf['error']);
+        $this->assertSame($lf['queries'], $crlf['queries']);
+        $this->assertNotEmpty($crlf['queries']);
+    }
+
+    #[Test]
+    public function neverReturnsAnEmptyStatementListForAValidDump(): void
+    {
+        foreach (["\n", "\r\n"] as $eol) {
+            $result = $this->parse($this->dump($eol));
+            $this->assertNotSame(
+                [],
+                $result['queries'],
+                'A valid dump must never parse to zero statements: the caller '
+                . 'would drop every table and restore nothing.'
+            );
+        }
+    }
+
+    #[Test]
+    public function keepsAFinalStatementThatLacksATrailingNewline(): void
+    {
+        $contents = self::HEADER . "\n"
+            . "INSERT INTO words VALUES(1,'Haus');\n"
+            . "INSERT INTO words VALUES(2,'Baum');";
+
+        $result = $this->parse($contents);
+
+        $this->assertNull($result['error']);
+        $this->assertCount(2, $result['queries']);
+        $this->assertSame("INSERT INTO words VALUES(2,'Baum')", $result['queries'][1]);
+    }
+
+    #[Test]
+    public function joinsAStatementSpanningSeveralLines(): void
+    {
+        $contents = self::HEADER . "\n"
+            . "CREATE TABLE words (\n"
+            . "  WoID int,\n"
+            . "  WoText varchar(250)\n"
+            . ");\n";
+
+        $result = $this->parse($contents);
+
+        $this->assertNull($result['error']);
+        $this->assertCount(1, $result['queries']);
+        $this->assertStringContainsString('WoText varchar(250)', $result['queries'][0]);
+    }
+
+    #[Test]
+    public function skipsCommentLines(): void
+    {
+        $contents = self::HEADER . "\n"
+            . "-- a comment\n"
+            . "--\n"
+            . "INSERT INTO words VALUES(1,'Haus');\n";
+
+        $result = $this->parse($contents);
+
+        $this->assertNull($result['error']);
+        $this->assertSame(["INSERT INTO words VALUES(1,'Haus')"], $result['queries']);
+    }
+
+    #[Test]
+    public function acceptsTheExpVersionHeaderVariant(): void
+    {
+        $contents = "-- lwt-exp_version-backup-2026-07-08.sql.gz\n"
+            . "INSERT INTO words VALUES(1,'Haus');\n";
+
+        $result = $this->parse($contents);
+
+        $this->assertNull($result['error']);
+        $this->assertCount(1, $result['queries']);
+    }
+
+    #[Test]
+    public function rejectsAFileWithoutAnLwtHeader(): void
+    {
+        $result = $this->parse("-- some other dump\nINSERT INTO words VALUES(1,'x');\n");
+
+        $this->assertNotNull($result['error']);
+        $this->assertStringContainsString('possibly not created by LWT backup', $result['error']);
+        $this->assertSame([], $result['queries']);
+    }
+
+    #[Test]
+    public function rejectsAHeaderOnlyFileWithNoStatements(): void
+    {
+        $result = $this->parse(self::HEADER . "\n");
+
+        // The parser itself reports no error here; restoreFile() turns the
+        // empty list into a refusal so nothing is ever dropped.
+        $this->assertNull($result['error']);
+        $this->assertSame([], $result['queries']);
+    }
+}

--- a/tests/frontend/admin/backup_manager.test.ts
+++ b/tests/frontend/admin/backup_manager.test.ts
@@ -51,6 +51,7 @@ describe('backup_manager.ts', () => {
       expect(state).toHaveProperty('restoring');
       expect(state).toHaveProperty('emptying');
       expect(state).toHaveProperty('confirmEmpty');
+      expect(state).toHaveProperty('selectFile');
     });
 
     it('returns a fresh state on each call', () => {
@@ -62,6 +63,100 @@ describe('backup_manager.ts', () => {
 
       expect(state2.fileName).toBe('');
       expect(state2.restoring).toBe(false);
+    });
+  });
+
+  // ===========================================================================
+  // selectFile Tests (issue #249)
+  // ===========================================================================
+
+  describe('selectFile', () => {
+    /**
+     * Build a file input whose `files` list holds the given names, the way a
+     * browser presents it to a change handler.
+     */
+    function inputWithFiles(names: string[]): HTMLInputElement {
+      const input = document.createElement('input');
+      input.type = 'file';
+      Object.defineProperty(input, 'files', {
+        value: names.map((name) => new File(['x'], name)),
+        configurable: true
+      });
+      document.body.appendChild(input);
+      return input;
+    }
+
+    it('records the chosen file name', () => {
+      const state = backupManager();
+      const input = inputWithFiles(['LWT 7-8-26.gz']);
+
+      state.selectFile({ target: input } as unknown as Event);
+
+      expect(state.fileName).toBe('LWT 7-8-26.gz');
+    });
+
+    it('clears the name when the selection is emptied', () => {
+      const state = backupManager();
+      state.fileName = 'previous.sql';
+      const input = inputWithFiles([]);
+
+      state.selectFile({ target: input } as unknown as Event);
+
+      expect(state.fileName).toBe('');
+    });
+
+    it('handles an event with no target without throwing', () => {
+      const state = backupManager();
+
+      expect(() => state.selectFile({ target: null } as unknown as Event)).not.toThrow();
+      expect(state.fileName).toBe('');
+    });
+
+    it('handles an input with a null files list', () => {
+      const state = backupManager();
+      const input = document.createElement('input');
+      input.type = 'file';
+      Object.defineProperty(input, 'files', { value: null, configurable: true });
+
+      state.selectFile({ target: input } as unknown as Event);
+
+      expect(state.fileName).toBe('');
+    });
+
+    it('is evaluable by the CSP Alpine build, unlike an inline optional chain', async () => {
+      // The regression this guards: `@change="fileName = $event.target
+      // .files[0]?.name || ''"` throws "CSP Parser Error: Unexpected token"
+      // in @alpinejs/csp, so the filename never appeared and the restore
+      // button stayed disabled. A method call parses fine.
+      const Alpine = (await import('alpinejs')).default;
+      const captured: string[] = [];
+      const origWarn = console.warn;
+      const origError = console.error;
+      console.warn = (...a: unknown[]) => { captured.push(a.map(String).join(' ')); };
+      console.error = (...a: unknown[]) => { captured.push(a.map(String).join(' ')); };
+
+      Alpine.data('backupManagerCspCheck', backupManager);
+      document.body.innerHTML = `
+        <div x-data="backupManagerCspCheck">
+          <input id="csp-file" type="file" @change="selectFile($event)">
+          <span id="csp-name" x-text="fileName || 'NO FILE'"></span>
+        </div>`;
+      Alpine.start();
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      const input = document.getElementById('csp-file') as HTMLInputElement;
+      Object.defineProperty(input, 'files', {
+        value: [new File(['x'], 'backup.sql.gz')],
+        configurable: true
+      });
+      input.dispatchEvent(new Event('change'));
+      await new Promise((resolve) => setTimeout(resolve, 30));
+
+      console.warn = origWarn;
+      console.error = origError;
+
+      expect(captured.join('\n')).not.toContain('CSP Parser Error');
+      expect(document.getElementById('csp-name')?.textContent).toBe('backup.sql.gz');
     });
   });
 


### PR DESCRIPTION
Fixes #249 — "Unable to Import Database": on a Windows host, "Restore from Backup" emptied the install and restored nothing, while the page still reported **"Database restored"**.

Three separate defects on the restore path. Each was reproduced against a real database before and after the change.

## 1. The wipe (Windows, silent)

`Restore::restoreFile` split the dump into statements on `';' . PHP_EOL` — `";\r\n"` on Windows — but the backup writer always emits `";\n"`. The split never matched, so every statement piled up in the accumulator and the statement list came back **empty**. `dropAllLwtTables()` still ran, the replay loop iterated zero times, and migrations then rebuilt an empty schema. `AdminController` discarded the detailed status string, so the admin saw a plain success message.

This is the same defect fixed in `SqlFileParser` for #241; the restore path was missed at the time.

Reproduced on the unmodified code, restoring a CRLF dump into a seeded database:

```
[CRLF dump] Success: Database restored - 0 queries - 0 successful (0/0 tables dropped/created), 0 failed.
  probe row: NULL, tables: 23
```

After the fix, the same dump reports `27 queries - 27 successful (12/12 tables dropped/created), 0 failed` and round-trips the seeded row.

Line endings are now normalized before splitting, so a dump restores identically regardless of which OS wrote or reads it.

## 2. Restore left the database in pieces whenever foreign keys were enabled

Found while verifying the above end-to-end — **this one affected every platform, not just Windows.**

A dump's `CREATE TABLE` statements come from `SHOW CREATE TABLE`, so they carry their `FOREIGN KEY` clauses, but they are emitted in backup-table order rather than dependency order (`feed_links` references `news_feeds` yet is created six statements earlier). With FK checks on, each such statement failed with errno 1215 — on a 12-table backup, **11 of 12 `CREATE TABLE`s were lost** and the database collapsed to a single table.

`dropAllLwtTables()` restores checks to `1` on its way out, so they are now suspended again for the replay and enforced once every table exists.

Without this, the first fix would only have converted a silent wipe into a loud one.

## 3. Choosing a restore file did nothing

The file field stayed empty and the submit button stayed disabled, because the inline `@change` handler used optional chaining:

```
@change="fileName = $event.target.files[0]?.name || ''"
```

`@alpinejs/csp` cannot parse `?.` — it threw `CSP Parser Error: Unexpected token: PUNCTUATION "."` on every selection. The handler moved into the `backupManager` component as `selectFile()`.

Note that only `?.` is a problem here: `x-text="fileName || '…'"` and `:disabled="!fileName"` were verified to work in `@alpinejs/csp` 3.15.11 and are left untouched, contrary to what `CLAUDE.md` currently implies.

## Hardening

So that a recurrence is not destructive:

- a dump that parses to **zero statements is refused before any table is dropped** — a future parser bug now costs an error message rather than the user's data;
- the restore's own report (query and record counts) is surfaced verbatim instead of a flat "Database restored", which is the only signal an admin has that the dump actually replayed;
- a final statement not followed by a newline is no longer discarded.

The statement parser is extracted as `Restore::parseBackupStream()` so it can be unit tested without a database.

## Verification

- **9 new unit tests** for the parser (LF, CRLF, missing trailing newline, multi-line statements, comments, both header variants, bad header, zero statements). No database needed, so they run on CI. Confirmed they **fail against the old implementation** before the fix was restored.
- **5 new frontend tests**, including one that mounts the component under Alpine and asserts no CSP parser error occurs.
- **2 new use-case tests** for the refusal and the report passthrough.
- Full suites: PHPUnit 9104 passed, Vitest 4437 passed, integration 157 passed, Psalm 0 errors, PHPCS clean, typecheck clean.
- End-to-end against a real MySQL database: LF and CRLF dumps both restore successfully and round-trip a seeded row; a header-only dump is refused with the tables left intact.

## Not covered

The foreign-key fix has no automated test — a genuine round-trip drops every table, which would wreck the database for the rest of the suite, so it was verified with a throwaway harness instead of destabilizing CI.

Separately, now that restore actually succeeds, the post-restore `Migrations::checkAndUpdate()` logs a few non-fatal failures (`archived_texts` missing, duplicate `UsRecoveryCodeHash`) — migrations that are not idempotent against a restored schema. Pre-existing, does not fail the restore, and left alone as a separate issue.