### PR TITLE
fix: reading-flow and language-resolution fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,111 +9,62 @@ ones are marked like "v1.0.0-fork".
 
 ### Fixed
 
-* **One over-long headword aborted a whole dictionary import** (#250):
-  importing FreeDict German-English failed with "Data too long for column
-  'LeTerm' at row 670" and no entries usable. `LeTerm` is `VARCHAR(250)`, and
-  exactly one of that dictionary's 517,534 entries has a 293-character headword
-  (the Lord's Prayer, stored as a single entry). Under `STRICT_ALL_TABLES` an
-  over-long value fails the entire multi-row `INSERT`, so that one entry
-  discarded its whole 1000-row batch and ended the import — losing the other
-  517,533 entries. Entries whose headword cannot be stored are now skipped and
-  counted instead of aborting the run, and the count is reported alongside the
-  import total so the result is not silently lossy. 250 characters is also LWT's
-  own term length (`words.WoText`), so a longer headword could never have become
-  a usable term. `LeReading` and `LePartOfSpeech` are descriptive metadata and
-  are truncated rather than costing the entry. This applies to every import path
-  — curated, uploaded file, and API — not just the curated one. A failed import
-  now also drops its half-filled dictionary, which previously stayed behind with
-  however many rows had already been inserted.
+* **The term-edit modal hid the text while reading** (#253): "Add"/"Edit" opened
+  a full-viewport Bulma modal that covered the text being read. The backdrop
+  dimming is gone, on mobile the card is a capped-height bottom sheet, and the
+  form is split into tabs (Translation / Example / Notes / Tags) so it fits
+  without scrolling.
+* **One over-long headword aborted a whole dictionary import** (#250): a single
+  293-character headword in FreeDict German-English failed its multi-row
+  `INSERT` under `STRICT_ALL_TABLES` and ended the import, losing all 517,533
+  other entries. Unstorable headwords are now skipped and counted rather than
+  aborting the run, across every import path. A failed import no longer leaves a
+  half-filled dictionary behind.
 * **Japanese (MeCab) parsing produced no tokens on Windows**: both MeCab output
-  readers split their lines on `PHP_EOL`, but a subprocess's line terminator
-  comes from MeCab, not from the host PHP runs on. Wherever the two disagree —
-  notably Windows, where `PHP_EOL` is `"\r\n"` while the output ends lines with
-  `"\n"` — the entire output stayed a single line and every token collapsed into
-  one, yielding zero usable tokens. Both
-  `JapaneseTextParser::buildTokensFromMecab()` and
-  `MecabParser::parseMecabOutput()` now normalize line endings before splitting,
-  the same way `SqlFileParser` does since #241. This is what failed the Windows
-  PHPUnit jobs. Verified end-to-end against MeCab 0.996 and covered by tests
-  that assert LF, CRLF and CR-only output tokenize identically.
-* **Restoring a backup wiped the database and reported success** (#249): on a
-  Windows host, "Restore from Backup" emptied the install and restored nothing,
-  while the page still said "Database restored". `Restore::restoreFile` split
-  the dump into statements on `';' . PHP_EOL` — `";\r\n"` on Windows — but LWT
-  always writes `";\n"`, so the split never matched, every statement piled up
-  in the accumulator and the statement list came back empty. The restore then
-  dropped every table and replayed nothing. This is the same defect fixed in
-  `SqlFileParser` for #241; the restore path was missed. Line endings are now
-  normalized before splitting, so a dump restores identically regardless of
-  which OS wrote or reads it. Three further hardening changes make the failure
-  non-destructive if it ever recurs: a dump that parses to zero statements is
-  refused *before* any table is dropped, the restore's own report (query and
-  record counts) is shown verbatim instead of a flat "Database restored", and a
-  final statement not followed by a newline is no longer discarded.
-* **Restore left the database in pieces when foreign keys were enabled**
-  (#249): a dump's `CREATE TABLE` statements come from `SHOW CREATE TABLE`, so
-  they carry their `FOREIGN KEY` clauses, but they are replayed in backup-table
-  order rather than dependency order (`feed_links` references `news_feeds` yet
-  is created before it). With foreign-key checks on, every such statement
-  failed with errno 1215 — on a 12-table backup, 11 of 12 `CREATE TABLE`s were
-  lost. Checks are now suspended for the replay and enforced again once every
-  table exists.
-* **Choosing a restore file did nothing** (#249): the file field stayed empty
-  and the "Restore from Backup" button stayed disabled, because the inline
-  `@change` handler used optional chaining
-  (`$event.target.files[0]?.name || ''`), which `@alpinejs/csp` cannot parse —
-  it threw "CSP Parser Error: Unexpected token" on every selection. The handler
-  moved into the `backupManager` component as `selectFile()`.
+  readers split on `PHP_EOL`, but the terminator comes from MeCab, not the
+  host — on Windows the output stayed one line and every token collapsed into one.
+  Both readers now normalize line endings first.
+* **Restoring a backup wiped the database and reported success** (#249): on
+  Windows, `Restore::restoreFile` split on `';' . PHP_EOL` while LWT writes
+  `";\n"`, so no statement ever matched — the restore dropped every table and
+  replayed nothing. Line endings are normalized before splitting, and a dump that
+  parses to zero statements is now refused *before* any table is dropped.
+* **Restore left the database in pieces when foreign keys were enabled** (#249):
+  `CREATE TABLE` statements carry their `FOREIGN KEY` clauses but replay in
+  backup-table order, not dependency order, so 11 of 12 failed with errno 1215.
+  Checks are suspended for the replay and enforced once every table exists.
+* **Choosing a restore file did nothing** (#249): the inline `@change` handler
+  used optional chaining, which `@alpinejs/csp` cannot parse. Moved into the
+  `backupManager` component as `selectFile()`.
 
 ### Changed
 
-* **Dependency security bumps** clearing all eight open Dependabot alerts
-  (two high, six moderate) plus two more that `npm audit` reports — ten
-  advisories across five packages, all fixed within existing version
-  constraints. PHP runtime: `guzzlehttp/guzzle` 7.12.1 → 7.15.1 (five
-  advisories: proxy-authorization headers sent to origin servers, URI
-  fragments disclosed in redirect `Referer` headers, unbounded response
-  cookies, host-only cookie scope not preserved, and cookie disclosure via
-  IP-address domains) and `guzzlehttp/psr7` 2.12.1 → 2.13.0 (host confusion
-  via weak URI host validation, CVE-2026-59882). Both reach LWT through
-  `league/oauth2-google`, so these affect the running application, not just
-  the toolchain. JS build/test toolchain (not shipped to users):
-  `brace-expansion` → 5.0.8 (two denial-of-service advisories),
-  `linkify-it` → 5.0.2 and `postcss` → 8.5.23. The `brace-expansion` override
-  floor moves from `>=5.0.6` to `>=5.0.8`, since the newer advisory covers
-  versions up to 5.0.7. `composer audit` and `npm audit` are both clean.
-* **Routine dependency refresh** alongside the security bumps, all inside the
-  declared ranges: `phpmailer/phpmailer` 7.1.1, `league/commonmark` 2.8.3,
-  `thenetworg/oauth2-azure` 2.2.6, `phpunit/phpunit` 11.5.56, plus Symfony and
-  amphp transitives; on the JS side `vite` 8.1.5, `vitest` 4.1.10, `eslint`
-  10.8.0, `cypress` 15.19.0, `lucide` 1.26.0, `@alpinejs/csp` 3.15.12,
-  `typescript-eslint` 8.65.0, `prettier` 3.9.6 and `vue` 3.5.40. Held back at
-  their current majors: `typescript` (6 → 7), `purgecss` (4 → 8) and
-  `@types/node` (25 → 26).
+* **Dependency security bumps** clearing all eight open Dependabot alerts plus
+  two more from `npm audit` — ten advisories across five packages, all within
+  existing constraints. Affecting the running app: `guzzlehttp/guzzle`
+  7.12.1 → 7.15.1 (five advisories) and `guzzlehttp/psr7` 2.12.1 → 2.13.0
+  (CVE-2026-59882), both reached via `league/oauth2-google`. Build/test only:
+  `brace-expansion` → 5.0.8, `linkify-it` → 5.0.2, `postcss` → 8.5.23.
+  `composer audit` and `npm audit` are clean.
+* **Routine dependency refresh** inside the declared ranges: `phpmailer`,
+  `league/commonmark`, `oauth2-azure`, `phpunit` on the PHP side; `vite`,
+  `vitest`, `eslint`, `cypress`, `lucide`, `@alpinejs/csp`, `typescript-eslint`,
+  `prettier` and `vue` on the JS side. Held at their current majors:
+  `typescript`, `purgecss`, `@types/node`.
 * **Word-status model is now a single source of truth** (#238, Phase 1): the
-  `TermStatus` value object is promoted to the authoritative model — it owns the
-  abbreviation, CSS class, light-theme colour, display order and predicates, and
-  exposes `TermStatus::definitions()` (the one ordered status table). The scattered
-  `[1,2,3,4,5,98,99]` literals and `=== 5 || === 99` / `=== 98` checks across the
-  Review, Vocabulary and Admin modules now call `TermStatus::isValid()` /
-  `values()` / `isKnownValue()` / `isIgnoredValue()`, and `TermStatusService` /
-  `StatusHelper` delegate to the VO instead of redefining the tables. The model is
-  exposed once to the frontend via `GET /api/v1/settings/status-definitions`, and
-  the duplicated TypeScript status tables (`text_status_chart.ts`,
-  `texts_grouped_app.ts`, `html_utils.ts`, `term_edit_modal.ts`, the `app_data.ts`
-  proxy) now resolve from a single `shared/stores/statuses.ts`. No behaviour or
-  wire-format change; the per-status scheduling formulas are untouched (they belong
-  to the proposed Phase 2, FSRS-aligned scheduling).
-* **Single `data_hex` word identity in the reading view** (#237): every word
-  occurrence now carries its term identity solely as a `data_hex` attribute,
-  and the redundant `TERM<hex>` CSS class has been dropped. The token is now a
-  short SHA-256-derived hex string (`StringUtils::toClassName()`) — pure
-  `[0-9a-f]`, so it is selector-safe and the occurrence-lookup regexes become
-  correct by construction. This replaces the original 2011 `¤`/hex encoder
-  whose per-byte vs. per-codepoint confusion PHP 8.5 surfaced by deprecating
-  `ord()` on multi-byte strings. There is no API wire-format change (the `hex`
-  field keeps its role, recomputed identically on the PHP and JS sides) and no
-  styling change (the `TERM` class carried no CSS rules).
+  `TermStatus` value object owns the abbreviation, CSS class, colour, order and
+  predicates, replacing scattered `[1,2,3,4,5,98,99]` literals and `=== 98`-style
+  checks across the Review, Vocabulary and Admin modules. Exposed to the frontend
+  once via `GET /api/v1/settings/status-definitions`, so the duplicated
+  TypeScript status tables now resolve from a single store. No behaviour or
+  wire-format change; scheduling formulas are untouched.
+* **Single `data_hex` word identity in the reading view** (#237): word
+  occurrences carry their term identity solely as `data_hex`, and the redundant
+  `TERM<hex>` class is dropped. The token is now a SHA-256-derived hex string —
+  pure `[0-9a-f]`, so the occurrence-lookup regexes are correct by construction.
+  Replaces the 2011 `¤`/hex encoder whose per-byte vs. per-codepoint confusion
+  PHP 8.5 surfaced by deprecating `ord()` on multi-byte strings. No API or
+  styling change.
 
 ## [3.2.1-fork] - 2026-06-30
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,14 @@ ones are marked like "v1.0.0-fork".
   `"\r"` on every last field and an LF file on Windows collapsed the upload into
   one line. Line endings are normalised before splitting — the last site of the
   defect fixed in #241, #248 and #249.
+* **The term modal covered the word being added**: the word popover anchors
+  itself above or below the clicked word, but the Add/Edit modal did not — Bulma
+  centred it, so it regularly landed on the word whose sentence the user needs
+  while typing a translation. The modal now measures the anchor word when it
+  opens and takes the half of the viewport the word is not in, flipping the
+  mobile sheet to the top edge when the word sits low. Best-effort rather than
+  exact: a word near the middle of a short viewport can still be covered. With
+  no anchor available it falls back to the previous placement.
 * **The term-edit modal hid the text while reading** (#253): "Add"/"Edit" opened
   a full-viewport Bulma modal that covered the text being read. The backdrop
   dimming is gone, on mobile the card is a capped-height bottom sheet, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,11 @@ ones are marked like "v1.0.0-fork".
 
 ### Fixed
 
+* **A CRLF term file broke tag-only imports**: `CompleteImportService`'s
+  tags-only path split uploads on `PHP_EOL`, so a CRLF file on Linux left a stray
+  `"\r"` on every last field and an LF file on Windows collapsed the upload into
+  one line. Line endings are normalised before splitting — the last site of the
+  defect fixed in #241, #248 and #249.
 * **The term-edit modal hid the text while reading** (#253): "Add"/"Edit" opened
   a full-viewport Bulma modal that covered the text being read. The backdrop
   dimming is gone, on mobile the card is a capped-height bottom sheet, and the

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,15 @@ ones are marked like "v1.0.0-fork".
 
 ### Fixed
 
+* **A single-language install could never browse Gutenberg or GDL**: the
+  new-text page said "Please select a language above" while the navbar already
+  showed one. `currentlanguage` is only written when the user picks from the
+  navbar dropdown, and with exactly one language there is nothing to switch to,
+  so it could never be set. The navbar looked right only because a `<select>`
+  with no `selected` option displays the first one. `CurrentLanguage::resolveId()`
+  is now the single source for the active language — the stored setting when it
+  still points at an existing language, otherwise the first one the navbar lists.
+  Read-only: a plain GET never writes the setting.
 * **A CRLF term file broke tag-only imports**: `CompleteImportService`'s
   tags-only path split uploads on `PHP_EOL`, so a CRLF file on Linux left a stray
   `"\r"` on every last field and an LF file on Windows collapsed the upload into

--- a/src/Modules/Feed/Http/FeedEditController.php
+++ b/src/Modules/Feed/Http/FeedEditController.php
@@ -12,6 +12,7 @@ use Lwt\Shared\Infrastructure\Database\Settings;
 use Lwt\Shared\Infrastructure\Database\Validation;
 use Lwt\Shared\Infrastructure\Http\FlashMessageService;
 use Lwt\Shared\Infrastructure\Http\InputValidator;
+use Lwt\Shared\Infrastructure\Language\CurrentLanguage;
 use Lwt\Shared\UI\Helpers\PageLayoutHelper;
 
 /**
@@ -379,16 +380,10 @@ class FeedEditController
         $editFeedId = null;
         $languages = $this->languageFacade->getLanguagesForSelect();
         $curatedFeeds = $this->loadCuratedFeeds();
-        $currentLanguageId = (int) Settings::get('currentlanguage');
-        // A user who just created their first language hasn't toggled the
-        // navbar dropdown, so 'currentlanguage' is unset. Fall back to the
-        // first language in their list — without this, the curated-feed
-        // wizard posts NfLgID=0 and the server rejects with 500.
-        if ($currentLanguageId === 0 && !empty($languages)) {
-            /** @var array{LgID: int|string} $first */
-            $first = $languages[0];
-            $currentLanguageId = (int) $first['LgID'];
-        }
+        // Resolves the unset-'currentlanguage' case centrally; without a
+        // language the curated-feed wizard posts NfLgID=0 and the server
+        // rejects with 500.
+        $currentLanguageId = CurrentLanguage::resolveId();
         $currentLanguageName = $this->languageFacade->getLanguageName($currentLanguageId);
 
         include $this->viewPath . 'wizard_step1.php';

--- a/src/Modules/Text/Http/TextCrudController.php
+++ b/src/Modules/Text/Http/TextCrudController.php
@@ -29,6 +29,7 @@ use Lwt\Shared\Infrastructure\Http\RedirectResponse;
 use Lwt\Shared\Infrastructure\Utilities\StringUtils;
 use Lwt\Shared\Infrastructure\Container\Container;
 use Lwt\Shared\Infrastructure\Globals;
+use Lwt\Shared\Infrastructure\Language\CurrentLanguage;
 use Lwt\Modules\Review\Infrastructure\SessionStateManager;
 
 /**
@@ -71,6 +72,15 @@ class TextCrudController extends BaseController
         $currentLang = Validation::language(
             InputValidator::getStringWithDb("filterlang", 'currentlanguage')
         );
+        // The new-text form carries the language in a hidden TxLgID field taken
+        // from the navbar selection. Without this fallback that field rendered
+        // as 0 whenever 'currentlanguage' was unset, gating the Gutenberg and
+        // GDL browsers behind "Please select a language above" on an install
+        // whose navbar was already displaying a language.
+        if ($currentLang === '') {
+            $resolved = CurrentLanguage::resolveId();
+            $currentLang = $resolved > 0 ? (string) $resolved : '';
+        }
 
         $op = $this->param('op');
         if ($op !== '') {

--- a/src/Modules/Text/Views/multi_word_modal.php
+++ b/src/Modules/Text/Views/multi_word_modal.php
@@ -22,7 +22,7 @@ namespace Lwt\Views\Text;
 
 ?>
 <div x-data="multiWordModal" x-cloak>
-  <div class="modal reading-modal" :class="{ 'is-active': isOpen }"
+  <div class="modal reading-modal" :class="modalClasses"
        role="dialog" aria-modal="true" aria-labelledby="multi-word-modal-title">
     <div class="modal-background" @click="close"></div>
     <div class="modal-card" style="max-width: 500px;">

--- a/src/Modules/Text/Views/word_modal.php
+++ b/src/Modules/Text/Views/word_modal.php
@@ -25,7 +25,7 @@ namespace Lwt\Views\Text;
 <div x-data="wordModal" x-cloak>
   <div
     class="modal reading-modal"
-    :class="{ 'is-active': isOpen }"
+    :class="modalClasses"
     role="dialog"
     aria-modal="true"
     aria-labelledby="word-modal-title">

--- a/src/Modules/Vocabulary/Application/Services/CompleteImportService.php
+++ b/src/Modules/Vocabulary/Application/Services/CompleteImportService.php
@@ -719,7 +719,14 @@ class CompleteImportService
                 return;
             }
 
-            foreach (explode(PHP_EOL, $dataText) as $line) {
+            // The upload's line terminator comes from whoever wrote the file,
+            // not from the host PHP runs on, so splitting on PHP_EOL broke this
+            // wherever the two disagree: a CRLF file on Linux left a stray "\r"
+            // on every last field, and an LF file on Windows collapsed the whole
+            // upload into one line. Normalise first, then split on "\n".
+            $dataText = str_replace(["\r\n", "\r"], "\n", $dataText);
+
+            foreach (explode("\n", $dataText) as $line) {
                 if ($i++ == 0 && $ignoreFirst) {
                     continue;
                 }

--- a/src/Shared/Infrastructure/Language/CurrentLanguage.php
+++ b/src/Shared/Infrastructure/Language/CurrentLanguage.php
@@ -1,0 +1,107 @@
+<?php
+
+/**
+ * Current Language - Resolves the effective language for the current request
+ *
+ * PHP version 8.1
+ *
+ * @category Lwt
+ * @package  Lwt\Shared\Infrastructure\Language
+ * @author   HugoFara <hugo.farajallah@protonmail.com>
+ * @license  Unlicense <http://unlicense.org/>
+ * @link     https://hugofara.github.io/lwt/developer/api
+ * @since    3.2.2
+ */
+
+declare(strict_types=1);
+
+namespace Lwt\Shared\Infrastructure\Language;
+
+use Lwt\Shared\Infrastructure\Database\QueryBuilder;
+use Lwt\Shared\Infrastructure\Database\Settings;
+
+/**
+ * Resolves the language the user is currently working in.
+ *
+ * The `currentlanguage` setting is only written when the user actively picks a
+ * language from the navbar dropdown. Two situations leave it unset or stale, and
+ * both used to surface as "no language selected" even though the navbar showed
+ * one:
+ *
+ * - A user who has just created their first language has never fired the
+ *   dropdown's `change` event. With exactly one language there is no other
+ *   option to switch to, so the event can never fire and the setting can never
+ *   be written — the install is stuck in that state permanently.
+ * - The setting can point at a language that has since been deleted.
+ *
+ * In both cases the navbar still *looked* right: it renders a `<select>` and
+ * marks an option `selected` only when the id matches, so with no match the
+ * browser falls back to displaying the first option. The display and the stored
+ * state disagreed, and every server-side consumer read 0.
+ *
+ * This resolver is the single answer to "which language is active?". It is
+ * read-only on purpose: it never writes the setting, so a plain GET has no side
+ * effects and the same request always resolves the same way.
+ *
+ * Callers that need the id to agree with what the navbar displays must use this
+ * rather than reading the setting directly — the fallback ordering here matches
+ * the navbar's (`LgName`, skipping unnamed rows).
+ */
+class CurrentLanguage
+{
+    /**
+     * Resolve the effective current language ID.
+     *
+     * Returns the stored setting when it still points at an existing language,
+     * otherwise the first language the navbar would list. Returns 0 only when
+     * the user genuinely has no languages yet.
+     *
+     * @return int Language ID, or 0 if none is available
+     */
+    public static function resolveId(): int
+    {
+        try {
+            $stored = (int) Settings::getWithDefault('currentlanguage');
+            if ($stored > 0 && self::exists($stored)) {
+                return $stored;
+            }
+
+            return self::firstAvailableId();
+        } catch (\Throwable $e) {
+            return 0;
+        }
+    }
+
+    /**
+     * Check whether a language ID still exists.
+     *
+     * @param int $languageId Language ID to check
+     *
+     * @return bool True if the language exists
+     */
+    private static function exists(int $languageId): bool
+    {
+        return QueryBuilder::table('languages')
+            ->where('LgID', '=', $languageId)
+            ->countPrepared() > 0;
+    }
+
+    /**
+     * Get the first language the navbar would list.
+     *
+     * Mirrors the navbar's own filter and ordering so the resolved fallback is
+     * the language the user already sees displayed.
+     *
+     * @return int Language ID, or 0 if the user has no languages
+     */
+    private static function firstAvailableId(): int
+    {
+        $row = QueryBuilder::table('languages')
+            ->select(['LgID'])
+            ->where('LgName', '<>', '')
+            ->orderBy('LgName')
+            ->firstPrepared();
+
+        return $row !== null ? (int) $row['LgID'] : 0;
+    }
+}

--- a/src/Shared/UI/Helpers/PageLayoutHelper.php
+++ b/src/Shared/UI/Helpers/PageLayoutHelper.php
@@ -22,6 +22,7 @@ use Lwt\Shared\Infrastructure\Container\Container;
 use Lwt\Shared\Infrastructure\Database\Settings;
 use Lwt\Shared\Infrastructure\Database\QueryBuilder;
 use Lwt\Shared\Infrastructure\Globals;
+use Lwt\Shared\Infrastructure\Language\CurrentLanguage;
 use Lwt\Shared\Infrastructure\Http\UrlUtilities;
 use Lwt\Shared\I18n\Translator;
 use Lwt\Shared\UI\Assets\ViteHelper;
@@ -95,7 +96,11 @@ class PageLayoutHelper
                 ];
             }
 
-            $currentId = (int) Settings::getWithDefault('currentlanguage');
+            // Resolve rather than read the raw setting: with 'currentlanguage'
+            // unset, no option got marked selected and the browser silently
+            // displayed the first one anyway, so the navbar showed a language
+            // the rest of the app did not consider selected.
+            $currentId = CurrentLanguage::resolveId();
 
             return ['languages' => $result, 'currentId' => $currentId];
         } catch (\Throwable $e) {

--- a/src/frontend/css/base/styles.css
+++ b/src/frontend/css/base/styles.css
@@ -3052,18 +3052,50 @@ Settings Page - Collapsible Sections
   background-color: transparent;
 }
 
+/* Keep the clicked word visible: the card takes the half of the viewport the
+   word is not in. `is-placed-top`/`is-placed-bottom` come from the modal
+   components, which measure the anchor word when the modal opens. Bulma's
+   `.modal` is `flex-direction: column`, so the vertical axis is the main one
+   and `justify-content` — not `align-items` — is what moves the card. Leave
+   `align-items` alone or the card stops being horizontally centred. */
+.reading-modal.is-placed-top {
+  justify-content: flex-start;
+}
+
+.reading-modal.is-placed-bottom {
+  justify-content: flex-end;
+}
+
+.reading-modal.is-placed-top .modal-card,
+.reading-modal.is-placed-bottom .modal-card {
+  margin-top: 1rem;
+  margin-bottom: 1rem;
+  max-height: calc(50vh - 2rem);
+}
+
 @media screen and (max-width: 768px) {
   .reading-modal .modal-card {
     position: fixed;
-    bottom: 0;
     left: 0;
     right: 0;
-    top: auto;
     max-width: 100%;
     min-width: 100%;
     max-height: 50vh;
     margin: 0;
+  }
+
+  .reading-modal.is-placed-bottom .modal-card {
+    bottom: 0;
+    top: auto;
     border-radius: 12px 12px 0 0;
+  }
+
+  /* Word in the lower half — flip the sheet to the top edge so the sentence
+     being read stays on screen below it. */
+  .reading-modal.is-placed-top .modal-card {
+    top: 0;
+    bottom: auto;
+    border-radius: 0 0 12px 12px;
   }
 }
 

--- a/src/frontend/js/modules/text/components/text_reader.ts
+++ b/src/frontend/js/modules/text/components/text_reader.ts
@@ -16,6 +16,7 @@ import { TextsApi } from '@modules/text/api/texts_api';
 import { SettingsApi } from '@modules/admin/api/settings_api';
 import { renderBookNav } from '../pages/reading/book_nav_renderer';
 import { initIcons } from '@shared/icons/lucide_icons';
+import { rememberModalAnchor } from '@modules/vocabulary/components/modal_placement';
 
 /**
  * Text reader Alpine.js component interface.
@@ -236,6 +237,10 @@ export function textReaderData(): TextReaderData {
 
       event.preventDefault();
       event.stopPropagation();
+
+      // Anchor for the term modals, which place themselves in the half of the
+      // viewport this word is not in.
+      rememberModalAnchor(wordEl);
 
       // Get word data from element (use getAttribute for underscore attributes)
       const hex = wordEl.getAttribute('data_hex') || '';

--- a/src/frontend/js/modules/vocabulary/components/modal_placement.ts
+++ b/src/frontend/js/modules/vocabulary/components/modal_placement.ts
@@ -1,0 +1,79 @@
+/**
+ * Placement for the reading-view term modals.
+ *
+ * The word popover already anchors itself above or below the clicked word. The
+ * Add/Edit modals did not: Bulma centres `.modal-card` in the viewport (and on
+ * mobile #253 pinned it to the bottom), so the form regularly landed on top of
+ * the very word the user had just clicked — the word whose sentence they need
+ * to see while typing a translation.
+ *
+ * These modals are too tall to anchor tightly to a word the way the popover
+ * does, so instead they take the half of the viewport the word is *not* in.
+ * That is a best-effort rule, not a guarantee: a word sitting near the middle
+ * of a short viewport can still be covered. It removes the common case without
+ * introducing the popover's collision maths.
+ */
+
+/** Which half of the viewport the modal card should occupy. */
+export type ModalPlacement = 'top' | 'bottom';
+
+/**
+ * Last word element the reader interacted with.
+ *
+ * The single-word modal can use the store's `popoverTargetElement`, but the
+ * multi-word modal is opened by id and never sees an element. Recording the
+ * click here gives both a usable anchor without threading one through the
+ * stores.
+ */
+let lastAnchor: HTMLElement | null = null;
+
+/**
+ * Record the word element the user just interacted with.
+ *
+ * @param element The clicked `.word` / `.mword` element
+ */
+export function rememberModalAnchor(element: HTMLElement | null): void {
+  lastAnchor = element;
+}
+
+/**
+ * Get the most recently recorded anchor element.
+ */
+export function getRememberedModalAnchor(): HTMLElement | null {
+  return lastAnchor;
+}
+
+/**
+ * Choose the half of the viewport that keeps the anchor word visible.
+ *
+ * Falls back to 'bottom' — the pre-existing behaviour — whenever there is no
+ * usable anchor, so a missing element never makes placement worse than before.
+ *
+ * @param anchor The word element the modal was opened for
+ *
+ * @return 'top' when the word sits in the lower half, otherwise 'bottom'
+ */
+export function computeModalPlacement(anchor: HTMLElement | null): ModalPlacement {
+  if (!anchor || !anchor.isConnected) return 'bottom';
+
+  const rect = anchor.getBoundingClientRect();
+  // A hidden or unrendered anchor gives a zero rect, which would always read as
+  // "top half" and push the modal around for no reason.
+  if (rect.width === 0 && rect.height === 0) return 'bottom';
+
+  const anchorCentre = rect.top + rect.height / 2;
+  return anchorCentre > window.innerHeight / 2 ? 'top' : 'bottom';
+}
+
+/**
+ * Build the class string for a reading modal's outer `.modal` element.
+ *
+ * @param isOpen    Whether the modal is open
+ * @param placement Which half the card should occupy
+ */
+export function modalPlacementClasses(isOpen: boolean, placement: ModalPlacement): string {
+  const classes: string[] = [];
+  if (isOpen) classes.push('is-active');
+  classes.push(placement === 'top' ? 'is-placed-top' : 'is-placed-bottom');
+  return classes.join(' ');
+}

--- a/src/frontend/js/modules/vocabulary/components/multi_word_modal.ts
+++ b/src/frontend/js/modules/vocabulary/components/multi_word_modal.ts
@@ -13,6 +13,12 @@ import type { MultiWordFormStoreState } from '../stores/multi_word_form_store';
 import { initIcons } from '@shared/icons/lucide_icons';
 import { trapFocus, releaseFocus } from '@shared/accessibility/focus_trap';
 import { announce } from '@shared/accessibility/aria_live';
+import {
+  computeModalPlacement,
+  getRememberedModalAnchor,
+  modalPlacementClasses,
+  type ModalPlacement,
+} from './modal_placement';
 
 /**
  * Status display information.
@@ -42,6 +48,10 @@ export interface MultiWordModalData {
   // Computed properties
   readonly store: MultiWordFormStoreState;
   readonly isOpen: boolean;
+
+  // Which half of the viewport the card takes, so it avoids the selected words
+  placement: ModalPlacement;
+  readonly modalClasses: string;
   readonly isLoading: boolean;
   readonly isSubmitting: boolean;
   readonly modalTitle: string;
@@ -82,6 +92,10 @@ export interface MultiWordModalData {
  */
 export function multiWordModalData(): MultiWordModalData {
   return {
+    // Default matches the pre-existing placement, so nothing moves until an
+    // anchor says it should.
+    placement: 'bottom' as ModalPlacement,
+
     // Initialize icons and focus trap when modal opens
     init(): void {
       // Close on Escape key
@@ -93,6 +107,9 @@ export function multiWordModalData(): MultiWordModalData {
 
       Alpine.effect(() => {
         if (this.store.isVisible) {
+          // The multi-word store is opened by id and never sees an element, so
+          // this falls back to the last word the reader clicked.
+          this.placement = computeModalPlacement(getRememberedModalAnchor());
           requestAnimationFrame(() => {
             initIcons();
             const modalCard = document.querySelector<HTMLElement>('#multi-word-modal-title')
@@ -112,6 +129,10 @@ export function multiWordModalData(): MultiWordModalData {
 
     get isOpen(): boolean {
       return this.store.isVisible;
+    },
+
+    get modalClasses(): string {
+      return modalPlacementClasses(this.isOpen, this.placement);
     },
 
     get isLoading(): boolean {

--- a/src/frontend/js/modules/vocabulary/components/word_modal.ts
+++ b/src/frontend/js/modules/vocabulary/components/word_modal.ts
@@ -17,6 +17,12 @@ import { initIcons } from '@shared/icons/lucide_icons';
 import { trapFocus, releaseFocus } from '@shared/accessibility/focus_trap';
 import { announce } from '@shared/accessibility/aria_live';
 import { t } from '@shared/i18n/translator';
+import {
+  computeModalPlacement,
+  getRememberedModalAnchor,
+  modalPlacementClasses,
+  type ModalPlacement,
+} from './modal_placement';
 
 /**
  * Status display information.
@@ -71,6 +77,10 @@ export interface WordModalData {
   readonly modalTitle: string;
   readonly statuses: StatusInfo[];
 
+  // Which half of the viewport the card takes, so it avoids the clicked word
+  placement: ModalPlacement;
+  readonly modalClasses: string;
+
   // CSP-safe null-safe proxy properties for word.*
   readonly wordText: string;
   readonly wordTranslation: string;
@@ -117,6 +127,10 @@ export function wordModalData(): WordModalData {
     // View mode state
     viewMode: 'info' as ViewMode,
 
+    // Default matches the pre-existing placement, so nothing moves until an
+    // anchor says it should.
+    placement: 'bottom' as ModalPlacement,
+
     // Initialize icons when modal opens (called by Alpine.js x-init or x-effect)
     init(): void {
       // Close on Escape key
@@ -129,6 +143,12 @@ export function wordModalData(): WordModalData {
       // Watch for modal open state changes to load form data and re-initialize icons
       Alpine.effect(() => {
         if (this.store.isEditModalOpen) {
+          // Decide placement before the card paints, so it does not visibly
+          // jump. `openEditModal()` keeps `popoverTargetElement` alive, so the
+          // clicked word is still available here.
+          this.placement = computeModalPlacement(
+            this.store.popoverTargetElement || getRememberedModalAnchor()
+          );
           // Load form data when modal opens
           this.showEditForm();
           // Re-initialize icons and trap focus after DOM update
@@ -183,6 +203,10 @@ export function wordModalData(): WordModalData {
 
     get isOpen(): boolean {
       return this.store.isEditModalOpen;
+    },
+
+    get modalClasses(): string {
+      return modalPlacementClasses(this.isOpen, this.placement);
     },
 
     get isLoading(): boolean {


### PR DESCRIPTION
Three independent fixes found while exercising a fresh install end to end, plus a changelog trim.

## `docs(changelog)`: trim the unreleased section

Unreleased entries had grown into forensic write-ups (the dictionary-import entry ran 15 lines). Each now keeps the symptom, the cause in a sentence, and what changed — 149 lines down to 76. Released sections untouched.

## `fix(import)`: normalise line endings in tag-only imports

`importTagsOnly()` split uploads on `PHP_EOL`. A CRLF file on Linux left a stray `"\r"` on every last field; an LF file on Windows collapsed the upload into one line.

Same defect as #241 / #248 / #249 — this was the last remaining site in `src/`. The sibling term-import path was already correct and is unchanged.

## `fix(language)`: resolve the active language centrally

A single-language install could never browse Gutenberg or GDL — "Please select a language above" while the navbar already showed a language.

`currentlanguage` is only written when the user picks from the navbar dropdown, and with exactly one language there is no second option, so the `change` event can never fire and the setting can never be written. The navbar looked right only because a `<select>` with no `selected` option displays the first one; every server-side consumer read 0.

`CurrentLanguage::resolveId()` is now the single answer, read-only by design. Applied to the navbar payload, the new-text form's `TxLgID`, and the curated-feed wizard (replacing the local workaround it carried for this same defect). A setting pointing at a deleted language no longer sticks either.

## `fix(reading)`: keep the term modal off the word being added

The Add/Edit modal centred itself and regularly covered the word just clicked. It now takes the half of the viewport the word is not in, flipping the mobile sheet to the top edge when the word sits low. Best-effort — a word near the middle of a short viewport can still be covered — and falls back to the previous placement when no anchor is available.

## Verification

Psalm 0 errors, PHPCS 0/0, PHPUnit 9085 pass, Vitest 4445 pass, typecheck and ESLint clean.

Both fixes were confirmed against a running install rather than reasoned about:

| check | before | after |
| --- | --- | --- |
| `TxLgID` hidden field | `0` | `10` |
| navbar option marked `selected` | `false` | `true` |
| "select a language above" | shown | gone |
| modal vs word in lower half | overlapped | `is-placed-top`, no overlap |

Note: 12 `ForeignKeyTest` cases skip locally ("FK constraints not present"). Pre-existing and environment-dependent — reproduced with these changes stashed; the local main DB has 0 FK constraints while the test DB has 12.