### PR TITLE
chore(release): LWT 3.2.2-fork

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ ones are marked like "v1.0.0-fork".
 
 ## [Unreleased]
 
+## [3.2.2-fork] - 2026-08-05
+
 ### Fixed
 
 * **A single-language install could never browse Gutenberg or GDL**: the

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwt",
-  "version": "3.2.1",
+  "version": "3.2.2",
   "description": "Learning with Texts - A self-hosted language learning application for reading-based vocabulary acquisition",
   "type": "module",
   "main": "index.js",

--- a/src/Shared/Infrastructure/ApplicationInfo.php
+++ b/src/Shared/Infrastructure/ApplicationInfo.php
@@ -30,12 +30,12 @@ class ApplicationInfo
     /**
      * Version of this current LWT application.
      */
-    public const VERSION = '3.2.1-fork';
+    public const VERSION = '3.2.2-fork';
 
     /**
      * Date of the latest published release of LWT.
      */
-    public const RELEASE_DATE = '2026-06-30';
+    public const RELEASE_DATE = '2026-08-05';
 
     /**
      * Get the application version for display to humans.


### PR DESCRIPTION
Patch release bundling everything landed since 3.2.1 (2026-06-30).

Bumps `ApplicationInfo::VERSION` + `RELEASE_DATE`, `package.json`, and moves the `[Unreleased]` items into a dated `3.2.2-fork` section — the same three files #243 touched.

## Why patch, not minor

#246 added one new endpoint, `GET /api/v1/settings/status-definitions`, which strictly reads as additive API surface. It exists to de-duplicate the word-status tables between PHP and TypeScript rather than as user-facing functionality, and the changelog has no `Added` section — everything is `Fixed` or `Changed`. Called as **3.2.2**.

## Contents

**Reading and import**
- #253 — term-edit modal no longer blocks the text while reading, and now takes the half of the viewport the clicked word is not in
- Single-language installs could never browse Gutenberg or GDL — `currentlanguage` was unwritable when there was no second language to switch to
- Tag-only term imports split uploads on `PHP_EOL` — the last site of the #241/#248/#249 defect
- #250 — one over-long headword no longer aborts a whole dictionary import
- #249 — restoring a backup no longer wipes the database on Windows (plus FK ordering and the CSP file-picker bug)
- MeCab/Japanese parsing produced no tokens on Windows

**Internal**
- #246 — `TermStatus` as single source of truth for the word-status model
- #237 — single `data_hex` word identity in the reading view

**Security** — ten advisories cleared in #255; three more in #257 (two guzzle CVEs affecting the running app, plus a `brace-expansion` floor its own follow-up advisory had overtaken). `composer audit` and `npm audit` both clean.

## Verification

Psalm 0 errors, PHPCS clean on the changed file, PHPUnit 9085 pass, assets rebuild.

`GET /api/v1/version` on a running instance returns `{"version":"3.2.2","release_date":"2026-08-05"}`.

Tag `3.2.2` will be cut from the merge commit once this lands.