### PR TITLE
refactor(feed): rename Nf-prefixed identifiers to explicit feed names

### DIFF
--- a/src/Modules/Feed/Application/FeedFacade.php
+++ b/src/Modules/Feed/Application/FeedFacade.php
@@ -489,7 +489,7 @@ class FeedFacade
      *
      * @return string|array|null Option value
      */
-    public function getNfOption(string $optionsStr, string $option): string|array|null
+    public function getFeedOption(string $optionsStr, string $option): string|array|null
     {
         $optionsStr = trim($optionsStr);
         if (empty($optionsStr)) {
@@ -849,22 +849,22 @@ class FeedFacade
     {
         $texts = array_reverse($texts);
         $textsArchived = $sentencesDeleted = $textItemsDeleted = $archiveCount = 0;
-        /** @var list<int|string> $NfID */
-        $NfID = [];
+        /** @var list<int|string> $feedIds */
+        $feedIds = [];
 
         foreach ($texts as $text) {
-            $NfID[] = $text['Nf_ID'];
+            $feedIds[] = $text['Nf_ID'];
         }
-        $NfID = array_unique($NfID);
+        $feedIds = array_unique($feedIds);
 
         /** @var list<string> $currentTagList */
         $currentTagList = [];
         /** @var list<int|string> $textItem */
         $textItem = [];
-        /** @var int|null $nfMaxTexts */
-        $nfMaxTexts = null;
+        /** @var int|null $feedMaxTexts */
+        $feedMaxTexts = null;
 
-        foreach ($NfID as $feedID) {
+        foreach ($feedIds as $feedID) {
             foreach ($texts as $text) {
                 if ($feedID == $text['Nf_ID']) {
                     if ($currentTagList !== $text['TagList']) {
@@ -885,7 +885,7 @@ class FeedFacade
                                 \Lwt\Shared\Infrastructure\Database\Connection::preparedExecute($sql, $bindings);
                             }
                         }
-                        $nfMaxTexts = $text['Nf_Max_Texts'];
+                        $feedMaxTexts = $text['Nf_Max_Texts'];
                     }
 
                     // Create the text
@@ -959,9 +959,9 @@ class FeedFacade
             $textCount = count($textItem);
 
             // Archive excess texts
-            if ($textCount > (int)$nfMaxTexts) {
+            if ($textCount > (int)$feedMaxTexts) {
                 sort($textItem, SORT_NUMERIC);
-                $textItem = array_slice($textItem, 0, $textCount - (int)$nfMaxTexts);
+                $textItem = array_slice($textItem, 0, $textCount - (int)$feedMaxTexts);
 
                 foreach ($textItem as $txId) {
                     $textItemsDeleted += \Lwt\Shared\Infrastructure\Database\QueryBuilder::table('word_occurrences')

--- a/src/Modules/Feed/Http/FeedApiHandler.php
+++ b/src/Modules/Feed/Http/FeedApiHandler.php
@@ -320,45 +320,50 @@ class FeedApiHandler implements ApiRoutableInterface
     /**
      * Get the list of feeds and insert them into the database.
      *
-     * @param array<array<string, string>> $feed A feed with articles
-     * @param int                          $nfid News feed ID
+     * @param array<array<string, string>> $feed   A feed with articles
+     * @param int                          $feedId Feed ID
      *
      * @return array{0: int, 1: int} Number of imported feeds and number of duplicated feeds.
      */
-    public function getFeedsList(array $feed, int $nfid): array
+    public function getFeedsList(array $feed, int $feedId): array
     {
-        return $this->load->getFeedsList($feed, $nfid);
+        return $this->load->getFeedsList($feed, $feedId);
     }
 
     /**
      * Update the feeds database and return a result message.
      *
-     * @param int    $importedFeed Number of imported feeds
-     * @param int    $nif          Number of duplicated feeds
-     * @param string $nfname       News feed name
-     * @param int    $nfid         News feed ID
-     * @param string $nfoptions    News feed options
+     * @param int    $importedCount  Number of imported feeds
+     * @param int    $duplicateCount Number of duplicated feeds
+     * @param string $feedName       Feed name
+     * @param int    $feedId         Feed ID
+     * @param string $feedOptions    Feed options
      *
      * @return string Result message
      */
-    public function getFeedResult(int $importedFeed, int $nif, string $nfname, int $nfid, string $nfoptions): string
-    {
-        return $this->load->getFeedResult($importedFeed, $nif, $nfname, $nfid, $nfoptions);
+    public function getFeedResult(
+        int $importedCount,
+        int $duplicateCount,
+        string $feedName,
+        int $feedId,
+        string $feedOptions
+    ): string {
+        return $this->load->getFeedResult($importedCount, $duplicateCount, $feedName, $feedId, $feedOptions);
     }
 
     /**
      * Load a feed and return result.
      *
-     * @param string $nfname      Newsfeed name
-     * @param int    $nfid        News feed ID
-     * @param string $nfsourceuri News feed source
-     * @param string $nfoptions   News feed options
+     * @param string $feedName      Feed name
+     * @param int    $feedId        Feed ID
+     * @param string $feedSourceUri Feed source URI
+     * @param string $feedOptions   Feed options
      *
      * @return array{success?: true, message?: string, imported?: int, duplicates?: int, error?: string}
      */
-    public function loadFeed(string $nfname, int $nfid, string $nfsourceuri, string $nfoptions): array
+    public function loadFeed(string $feedName, int $feedId, string $feedSourceUri, string $feedOptions): array
     {
-        return $this->load->loadFeed($nfname, $nfid, $nfsourceuri, $nfoptions);
+        return $this->load->loadFeed($feedName, $feedId, $feedSourceUri, $feedOptions);
     }
 
     /**

--- a/src/Modules/Feed/Http/FeedArticleApiHandler.php
+++ b/src/Modules/Feed/Http/FeedArticleApiHandler.php
@@ -239,13 +239,15 @@ class FeedArticleApiHandler
 
         foreach ($feedLinks as $row) {
             /** @var array<string, mixed> $row */
-            $nfOptions = (string)($row['NfOptions'] ?? '');
-            $nfName = (string)($row['NfName'] ?? '');
+            $feedOptions = (string)($row['NfOptions'] ?? '');
+            $feedName = (string)($row['NfName'] ?? '');
 
-            $tagNameRaw = $this->feedFacade->getNfOption($nfOptions, 'tag');
-            $tagName = is_string($tagNameRaw) && $tagNameRaw !== '' ? $tagNameRaw : mb_substr($nfName, 0, 20, 'utf-8');
+            $tagNameRaw = $this->feedFacade->getFeedOption($feedOptions, 'tag');
+            $tagName = is_string($tagNameRaw) && $tagNameRaw !== ''
+                ? $tagNameRaw
+                : mb_substr($feedName, 0, 20, 'utf-8');
 
-            $maxTextsRaw = $this->feedFacade->getNfOption($nfOptions, 'max_texts');
+            $maxTextsRaw = $this->feedFacade->getFeedOption($feedOptions, 'max_texts');
             $maxTexts = is_string($maxTextsRaw) ? (int)$maxTextsRaw : 0;
             if (!$maxTexts) {
                 $maxTexts = (int)Settings::getWithDefault('set-max-texts-per-feed');
@@ -260,7 +262,7 @@ class FeedArticleApiHandler
                 'text' => (string)($row['FlText'] ?? '')
             ]];
 
-            $charsetRaw = $this->feedFacade->getNfOption($nfOptions, 'charset');
+            $charsetRaw = $this->feedFacade->getFeedOption($feedOptions, 'charset');
             $charset = is_string($charsetRaw) ? $charsetRaw : null;
             $texts = $this->feedFacade->extractTextFromArticle(
                 $doc,

--- a/src/Modules/Feed/Http/FeedCrudApiHandler.php
+++ b/src/Modules/Feed/Http/FeedCrudApiHandler.php
@@ -146,7 +146,7 @@ class FeedCrudApiHandler
      */
     public function formatFeedRecord(array $row): array
     {
-        $options = $this->feedFacade->getNfOption((string)$row['NfOptions'], 'all');
+        $options = $this->feedFacade->getFeedOption((string)$row['NfOptions'], 'all');
         $updateTimestamp = (int)$row['NfUpdate'];
         $lastUpdate = $updateTimestamp > 0
             ? $this->feedFacade->formatLastUpdate(time() - $updateTimestamp)

--- a/src/Modules/Feed/Http/FeedEditController.php
+++ b/src/Modules/Feed/Http/FeedEditController.php
@@ -435,13 +435,13 @@ class FeedEditController
         $languages = $this->feedFacade->getLanguages();
 
         // Parse options
-        $options = $this->feedFacade->getNfOption($feed['NfOptions'], '');
+        $options = $this->feedFacade->getFeedOption($feed['NfOptions'], '');
         if (!is_array($options)) {
             $options = [];
         }
 
         // Parse auto-update interval
-        $autoUpdateRaw = $this->feedFacade->getNfOption($feed['NfOptions'], 'autoupdate');
+        $autoUpdateRaw = $this->feedFacade->getFeedOption($feed['NfOptions'], 'autoupdate');
         if ($autoUpdateRaw === null || !is_string($autoUpdateRaw)) {
             $autoUpdateInterval = null;
             $autoUpdateUnit = null;

--- a/src/Modules/Feed/Http/FeedIndexController.php
+++ b/src/Modules/Feed/Http/FeedIndexController.php
@@ -112,7 +112,7 @@ class FeedIndexController
         $languages = null;
 
         foreach ($feedLinks as $row) {
-            $requiresEdit = $this->feedFacade->getNfOption($row['NfOptions'], 'edit_text') == 1;
+            $requiresEdit = $this->feedFacade->getFeedOption($row['NfOptions'], 'edit_text') == 1;
 
             if ($requiresEdit) {
                 if ($editText == 1) {
@@ -132,20 +132,22 @@ class FeedIndexController
                 'text' => $row['FlText']
             ]];
 
-            $nfName = $row['NfName'];
-            $nfId = $row['NfID'];
-            $nfOptions = $row['NfOptions'];
+            $feedName = $row['NfName'];
+            $feedId = $row['NfID'];
+            $feedOptions = $row['NfOptions'];
 
-            $tagNameRaw = $this->feedFacade->getNfOption($nfOptions, 'tag');
-            $tagName = is_string($tagNameRaw) && $tagNameRaw !== '' ? $tagNameRaw : mb_substr($nfName, 0, 20, "utf-8");
+            $tagNameRaw = $this->feedFacade->getFeedOption($feedOptions, 'tag');
+            $tagName = is_string($tagNameRaw) && $tagNameRaw !== ''
+                ? $tagNameRaw
+                : mb_substr($feedName, 0, 20, "utf-8");
 
-            $maxTextsRaw = $this->feedFacade->getNfOption($nfOptions, 'max_texts');
+            $maxTextsRaw = $this->feedFacade->getFeedOption($feedOptions, 'max_texts');
             $maxTexts = is_string($maxTextsRaw) ? (int)$maxTextsRaw : 0;
             if (!$maxTexts) {
                 $maxTexts = (int)Settings::getWithDefault('set-max-texts-per-feed');
             }
 
-            $charsetRaw = $this->feedFacade->getNfOption($nfOptions, 'charset');
+            $charsetRaw = $this->feedFacade->getFeedOption($feedOptions, 'charset');
             $charset = is_string($charsetRaw) ? $charsetRaw : null;
             $texts = $this->feedFacade->extractTextFromArticle(
                 $doc,

--- a/src/Modules/Feed/Http/FeedLoadApiHandler.php
+++ b/src/Modules/Feed/Http/FeedLoadApiHandler.php
@@ -41,12 +41,12 @@ class FeedLoadApiHandler
     /**
      * Get the list of feeds and insert them into the database.
      *
-     * @param array<array<string, string>> $feed A feed with articles
-     * @param int                          $nfid News feed ID
+     * @param array<array<string, string>> $feed   A feed with articles
+     * @param int                          $feedId Feed ID
      *
      * @return array{0: int, 1: int} Number of imported feeds and number of duplicated feeds.
      */
-    public function getFeedsList(array $feed, int $nfid): array
+    public function getFeedsList(array $feed, int $feedId): array
     {
         if (empty($feed)) {
             return [0, 0];
@@ -69,75 +69,80 @@ class FeedLoadApiHandler
             $params[] = $data['desc'] ?? '';
             $params[] = $data['date'] ?? '';
             $params[] = $data['audio'] ?? '';
-            $params[] = $nfid;
+            $params[] = $feedId;
         }
 
         $stmt = Connection::prepare($sql);
         $stmt->bindValues($params);
         $stmt->execute();
 
-        $importedFeed = $stmt->affectedRows();
-        $nif = count($feed) - $importedFeed;
+        $importedCount = $stmt->affectedRows();
+        $duplicateCount = count($feed) - $importedCount;
 
-        return [$importedFeed, $nif];
+        return [$importedCount, $duplicateCount];
     }
 
     /**
      * Update the feeds database and return a result message.
      *
-     * @param int    $importedFeed Number of imported feeds
-     * @param int    $nif          Number of duplicated feeds
-     * @param string $nfname       News feed name
-     * @param int    $nfid         News feed ID
-     * @param string $nfoptions    News feed options
+     * @param int    $importedCount  Number of imported feeds
+     * @param int    $duplicateCount Number of duplicated feeds
+     * @param string $feedName       Feed name
+     * @param int    $feedId         Feed ID
+     * @param string $feedOptions    Feed options
      *
      * @return string Result message
      */
-    public function getFeedResult(int $importedFeed, int $nif, string $nfname, int $nfid, string $nfoptions): string
-    {
+    public function getFeedResult(
+        int $importedCount,
+        int $duplicateCount,
+        string $feedName,
+        int $feedId,
+        string $feedOptions
+    ): string {
         // Update feed timestamp using QueryBuilder
         QueryBuilder::table('news_feeds')
-            ->where('NfID', '=', $nfid)
+            ->where('NfID', '=', $feedId)
             ->updatePrepared(['NfUpdate' => time()]);
 
-        $nfMaxLinksRaw = $this->feedFacade->getNfOption($nfoptions, 'max_links');
-        if ($nfMaxLinksRaw === null || $nfMaxLinksRaw === '' || is_array($nfMaxLinksRaw)) {
-            $articleSource = $this->feedFacade->getNfOption($nfoptions, 'article_source');
+        $maxLinksRaw = $this->feedFacade->getFeedOption($feedOptions, 'max_links');
+        if ($maxLinksRaw === null || $maxLinksRaw === '' || is_array($maxLinksRaw)) {
+            $articleSource = $this->feedFacade->getFeedOption($feedOptions, 'article_source');
             if ($articleSource !== null && $articleSource !== '' && !is_array($articleSource)) {
-                $nfMaxLinksRaw = Settings::getWithDefault('set-max-articles-with-text');
+                $maxLinksRaw = Settings::getWithDefault('set-max-articles-with-text');
             } else {
-                $nfMaxLinksRaw = Settings::getWithDefault('set-max-articles-without-text');
+                $maxLinksRaw = Settings::getWithDefault('set-max-articles-without-text');
             }
         }
-        $nfMaxLinks = (int)$nfMaxLinksRaw;
+        $maxLinks = (int)$maxLinksRaw;
 
-        $msg = $nfname . ": ";
-        if (!$importedFeed) {
+        $msg = $feedName . ": ";
+        if (!$importedCount) {
             $msg .= "no";
         } else {
-            $msg .= $importedFeed;
+            $msg .= $importedCount;
         }
         $msg .= " new article";
-        if ($importedFeed > 1) {
+        if ($importedCount > 1) {
             $msg .= "s";
         }
         $msg .= " imported";
-        if ($nif > 1) {
-            $msg .= ", $nif articles are dublicates";
-        } elseif ($nif == 1) {
-            $msg .= ", $nif dublicated article";
+        if ($duplicateCount > 1) {
+            $msg .= ", $duplicateCount articles are dublicates";
+        } elseif ($duplicateCount == 1) {
+            $msg .= ", $duplicateCount dublicated article";
         }
 
         // Count total feed_links using QueryBuilder
         $row = QueryBuilder::table('feed_links')
             ->select(['COUNT(*) AS total'])
-            ->where('FlNfID', '=', $nfid)
+            ->where('FlNfID', '=', $feedId)
             ->firstPrepared();
 
-        $to = ($row !== null ? (int)$row['total'] : 0) - $nfMaxLinks;
+        $to = ($row !== null ? (int)$row['total'] : 0) - $maxLinks;
         if ($to > 0) {
             QueryBuilder::table('feed_links')
-                ->whereIn('FlNfID', [$nfid])
+                ->whereIn('FlNfID', [$feedId])
                 ->orderBy('FlDate', 'ASC')
                 ->limit($to)
                 ->deletePrepared();
@@ -149,30 +154,30 @@ class FeedLoadApiHandler
     /**
      * Load a feed and return result.
      *
-     * @param string $nfname      Newsfeed name
-     * @param int    $nfid        News feed ID
-     * @param string $nfsourceuri News feed source
-     * @param string $nfoptions   News feed options
+     * @param string $feedName      Feed name
+     * @param int    $feedId        Feed ID
+     * @param string $feedSourceUri Feed source URI
+     * @param string $feedOptions   Feed options
      *
      * @return array{success?: true, message?: string, imported?: int, duplicates?: int, error?: string}
      */
-    public function loadFeed(string $nfname, int $nfid, string $nfsourceuri, string $nfoptions): array
+    public function loadFeed(string $feedName, int $feedId, string $feedSourceUri, string $feedOptions): array
     {
-        $articleSource = $this->feedFacade->getNfOption($nfoptions, 'article_source');
-        $feed = $this->feedFacade->parseRssFeed($nfsourceuri, is_string($articleSource) ? $articleSource : '');
+        $articleSource = $this->feedFacade->getFeedOption($feedOptions, 'article_source');
+        $feed = $this->feedFacade->parseRssFeed($feedSourceUri, is_string($articleSource) ? $articleSource : '');
         if (!is_array($feed) || count($feed) === 0) {
             return [
-                "error" => 'Could not load "' . $nfname . '"'
+                "error" => 'Could not load "' . $feedName . '"'
             ];
         }
         /** @var array<array-key, array<string, string>> $feed */
-        list($importedFeed, $nif) = $this->getFeedsList($feed, $nfid);
-        $msg = $this->getFeedResult($importedFeed, $nif, $nfname, $nfid, $nfoptions);
+        list($importedCount, $duplicateCount) = $this->getFeedsList($feed, $feedId);
+        $msg = $this->getFeedResult($importedCount, $duplicateCount, $feedName, $feedId, $feedOptions);
         return [
             "success" => true,
             "message" => $msg,
-            "imported" => $importedFeed,
-            "duplicates" => $nif
+            "imported" => $importedCount,
+            "duplicates" => $duplicateCount
         ];
     }
 

--- a/src/Modules/Feed/Http/FeedWizardController.php
+++ b/src/Modules/Feed/Http/FeedWizardController.php
@@ -210,12 +210,12 @@ class FeedWizardController
         $feedLen = count(array_filter(array_keys($feedData), 'is_numeric'));
 
         // Handle article section change
-        $nfArticleSection = InputValidator::getString('NfArticleSection');
+        $articleSectionInput = InputValidator::getString('NfArticleSection');
         if (
-            $nfArticleSection !== '' &&
-            ($nfArticleSection != ($feedData['feed_text'] ?? ''))
+            $articleSectionInput !== '' &&
+            ($articleSectionInput != ($feedData['feed_text'] ?? ''))
         ) {
-            $this->updateFeedArticleSource($nfArticleSection, $feedLen);
+            $this->updateFeedArticleSource($articleSectionInput, $feedLen);
         }
 
         PageLayoutHelper::renderPageStart('Feed Wizard - Step 2', true);
@@ -269,13 +269,13 @@ class FeedWizardController
         }
 
         $options = $this->wizardSession->getOptions();
-        $autoUpdI = $this->feedFacade->getNfOption($options, 'autoupdate');
-        if ($autoUpdI === null || !is_string($autoUpdI)) {
-            $autoUpdV = null;
-            $autoUpdI = null;
+        $autoUpdateRaw = $this->feedFacade->getFeedOption($options, 'autoupdate');
+        if ($autoUpdateRaw === null || !is_string($autoUpdateRaw)) {
+            $autoUpdateUnit = null;
+            $autoUpdateInterval = null;
         } else {
-            $autoUpdV = substr($autoUpdI, -1);
-            $autoUpdI = substr($autoUpdI, 0, -1);
+            $autoUpdateUnit = substr($autoUpdateRaw, -1);
+            $autoUpdateInterval = substr($autoUpdateRaw, 0, -1);
         }
 
         $wizardData = $this->wizardSession->getAll();
@@ -381,7 +381,7 @@ class FeedWizardController
         $this->wizardSession->setLang((string)$row['NfLgID']);
 
         // Handle custom article source
-        $articleSource = $this->feedFacade->getNfOption($row['NfOptions'], 'article_source');
+        $articleSource = $this->feedFacade->getFeedOption($row['NfOptions'], 'article_source');
         $articleSourceStr = is_string($articleSource) ? $articleSource : '';
         $currentFeedText = $feedText;
         if ($currentFeedText !== $articleSourceStr && $articleSourceStr !== '') {
@@ -506,9 +506,9 @@ class FeedWizardController
         if ($hostStatus !== '' && $hostName !== '') {
             $this->wizardSession->setHostStatus($hostName, $hostStatus);
         }
-        $nfName = InputValidator::getString('NfName');
-        if ($nfName !== '') {
-            $this->wizardSession->setFeedTitle($nfName);
+        $feedName = InputValidator::getString('NfName');
+        if ($feedName !== '') {
+            $this->wizardSession->setFeedTitle($feedName);
         }
     }
 
@@ -519,13 +519,13 @@ class FeedWizardController
      */
     private function processStep3SessionParams(): void
     {
-        $nfName = InputValidator::getString('NfName');
-        if ($nfName !== '') {
-            $this->wizardSession->setFeedTitle($nfName);
+        $feedName = InputValidator::getString('NfName');
+        if ($feedName !== '') {
+            $this->wizardSession->setFeedTitle($feedName);
         }
-        $nfArticleSection = InputValidator::getString('NfArticleSection');
-        if ($nfArticleSection !== '') {
-            $this->wizardSession->setArticleSection($nfArticleSection);
+        $articleSectionInput = InputValidator::getString('NfArticleSection');
+        if ($articleSectionInput !== '') {
+            $this->wizardSession->setArticleSection($articleSectionInput);
         }
         $articleSelector = InputValidator::getString('article_selector');
         if ($articleSelector !== '') {
@@ -543,13 +543,13 @@ class FeedWizardController
         if ($html !== '') {
             $this->wizardSession->setFilterTags($html);
         }
-        $nfOptions = InputValidator::getString('NfOptions');
-        if ($nfOptions !== '') {
-            $this->wizardSession->setOptions($nfOptions);
+        $feedOptions = InputValidator::getString('NfOptions');
+        if ($feedOptions !== '') {
+            $this->wizardSession->setOptions($feedOptions);
         }
-        $nfLgId = InputValidator::getString('NfLgID');
-        if ($nfLgId !== '') {
-            $this->wizardSession->setLang($nfLgId);
+        $feedLanguageId = InputValidator::getString('NfLgID');
+        if ($feedLanguageId !== '') {
+            $this->wizardSession->setLang($feedLanguageId);
         }
         if (!$this->wizardSession->has('article_tags')) {
             $this->wizardSession->setArticleTags('');
@@ -648,7 +648,7 @@ class FeedWizardController
                 $typedItem['text'] = $feedItem['text'];
             }
             $aFeed = [$typedItem];
-            $charsetRaw = $this->feedFacade->getNfOption($this->wizardSession->getOptions(), 'charset');
+            $charsetRaw = $this->feedFacade->getFeedOption($this->wizardSession->getOptions(), 'charset');
             $charset = is_string($charsetRaw) ? $charsetRaw : null;
             $html = $this->feedFacade->extractTextFromArticle(
                 $aFeed,
@@ -691,7 +691,7 @@ class FeedWizardController
                 $typedItem['text'] = $feedItem['text'];
             }
             $aFeed = [$typedItem];
-            $charsetRaw = $this->feedFacade->getNfOption($this->wizardSession->getOptions(), 'charset');
+            $charsetRaw = $this->feedFacade->getFeedOption($this->wizardSession->getOptions(), 'charset');
             $charset = is_string($charsetRaw) ? $charsetRaw : null;
             $html = $this->feedFacade->extractTextFromArticle(
                 $aFeed,

--- a/src/Modules/Feed/Views/edit_text_form.php
+++ b/src/Modules/Feed/Views/edit_text_form.php
@@ -10,7 +10,7 @@
  * - $row: array feed link and feed data (NfLgID, NfID)
  * - $count: int starting form counter (passed by reference)
  * - $tagName: string tag name for the text
- * - $nfId: int feed ID
+ * - $feedId: int feed ID
  * - $maxTexts: int maximum texts setting
  * - $languages: array of language records
  * - $scrdir: string script direction HTML attribute
@@ -36,7 +36,7 @@ assert(is_array($texts));
 assert(is_array($row) && isset($row['NfLgID']) && isset($row['NfID']));
 assert(is_int($count));
 assert(is_string($tagName));
-assert(is_int($nfId));
+assert(is_int($feedId));
 assert(is_int($maxTexts));
 assert(is_array($languages));
 assert(is_string($scrdir));
@@ -46,7 +46,7 @@ assert(is_string($scrdir));
  * @var array{NfLgID: int, NfID: int} $row
  * @var int $count
  * @var string $tagName
- * @var int $nfId
+ * @var int $feedId
  * @var int $maxTexts
  * @var array<int, array{LgID: int, LgName: string}> $languages
  * @var string $scrdir
@@ -176,7 +176,7 @@ foreach ($texts as $text) :
                         </div>
                         <input type="hidden"
                                name="feed[<?php echo $count; ?>][Nf_ID]"
-                               value="<?php echo $nfId; ?>" />
+                               value="<?php echo $feedId; ?>" />
                         <input type="hidden"
                                name="feed[<?php echo $count; ?>][Nf_Max_Texts]"
                                value="<?php echo $maxTexts; ?>" />

--- a/src/Modules/Feed/Views/multi_load.php
+++ b/src/Modules/Feed/Views/multi_load.php
@@ -54,8 +54,8 @@ namespace Lwt\Views\Feed;
     <?php
     $time = time();
     foreach ($feeds as $row) :
-        $nfUpdate = $row['NfUpdate'] ?? 0;
-        $diff = $time - $nfUpdate;
+        $lastUpdate = $row['NfUpdate'] ?? 0;
+        $diff = $time - $lastUpdate;
         ?>
     <tr>
         <td class="has-text-centered">
@@ -66,7 +66,7 @@ namespace Lwt\Views\Feed;
             echo htmlspecialchars($row['NfName'] ?? '', ENT_QUOTES, 'UTF-8');
         ?></td>
         <td class="has-text-centered" sorttable_customkey="<?php echo $diff; ?>">
-            <?php if ($nfUpdate) {
+            <?php if ($lastUpdate) {
                 echo $feedService->formatLastUpdate($diff);
             } ?>
         </td>

--- a/src/Modules/Feed/Views/wizard_step4.php
+++ b/src/Modules/Feed/Views/wizard_step4.php
@@ -6,8 +6,8 @@
  * Variables expected:
  * - $wizardData: array wizard session data
  * - $languages: array of language records
- * - $autoUpdI: string|null auto update interval value
- * - $autoUpdV: string|null auto update interval unit
+ * - $autoUpdateInterval: string|null auto update interval value
+ * - $autoUpdateUnit: string|null auto update interval unit
  * - $service: FeedService instance
  *
  * PHP version 8.1
@@ -32,8 +32,8 @@ use Lwt\Shared\UI\Helpers\IconHelper;
  *     options?: string, redirect?: string, article_section?: string,
  *     edit_feed?: int} $wizardData Wizard session data
  * @var array<int, array{LgID: int, LgName: string}> $languages Language records
- * @var string|null $autoUpdI Auto update interval value
- * @var string|null $autoUpdV Auto update interval unit
+ * @var string|null $autoUpdateInterval Auto update interval value
+ * @var string|null $autoUpdateUnit Auto update interval unit
  * @var \Lwt\Modules\Feed\Application\FeedFacade $service Feed service
  */
 
@@ -48,17 +48,17 @@ $languagesJson = array_map(
 
 // Prepare options for JSON config
 $options = $wizardData['options'] ?? '';
-$maxLinksValue = $service->getNfOption($options, 'max_links');
-$maxTextsValue = $service->getNfOption($options, 'max_texts');
-$charsetValue = $service->getNfOption($options, 'charset');
-$tagValue = $service->getNfOption($options, 'tag');
+$maxLinksValue = $service->getFeedOption($options, 'max_links');
+$maxTextsValue = $service->getFeedOption($options, 'max_texts');
+$charsetValue = $service->getFeedOption($options, 'charset');
+$tagValue = $service->getFeedOption($options, 'tag');
 
 $optionsConfig = [
-    'editText' => $service->getNfOption($options, 'edit_text') !== null,
+    'editText' => $service->getFeedOption($options, 'edit_text') !== null,
     'autoUpdate' => [
-        'enabled' => $autoUpdI !== null,
-        'interval' => $autoUpdI !== null ? (int)$autoUpdI : null,
-        'unit' => $autoUpdV ?? 'h'
+        'enabled' => $autoUpdateInterval !== null,
+        'interval' => $autoUpdateInterval !== null ? (int)$autoUpdateInterval : null,
+        'unit' => $autoUpdateUnit ?? 'h'
     ],
     'maxLinks' => [
         'enabled' => $maxLinksValue !== null,

--- a/tests/backend/Core/Feed/FeedsTest.php
+++ b/tests/backend/Core/Feed/FeedsTest.php
@@ -51,38 +51,38 @@ class FeedsTest extends TestCase
     }
 
     /**
-     * Test getNfOption method - parses options from feed options string
+     * Test getFeedOption method - parses options from feed options string
      * Note: Uses comma as separator, not semicolon
      */
     public function testGetNfOption(): void
     {
         // Test basic option retrieval (comma-separated)
         $options = "max_texts=10";
-        $result = $this->feedService->getNfOption($options, 'max_texts');
+        $result = $this->feedService->getFeedOption($options, 'max_texts');
         $this->assertEquals('10', $result);
 
         // Test autoupdate option
         $options = "autoupdate=12h";
-        $result = $this->feedService->getNfOption($options, 'autoupdate');
+        $result = $this->feedService->getFeedOption($options, 'autoupdate');
         $this->assertEquals('12h', $result);
 
         // Test multiple options (comma-separated)
         $options = "max_texts=5,autoupdate=1d,tag=news";
-        $this->assertEquals('5', $this->feedService->getNfOption($options, 'max_texts'));
-        $this->assertEquals('1d', $this->feedService->getNfOption($options, 'autoupdate'));
-        $this->assertEquals('news', $this->feedService->getNfOption($options, 'tag'));
+        $this->assertEquals('5', $this->feedService->getFeedOption($options, 'max_texts'));
+        $this->assertEquals('1d', $this->feedService->getFeedOption($options, 'autoupdate'));
+        $this->assertEquals('news', $this->feedService->getFeedOption($options, 'tag'));
 
         // Test non-existent option - returns null, which is falsy
-        $result = $this->feedService->getNfOption($options, 'nonexistent');
+        $result = $this->feedService->getFeedOption($options, 'nonexistent');
         $this->assertNull($result);
 
         // Test empty options string
-        $result = $this->feedService->getNfOption('', 'max_texts');
+        $result = $this->feedService->getFeedOption('', 'max_texts');
         $this->assertNull($result);
 
         // Test option with special characters
         $options = "tag=news-daily";
-        $result = $this->feedService->getNfOption($options, 'tag');
+        $result = $this->feedService->getFeedOption($options, 'tag');
         $this->assertEquals('news-daily', $result);
     }
 
@@ -195,52 +195,52 @@ class FeedsTest extends TestCase
     }
 
     /**
-     * Test getNfOption with edge cases
+     * Test getFeedOption with edge cases
      */
     public function testGetNfOptionEdgeCases(): void
     {
         // Test with empty string
-        $result = $this->feedService->getNfOption('', 'max_texts');
+        $result = $this->feedService->getFeedOption('', 'max_texts');
         $this->assertNull($result);
 
         // Test with whitespace
-        $result = $this->feedService->getNfOption(' ', 'max_texts');
+        $result = $this->feedService->getFeedOption(' ', 'max_texts');
         $this->assertNull($result);
 
         // Test with malformed option
-        $result = $this->feedService->getNfOption('no_equals_sign', 'max_texts');
+        $result = $this->feedService->getFeedOption('no_equals_sign', 'max_texts');
         $this->assertNull($result);
 
         // Test with multiple equals signs (explode splits on first = only with limit 2)
         $options = 'key=value=extra';
-        $result = $this->feedService->getNfOption($options, 'key');
+        $result = $this->feedService->getFeedOption($options, 'key');
         // explode without limit takes all = signs, so 'value' is returned
         $this->assertEquals('value', $result);
     }
 
     /**
-     * Test getNfOption with special characters
+     * Test getFeedOption with special characters
      */
     public function testGetNfOptionWithSpecialCharacters(): void
     {
         // Test with special characters in value
         $options = 'tag=news&entertainment,max_texts=10';
-        $result = $this->feedService->getNfOption($options, 'tag');
+        $result = $this->feedService->getFeedOption($options, 'tag');
         $this->assertEquals('news&entertainment', $result);
 
         // Test with URL in value
         $options = 'url=http://example.com/feed,max_texts=5';
-        $result = $this->feedService->getNfOption($options, 'url');
+        $result = $this->feedService->getFeedOption($options, 'url');
         $this->assertEquals('http://example.com/feed', $result);
     }
 
     /**
-     * Test getNfOption with 'all' parameter
+     * Test getFeedOption with 'all' parameter
      */
     public function testGetNfOptionAll(): void
     {
         $options = 'max_texts=10,autoupdate=12h,tag=news';
-        $result = $this->feedService->getNfOption($options, 'all');
+        $result = $this->feedService->getFeedOption($options, 'all');
 
         $this->assertIsArray($result);
         $this->assertArrayHasKey('max_texts', $result);
@@ -252,45 +252,45 @@ class FeedsTest extends TestCase
     }
 
     /**
-     * Test getNfOption with 'all' on empty string
+     * Test getFeedOption with 'all' on empty string
      */
     public function testGetNfOptionAllEmpty(): void
     {
-        $result = $this->feedService->getNfOption('', 'all');
+        $result = $this->feedService->getFeedOption('', 'all');
         $this->assertIsArray($result);
         // Empty string creates one empty element when exploded
         // So array will have one entry with empty key and value
     }
 
     /**
-     * Test getNfOption with single option
+     * Test getFeedOption with single option
      */
     public function testGetNfOptionSingleOption(): void
     {
         $options = 'max_texts=25';
-        $result = $this->feedService->getNfOption($options, 'max_texts');
+        $result = $this->feedService->getFeedOption($options, 'max_texts');
         $this->assertEquals('25', $result);
     }
 
     /**
-     * Test getNfOption with whitespace in option
+     * Test getFeedOption with whitespace in option
      */
     public function testGetNfOptionWithWhitespace(): void
     {
         // With leading/trailing spaces (trim is used in function)
         $options = ' max_texts = 10 ,autoupdate=1d';
-        $result = $this->feedService->getNfOption($options, 'max_texts');
+        $result = $this->feedService->getFeedOption($options, 'max_texts');
         $this->assertNotNull($result);
     }
 
     /**
-     * Test getNfOption with duplicate keys
+     * Test getFeedOption with duplicate keys
      */
     public function testGetNfOptionDuplicateKeys(): void
     {
         // Last occurrence should win
         $options = 'max_texts=10,max_texts=20';
-        $result = $this->feedService->getNfOption($options, 'max_texts');
+        $result = $this->feedService->getFeedOption($options, 'max_texts');
         // Function returns first match, not last
         $this->assertEquals('10', $result);
     }
@@ -391,32 +391,32 @@ class FeedsTest extends TestCase
     }
 
     /**
-     * Test getNfOption with numeric values
+     * Test getFeedOption with numeric values
      */
     public function testGetNfOptionNumericValues(): void
     {
         $options = 'max_texts=100,min_length=50';
 
-        $result = $this->feedService->getNfOption($options, 'max_texts');
+        $result = $this->feedService->getFeedOption($options, 'max_texts');
         $this->assertEquals('100', $result);
         $this->assertIsString($result); // Returns string, not int
 
-        $result = $this->feedService->getNfOption($options, 'min_length');
+        $result = $this->feedService->getFeedOption($options, 'min_length');
         $this->assertEquals('50', $result);
     }
 
     /**
-     * Test getNfOption case sensitivity
+     * Test getFeedOption case sensitivity
      */
     public function testGetNfOptionCaseSensitivity(): void
     {
         $options = 'MaxTexts=10,max_texts=20';
 
         // Keys are case-sensitive
-        $result = $this->feedService->getNfOption($options, 'max_texts');
+        $result = $this->feedService->getFeedOption($options, 'max_texts');
         $this->assertEquals('20', $result);
 
-        $result = $this->feedService->getNfOption($options, 'MaxTexts');
+        $result = $this->feedService->getFeedOption($options, 'MaxTexts');
         $this->assertEquals('10', $result);
     }
 

--- a/tests/backend/Modules/Feed/FeedFacadeTest.php
+++ b/tests/backend/Modules/Feed/FeedFacadeTest.php
@@ -781,19 +781,19 @@ class FeedFacadeTest extends TestCase
 
     public function testGetNfOptionReturnsValueForExistingKey(): void
     {
-        $result = $this->facade->getNfOption('tag=news,autoupdate=1h,max_texts=10', 'tag');
+        $result = $this->facade->getFeedOption('tag=news,autoupdate=1h,max_texts=10', 'tag');
         $this->assertEquals('news', $result);
     }
 
     public function testGetNfOptionReturnsNullForMissingKey(): void
     {
-        $result = $this->facade->getNfOption('tag=news,autoupdate=1h', 'charset');
+        $result = $this->facade->getFeedOption('tag=news,autoupdate=1h', 'charset');
         $this->assertNull($result);
     }
 
     public function testGetNfOptionReturnsAllAsArray(): void
     {
-        $result = $this->facade->getNfOption('tag=news,autoupdate=1h,max_texts=10', 'all');
+        $result = $this->facade->getFeedOption('tag=news,autoupdate=1h,max_texts=10', 'all');
 
         $this->assertIsArray($result);
         $this->assertEquals('news', $result['tag']);
@@ -803,14 +803,14 @@ class FeedFacadeTest extends TestCase
 
     public function testGetNfOptionReturnsEmptyArrayForEmptyString(): void
     {
-        $result = $this->facade->getNfOption('', 'all');
+        $result = $this->facade->getFeedOption('', 'all');
         $this->assertIsArray($result);
         $this->assertEmpty($result);
     }
 
     public function testGetNfOptionReturnsNullForEmptyStringWithSpecificKey(): void
     {
-        $result = $this->facade->getNfOption('', 'tag');
+        $result = $this->facade->getFeedOption('', 'tag');
         $this->assertNull($result);
     }
 

--- a/tests/backend/Modules/Feed/Http/FeedApiHandlerTest.php
+++ b/tests/backend/Modules/Feed/Http/FeedApiHandlerTest.php
@@ -60,7 +60,7 @@ class FeedApiHandlerTest extends TestCase
 
     public function testLoadFeedReturnsErrorWhenParsingFails(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('');
         $this->feedFacade->method('parseRssFeed')
             ->willReturn(false);
@@ -73,7 +73,7 @@ class FeedApiHandlerTest extends TestCase
 
     public function testLoadFeedReturnsErrorWhenParsingReturnsEmptyArray(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('');
         $this->feedFacade->method('parseRssFeed')
             ->willReturn([]);
@@ -442,7 +442,7 @@ class FeedApiHandlerTest extends TestCase
 
     public function testFormatLoadFeedDelegatesToLoadFeed(): void
     {
-        $this->feedFacade->method('getNfOption')->willReturn('');
+        $this->feedFacade->method('getFeedOption')->willReturn('');
         $this->feedFacade->method('parseRssFeed')->willReturn(false);
 
         $result = $this->handler->formatLoadFeed('Test', 1, 'http://test.com', '');
@@ -572,7 +572,7 @@ class FeedApiHandlerTest extends TestCase
                 'NfOptions' => '',
                 'NfUpdate' => 0,
             ]);
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('never');
 
         $result = $this->handler->createFeed([
@@ -603,7 +603,7 @@ class FeedApiHandlerTest extends TestCase
             ]);
         $this->feedFacade->expects($this->once())
             ->method('updateFeed');
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('never');
 
         $result = $this->handler->updateFeed(1, ['name' => 'New Name']);
@@ -645,7 +645,7 @@ class FeedApiHandlerTest extends TestCase
         ];
 
         $this->feedFacade->method('getMarkedFeedLinks')->willReturn([$row]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([
                 'error' => [
@@ -684,7 +684,7 @@ class FeedApiHandlerTest extends TestCase
         ];
 
         $this->feedFacade->method('getMarkedFeedLinks')->willReturn([$row]);
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $opt) {
                 if ($opt === 'tag') {
                     return 'custom';
@@ -717,7 +717,7 @@ class FeedApiHandlerTest extends TestCase
 
     public function testLoadFeedErrorMessageContainsFeedName(): void
     {
-        $this->feedFacade->method('getNfOption')->willReturn('');
+        $this->feedFacade->method('getFeedOption')->willReturn('');
         $this->feedFacade->method('parseRssFeed')->willReturn(false);
 
         $result = $this->handler->loadFeed('My Special Feed', 1, 'http://example.com', '');
@@ -727,7 +727,7 @@ class FeedApiHandlerTest extends TestCase
 
     public function testLoadFeedPassesArticleSourceToParser(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $option) {
                 if ($option === 'article_source') {
                     return 'full_text';
@@ -849,7 +849,7 @@ class FeedApiHandlerTest extends TestCase
     #[Test]
     public function routePostWithIdAndLoadDelegatesToLoadFeed(): void
     {
-        $this->feedFacade->method('getNfOption')->willReturn('');
+        $this->feedFacade->method('getFeedOption')->willReturn('');
         $this->feedFacade->method('parseRssFeed')->willReturn(false);
 
         $result = $this->handler->routePost(
@@ -1188,7 +1188,7 @@ class FeedApiHandlerTest extends TestCase
             'NfArticleSectionTags' => '', 'NfFilterTags' => '',
             'NfOptions' => '', 'NfUpdate' => 0,
         ]);
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('never');
 
         $this->handler->createFeed([
@@ -1227,7 +1227,7 @@ class FeedApiHandlerTest extends TestCase
                     && $data['NfOptions'] === 'tag:old'
                     && $data['NfName'] === 'Updated Name';
             }));
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('1h ago');
 
         $this->handler->updateFeed(1, ['name' => 'Updated Name']);
@@ -1285,7 +1285,7 @@ class FeedApiHandlerTest extends TestCase
         ];
 
         $this->feedFacade->method('getFeedById')->willReturn($feed);
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('never');
 
         $result = $this->handler->getFeed(1);

--- a/tests/backend/Modules/Feed/Http/FeedArticleApiHandlerTest.php
+++ b/tests/backend/Modules/Feed/Http/FeedArticleApiHandlerTest.php
@@ -567,7 +567,7 @@ class FeedArticleApiHandlerTest extends TestCase
                 ]
             ]);
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
@@ -598,7 +598,7 @@ class FeedArticleApiHandlerTest extends TestCase
                 $this->makeFeedLinkRow('11', 'Article 2'),
             ]);
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
@@ -621,7 +621,7 @@ class FeedArticleApiHandlerTest extends TestCase
                 $this->makeFeedLinkRow('10', 'Broken Article'),
             ]);
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([
@@ -647,7 +647,7 @@ class FeedArticleApiHandlerTest extends TestCase
         $this->feedFacade->method('getMarkedFeedLinks')
             ->willReturn([$this->makeFeedLinkRow('10', 'Article')]);
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $option) {
                 return $option === 'tag' ? 'custom-tag' : null;
             });
@@ -674,7 +674,7 @@ class FeedArticleApiHandlerTest extends TestCase
                 $this->makeFeedLinkRow('10', 'Article', 'VeryLongFeedNameForTagging'),
             ]);
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $option) {
                 return $option === 'tag' ? '' : null;
             });
@@ -699,7 +699,7 @@ class FeedArticleApiHandlerTest extends TestCase
         $this->feedFacade->method('getMarkedFeedLinks')
             ->willReturn([$this->makeFeedLinkRow('10', 'Article')]);
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([
@@ -722,7 +722,7 @@ class FeedArticleApiHandlerTest extends TestCase
         $this->feedFacade->method('getMarkedFeedLinks')
             ->willReturn([$row]);
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturnCallback(function (array $doc) {
@@ -757,7 +757,7 @@ class FeedArticleApiHandlerTest extends TestCase
         $this->feedFacade->method('getMarkedFeedLinks')
             ->willReturn([$this->makeFeedLinkRow('10', 'Article')]);
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([
@@ -777,7 +777,7 @@ class FeedArticleApiHandlerTest extends TestCase
         $this->feedFacade->method('getMarkedFeedLinks')
             ->willReturn([$this->makeFeedLinkRow('10', 'Article')]);
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([
@@ -948,7 +948,7 @@ class FeedArticleApiHandlerTest extends TestCase
         $this->feedFacade->method('getMarkedFeedLinks')
             ->willReturn([$row]);
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $option) {
                 if ($option === 'charset') {
                     return 'windows-1252';
@@ -980,7 +980,7 @@ class FeedArticleApiHandlerTest extends TestCase
         $this->feedFacade->method('getMarkedFeedLinks')
             ->willReturn([$this->makeFeedLinkRow('10', 'Multi Article')]);
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         // Extraction returns multiple texts from one article
         $this->feedFacade->method('extractTextFromArticle')

--- a/tests/backend/Modules/Feed/Http/FeedCrudApiHandlerTest.php
+++ b/tests/backend/Modules/Feed/Http/FeedCrudApiHandlerTest.php
@@ -52,7 +52,7 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow();
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn(['opt1' => 'val1']);
         $this->feedFacade->method('formatLastUpdate')
             ->willReturn('last update: 5 minutes ago');
@@ -77,7 +77,7 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow(['NfUpdate' => 0]);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         // formatLastUpdate should NOT be called when timestamp is 0
         $this->feedFacade->expects($this->never())
             ->method('formatLastUpdate');
@@ -92,7 +92,7 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow(['LgName' => null]);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('last update: 1 hour ago');
 
         $result = $this->handler->formatFeedRecord($row);
@@ -105,7 +105,7 @@ class FeedCrudApiHandlerTest extends TestCase
         $row = $this->makeFeedRow();
         unset($row['articleCount']);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $result = $this->handler->formatFeedRecord($row);
@@ -117,8 +117,8 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow();
 
-        // When getNfOption returns a string instead of array
-        $this->feedFacade->method('getNfOption')
+        // When getFeedOption returns a string instead of array
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('some_string');
         $this->feedFacade->method('formatLastUpdate')
             ->willReturn('up to date');
@@ -132,7 +132,7 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow();
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn(null);
         $this->feedFacade->method('formatLastUpdate')
             ->willReturn('up to date');
@@ -146,7 +146,7 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow(['NfOptions' => '']);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $result = $this->handler->formatFeedRecord($row);
@@ -160,7 +160,7 @@ class FeedCrudApiHandlerTest extends TestCase
         $row = $this->makeFeedRow(['NfOptions' => 'charset=utf8,max=10']);
 
         $this->feedFacade->expects($this->once())
-            ->method('getNfOption')
+            ->method('getFeedOption')
             ->with('charset=utf8,max=10', 'all')
             ->willReturn(['charset' => 'utf8', 'max' => '10']);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
@@ -174,7 +174,7 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow(['NfID' => '99']);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $result = $this->handler->formatFeedRecord($row);
@@ -187,7 +187,7 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow(['NfLgID' => '7']);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $result = $this->handler->formatFeedRecord($row);
@@ -200,7 +200,7 @@ class FeedCrudApiHandlerTest extends TestCase
     {
         $row = $this->makeFeedRow();
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $result = $this->handler->formatFeedRecord($row);
@@ -488,7 +488,7 @@ class FeedCrudApiHandlerTest extends TestCase
                 'NfOptions' => 'charset=utf8'
             ]);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $this->handler->updateFeed(42, ['name' => 'Updated Name']);
@@ -515,7 +515,7 @@ class FeedCrudApiHandlerTest extends TestCase
                 'NfOptions' => 'charset=utf8'
             ]);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $this->handler->updateFeed(42, []);
@@ -542,7 +542,7 @@ class FeedCrudApiHandlerTest extends TestCase
                 'NfOptions' => 'max=20'
             ]);
 
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $this->handler->updateFeed(42, [
@@ -564,7 +564,7 @@ class FeedCrudApiHandlerTest extends TestCase
         $existing = $this->makeFeedRow();
         $this->feedFacade->method('getFeedById')
             ->willReturn($existing);
-        $this->feedFacade->method('getNfOption')->willReturn([]);
+        $this->feedFacade->method('getFeedOption')->willReturn([]);
         $this->feedFacade->method('formatLastUpdate')->willReturn('up to date');
 
         $result = $this->handler->updateFeed(42, ['name' => 'X']);

--- a/tests/backend/Modules/Feed/Http/FeedEditControllerTest.php
+++ b/tests/backend/Modules/Feed/Http/FeedEditControllerTest.php
@@ -499,7 +499,7 @@ class FeedEditControllerTest extends TestCase
             ->method('getLanguages')
             ->willReturn([]);
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn(null);
 
         $method = new \ReflectionMethod(FeedEditController::class, 'showEditForm');
@@ -531,7 +531,7 @@ class FeedEditControllerTest extends TestCase
         $this->feedFacade->method('getLanguages')->willReturn([]);
 
         // Return different values based on option param
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $options, string $option) {
                 if ($option === '') {
                     return [];
@@ -572,7 +572,7 @@ class FeedEditControllerTest extends TestCase
 
         $this->feedFacade->method('getFeedById')->willReturn($feed);
         $this->feedFacade->method('getLanguages')->willReturn([]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $method = new \ReflectionMethod(FeedEditController::class, 'showEditForm');
 
@@ -730,7 +730,7 @@ class FeedEditControllerTest extends TestCase
 
         $this->feedFacade->method('getFeedById')->willReturn($feed);
         $this->feedFacade->method('getLanguages')->willReturn([]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->languageFacade->expects($this->once())
             ->method('getLanguageName')

--- a/tests/backend/Modules/Feed/Http/FeedIndexControllerTest.php
+++ b/tests/backend/Modules/Feed/Http/FeedIndexControllerTest.php
@@ -231,7 +231,7 @@ class FeedIndexControllerTest extends TestCase
         ];
 
         $this->feedFacade->method('getMarkedFeedLinks')->willReturn([$feedLink]);
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $option) {
                 if ($option === 'edit_text') {
                     return '0';
@@ -293,7 +293,7 @@ class FeedIndexControllerTest extends TestCase
         ];
 
         $this->feedFacade->method('getMarkedFeedLinks')->willReturn([$feedLink]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([
@@ -339,7 +339,7 @@ class FeedIndexControllerTest extends TestCase
         ];
 
         $this->feedFacade->method('getMarkedFeedLinks')->willReturn([$feedLink]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([['TxTitle' => 'Test', 'TxText' => 'Text']]);
         $this->feedFacade->method('createTextFromFeed')->willReturn(1);
@@ -380,7 +380,7 @@ class FeedIndexControllerTest extends TestCase
         ];
 
         $this->feedFacade->method('getMarkedFeedLinks')->willReturn([$feedLink]);
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $opt) {
                 if ($opt === 'tag') {
                     return 'custom_tag';
@@ -703,8 +703,8 @@ class FeedIndexControllerTest extends TestCase
         ];
 
         $this->feedFacade->method('getMarkedFeedLinks')->willReturn([$feedLink]);
-        // getNfOption returns empty for 'tag', so fallback to first 20 chars of NfName
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        // getFeedOption returns empty for 'tag', so fallback to first 20 chars of NfName
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([['TxTitle' => 'Test', 'TxText' => 'Text']]);
@@ -747,7 +747,7 @@ class FeedIndexControllerTest extends TestCase
         ];
 
         $this->feedFacade->method('getMarkedFeedLinks')->willReturn([$feedLink]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([['TxTitle' => 'Test', 'TxText' => 'Text']]);
         $this->feedFacade->method('createTextFromFeed')->willReturn(1);

--- a/tests/backend/Modules/Feed/Http/FeedLoadApiHandlerTest.php
+++ b/tests/backend/Modules/Feed/Http/FeedLoadApiHandlerTest.php
@@ -89,7 +89,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
         $this->assertCount(2, $params);
         $this->assertSame('feed', $params[0]->getName());
-        $this->assertSame('nfid', $params[1]->getName());
+        $this->assertSame('feedId', $params[1]->getName());
         $this->assertSame('array', $params[0]->getType()->getName());
         $this->assertSame('int', $params[1]->getType()->getName());
     }
@@ -126,11 +126,11 @@ class FeedLoadApiHandlerTest extends TestCase
         $params = $ref->getParameters();
 
         $this->assertCount(5, $params);
-        $this->assertSame('importedFeed', $params[0]->getName());
-        $this->assertSame('nif', $params[1]->getName());
-        $this->assertSame('nfname', $params[2]->getName());
-        $this->assertSame('nfid', $params[3]->getName());
-        $this->assertSame('nfoptions', $params[4]->getName());
+        $this->assertSame('importedCount', $params[0]->getName());
+        $this->assertSame('duplicateCount', $params[1]->getName());
+        $this->assertSame('feedName', $params[2]->getName());
+        $this->assertSame('feedId', $params[3]->getName());
+        $this->assertSame('feedOptions', $params[4]->getName());
     }
 
     public function testGetFeedResultParameterTypes(): void
@@ -151,7 +151,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testLoadFeedReturnsErrorWhenParsingReturnsFalse(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('');
         $this->feedFacade->method('parseRssFeed')
             ->willReturn(false);
@@ -164,7 +164,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testLoadFeedReturnsErrorWhenParsingReturnsEmptyArray(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('');
         $this->feedFacade->method('parseRssFeed')
             ->willReturn([]);
@@ -176,7 +176,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testLoadFeedErrorIncludesFeedName(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('');
         $this->feedFacade->method('parseRssFeed')
             ->willReturn(false);
@@ -188,7 +188,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testLoadFeedErrorDoesNotHaveSuccessKey(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('');
         $this->feedFacade->method('parseRssFeed')
             ->willReturn(false);
@@ -203,7 +203,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testLoadFeedErrorWhenParsingReturnsNull(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('');
         // parseRssFeed returns false for failure, but the check is !is_array
         // so non-array values all trigger the error path
@@ -217,7 +217,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testLoadFeedPassesArticleSourceToParseRssFeed(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $key) {
                 if ($key === 'article_source') {
                     return 'article';
@@ -235,7 +235,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testLoadFeedPassesEmptyStringWhenArticleSourceNotString(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $key) {
                 if ($key === 'article_source') {
                     return null;
@@ -253,7 +253,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testLoadFeedPassesEmptyStringWhenArticleSourceIsArray(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $key) {
                 if ($key === 'article_source') {
                     return ['not', 'a', 'string'];
@@ -294,10 +294,10 @@ class FeedLoadApiHandlerTest extends TestCase
         $params = $ref->getParameters();
 
         $this->assertCount(4, $params);
-        $this->assertSame('nfname', $params[0]->getName());
-        $this->assertSame('nfid', $params[1]->getName());
-        $this->assertSame('nfsourceuri', $params[2]->getName());
-        $this->assertSame('nfoptions', $params[3]->getName());
+        $this->assertSame('feedName', $params[0]->getName());
+        $this->assertSame('feedId', $params[1]->getName());
+        $this->assertSame('feedSourceUri', $params[2]->getName());
+        $this->assertSame('feedOptions', $params[3]->getName());
     }
 
     // =========================================================================
@@ -306,7 +306,7 @@ class FeedLoadApiHandlerTest extends TestCase
 
     public function testFormatLoadFeedDelegatesToLoadFeed(): void
     {
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturn('');
         $this->feedFacade->method('parseRssFeed')
             ->willReturn(false);

--- a/tests/backend/Modules/Feed/Http/FeedWizardControllerTest.php
+++ b/tests/backend/Modules/Feed/Http/FeedWizardControllerTest.php
@@ -210,7 +210,7 @@ class FeedWizardControllerTest extends TestCase
 
         $this->wizardSession->method('getOptions')->willReturn('');
         $this->wizardSession->method('getAll')->willReturn([]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('getLanguages')->willReturn([]);
         $this->useStubViews();
 
@@ -352,7 +352,7 @@ class FeedWizardControllerTest extends TestCase
         $this->feedFacade->method('getFeedById')->willReturn($feedRow);
         $this->feedFacade->method('detectAndParseFeed')
             ->willReturn(['feed_text' => 'content', 'feed_title' => '']);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->wizardSession->expects($this->once())
             ->method('setEditFeedId')
@@ -386,7 +386,7 @@ class FeedWizardControllerTest extends TestCase
         $this->feedFacade->method('getFeedById')->willReturn($feedRow);
         $this->feedFacade->method('detectAndParseFeed')
             ->willReturn(['feed_text' => 'content']);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->wizardSession->expects($this->once())
             ->method('setRedirect')
@@ -434,7 +434,7 @@ class FeedWizardControllerTest extends TestCase
         $this->feedFacade->method('getFeedById')->willReturn($feedRow);
         $this->feedFacade->method('detectAndParseFeed')
             ->willReturn(['feed_text' => '', 0 => ['link' => 'http://a.com']]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
         $this->wizardSession->expects($this->once())
             ->method('setDetectedFeed')
@@ -469,7 +469,7 @@ class FeedWizardControllerTest extends TestCase
 
         $this->feedFacade->method('getFeedById')->willReturn($feedRow);
         $this->feedFacade->method('detectAndParseFeed')->willReturn($feedData);
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $options, string $key) {
                 if ($key === 'article_source') {
                     return 'description';
@@ -1049,7 +1049,7 @@ class FeedWizardControllerTest extends TestCase
         $this->wizardSession->method('getOptions')->willReturn('edit_text=1');
         $this->wizardSession->method('getRedirect')->willReturn('');
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn(['html' => '<div>extracted html</div>']);
 
@@ -1075,7 +1075,7 @@ class FeedWizardControllerTest extends TestCase
         $this->wizardSession->method('getOptions')->willReturn('charset:utf-8');
         $this->wizardSession->method('getRedirect')->willReturn('redirect http://x.com | ');
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $key) {
                 return $key === 'charset' ? 'utf-8' : null;
             });
@@ -1111,7 +1111,7 @@ class FeedWizardControllerTest extends TestCase
         $this->wizardSession->method('getOptions')->willReturn('');
         $this->wizardSession->method('getRedirect')->willReturn('');
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->expects($this->once())
             ->method('extractTextFromArticle')
             ->with(
@@ -1169,7 +1169,7 @@ class FeedWizardControllerTest extends TestCase
         $this->wizardSession->method('getOptions')->willReturn('');
         $this->wizardSession->method('getRedirect')->willReturn('');
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn(['html' => '<div>step3 html</div>']);
 
@@ -1195,7 +1195,7 @@ class FeedWizardControllerTest extends TestCase
         $this->wizardSession->method('getOptions')->willReturn('');
         $this->wizardSession->method('getRedirect')->willReturn('');
 
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('extractTextFromArticle')
             ->willReturn([]);
 
@@ -1217,7 +1217,7 @@ class FeedWizardControllerTest extends TestCase
         // We test the filter_tags logic directly via InputValidator check.
         $this->wizardSession->method('getOptions')->willReturn('');
         $this->wizardSession->method('getAll')->willReturn([]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('getLanguages')->willReturn([]);
         $this->useStubViews();
 
@@ -1237,11 +1237,11 @@ class FeedWizardControllerTest extends TestCase
     public function wizardStep4ParsesAutoUpdateOptionWithStringValue(): void
     {
         // Test the autoupdate parsing logic in isolation
-        // getNfOption returns '24h' => autoUpdV='h', autoUpdI='24'
+        // getFeedOption returns '24h' => autoUpdateUnit='h', autoUpdateInterval='24'
         $this->wizardSession->method('getOptions')
             ->willReturn('autoupdate:24h');
 
-        $this->feedFacade->method('getNfOption')
+        $this->feedFacade->method('getFeedOption')
             ->willReturnCallback(function (string $opts, string $key) {
                 if ($key === 'autoupdate') {
                     return '24h';
@@ -1249,8 +1249,8 @@ class FeedWizardControllerTest extends TestCase
                 return null;
             });
 
-        // Verify the getNfOption call works
-        $result = $this->feedFacade->getNfOption('autoupdate:24h', 'autoupdate');
+        // Verify the getFeedOption call works
+        $result = $this->feedFacade->getFeedOption('autoupdate:24h', 'autoupdate');
         $this->assertSame('24h', $result);
         $this->assertSame('h', substr((string)$result, -1));
         $this->assertSame('24', substr((string)$result, 0, -1));
@@ -1265,7 +1265,7 @@ class FeedWizardControllerTest extends TestCase
         // by testing that clear exists on the session mock.
         $this->wizardSession->method('getOptions')->willReturn('');
         $this->wizardSession->method('getAll')->willReturn([]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('getLanguages')->willReturn([]);
         $this->useStubViews();
 
@@ -1284,10 +1284,10 @@ class FeedWizardControllerTest extends TestCase
     #[Test]
     public function wizardStep4HandlesNullAutoUpdate(): void
     {
-        // When getNfOption returns null, autoUpdV and autoUpdI should be null
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        // When getFeedOption returns null, autoUpdateUnit and autoUpdateInterval should be null
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
 
-        $result = $this->feedFacade->getNfOption('edit_text=1', 'autoupdate');
+        $result = $this->feedFacade->getFeedOption('edit_text=1', 'autoupdate');
         $this->assertNull($result);
     }
 
@@ -1301,7 +1301,7 @@ class FeedWizardControllerTest extends TestCase
             ->method('setFilterTags');
         $this->wizardSession->method('getOptions')->willReturn('');
         $this->wizardSession->method('getAll')->willReturn([]);
-        $this->feedFacade->method('getNfOption')->willReturn(null);
+        $this->feedFacade->method('getFeedOption')->willReturn(null);
         $this->feedFacade->method('getLanguages')->willReturn([]);
         $this->useStubViews();
 


### PR DESCRIPTION
Split out of #259, where it was riding along as an unrelated commit. Pure refactor — no behaviour change, no user-visible change (hence no CHANGELOG entry).

Replaces the legacy `Nf`/`nf` newsfeed shorthand — carried over from the DB column prefix — with explicit names in code that isn't part of the schema or form contract. Only internal PHP is touched: method names, parameters, and locals inside the Feed module and its tests.

- `FeedFacade::getNfOption()` → `getFeedOption()`
- `$nfname`/`$nfid`/`$nfoptions`/`$nfsourceuri` → `$feedName`/`$feedId`/`$feedOptions`/`$feedSourceUri`
- `$nif`/`$importedFeed` → `$duplicateCount`/`$importedCount`
- Scattered `$nfOptions`/`$nfName`/`$nfId`/`$nfMaxTexts`/`$nfLgId`/`$nfUpdate` locals → explicit equivalents
- `$NfID` (odd-caps local in `saveTextsFromFeed`) → `$feedIds`
- Cryptic `$autoUpdI`/`$autoUpdV` → `$autoUpdateInterval`/`$autoUpdateUnit`
- `edit_text_form.php` view variable `$nfId` → `$feedId` (include scope in `FeedIndexController` updated to match)

**Deliberately unchanged**, to avoid schema/form breakage: DB columns (`NfID`, `NfName`, `NfOptions`, `FlNfID`, …), array keys read from DB rows, and HTML form field names (`NfName`, `NfLgID`, `Nf_ID`, `Nf_Max_Texts`, `Nf_count`, …).

Verified independently on top of `main`: psalm 0 errors, phpcs PSR12 clean, PHPUnit 9085 pass.