### PR TITLE
chore(release): LWT 3.3.0-fork, and restore the lost 3.2.2 changelog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ ones are marked like "v1.0.0-fork".
 
 ## [Unreleased]
 
+## [3.3.0-fork] - 2026-08-06
+
 ### Added
 
 * **Import an Anki deck to seed known words** (#228): point LWT at a deck you
@@ -48,6 +50,20 @@ ones are marked like "v1.0.0-fork".
   at `edit_tword.php`, a filename that stopped being routed in v3, and opened it
   in a frame the reader no longer renders. It now links to `/word/edit-term`,
   the same route the Alpine review view already used.
+
+### Removed
+
+* **Dead legacy result-view plumbing** (#266): four result handlers
+  (`delete_result`, `insert_wellknown_result`, `insert_ignore_result`,
+  `delete_multi_result`) outlived the views that once fed them, and
+  `word_status_ajax.ts` waited on a `#word-status-config` element no page has
+  emitted since the frame reader was retired. Dropping them plus their now
+  orphaned DOM helpers removes ~1000 lines. No behaviour change — none of it
+  could run.
+
+## [3.2.2-fork] - 2026-08-05
+
+### Fixed
 
 * **A single-language install could never browse Gutenberg or GDL**: the
   new-text page said "Please select a language above" while the navbar already
@@ -138,16 +154,6 @@ ones are marked like "v1.0.0-fork".
   Replaces the 2011 `¤`/hex encoder whose per-byte vs. per-codepoint confusion
   PHP 8.5 surfaced by deprecating `ord()` on multi-byte strings. No API or
   styling change.
-
-### Removed
-
-* **Dead legacy result-view plumbing** (#266): four result handlers
-  (`delete_result`, `insert_wellknown_result`, `insert_ignore_result`,
-  `delete_multi_result`) outlived the views that once fed them, and
-  `word_status_ajax.ts` waited on a `#word-status-config` element no page has
-  emitted since the frame reader was retired. Dropping them plus their now
-  orphaned DOM helpers removes ~1000 lines. No behaviour change — none of it
-  could run.
 
 ## [3.2.1-fork] - 2026-06-30
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "lwt",
-  "version": "3.2.2",
+  "version": "3.3.0",
   "description": "Learning with Texts - A self-hosted language learning application for reading-based vocabulary acquisition",
   "type": "module",
   "main": "index.js",

--- a/src/Shared/Infrastructure/ApplicationInfo.php
+++ b/src/Shared/Infrastructure/ApplicationInfo.php
@@ -30,12 +30,12 @@ class ApplicationInfo
     /**
      * Version of this current LWT application.
      */
-    public const VERSION = '3.2.2-fork';
+    public const VERSION = '3.3.0-fork';
 
     /**
      * Date of the latest published release of LWT.
      */
-    public const RELEASE_DATE = '2026-08-05';
+    public const RELEASE_DATE = '2026-08-06';
 
     /**
      * Get the application version for display to humans.


### PR DESCRIPTION
Cuts 3.3.0-fork, and first repairs a changelog bug that would otherwise be
made permanent by the release.

## The 3.2.2 changelog was silently deleted

3.2.2 has been tagged and on `main` since 2026-08-05, and `ApplicationInfo`
reports it — but `grep 3.2.2 CHANGELOG.md` returned nothing. The sections read
`[Unreleased] → [3.2.1-fork]`.

The release commit `b35053cf3` did write the heading. Merge `2a9117053`
(PR #259, apkg export) removed it:

| commit | has `[3.2.2-fork]`? |
| --- | --- |
| `aa0b366bb` (first parent, PR #260) | yes |
| `579c9c9fa` (second parent, apkg branch) | no |
| `2a9117053` (merge result) | **no** |

That branch was cut before the release, so resolving the CHANGELOG conflict
took the branch side. The effect isn't cosmetic: the fifteen items that
*shipped* in 3.2.2 — the term modal, `CurrentLanguage::resolveId()`, the CRLF
tag-import fix, #250, #249, the `data_hex` identity change, thirteen security
advisories — were sitting back under `[Unreleased]`. Anyone running 3.2.2 had
no changelog for their version.

It had to be fixed before the release or 3.3.0's section would have absorbed
3.2.2's content and the gap would have become permanent.

Verified by extracting both and diffing: the restored section is byte-identical
to what `b35053cf3` published. The `### Removed` block for #266 is new work,
so it moves up into 3.3.0 rather than staying inside the restored 3.2.2.

## The release

Minor rather than patch — three Added entries:

* Anki deck import (#228)
* FSRS-6 scheduling groundwork (#238, phase 2a)
* `.apkg` export and import round-trip

The reader fix is the one users are actually waiting on: selecting several
words in the reader produced a term named `e6967a5826fe441a 75e3090289e2955d`,
and 3.2.x still ships it.

`@since 3.2.2` annotations in source are left alone — those features did ship
in 3.2.2.

## Checks

* Psalm `--threads=1` — no errors found
* PHPCS PSR12 on `ApplicationInfo.php` — 0 errors, 0 warnings
* PHPUnit — 9174 tests, 22377 assertions, all pass. The 1 warning is
  pre-existing and inside `vendor/kiwilan/php-ebook`.
* Vitest — 133 files, 4419 tests pass
* markdownlint MD013 count unchanged at the pre-existing 319
* No frontend rebuild: nothing in `vite.config.ts` or `src/frontend/` reads the
  package version.
